### PR TITLE
iPad adaptive UI (readable column + adaptive grids)

### DIFF
--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		5DC0DE0000000000000000C1 /* ClockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE0000000000000000C2 /* ClockService.swift */; };
 		5DC0DE0000000000000000D1 /* TrackingPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE0000000000000000D2 /* TrackingPermission.swift */; };
 		5DC0DE0000000000000000E1 /* ScrollTitleHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE0000000000000000E2 /* ScrollTitleHandoff.swift */; };
+		5DC0DE0000000000000000F1 /* iPadAdaptive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE0000000000000000F2 /* iPadAdaptive.swift */; };
 		5DDF035A2C2751670087BA59 /* ContentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDF03592C2751670087BA59 /* ContentListView.swift */; };
 		5DDF035C2C2767750087BA59 /* ContentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDF035B2C2767750087BA59 /* ContentCellView.swift */; };
 		5DDF035E2C28B4F10087BA59 /* ContentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDF035D2C28B4F10087BA59 /* ContentDetailView.swift */; };
@@ -211,6 +212,7 @@
 		5DC0DE0000000000000000C2 /* ClockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockService.swift; sourceTree = "<group>"; };
 		5DC0DE0000000000000000D2 /* TrackingPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingPermission.swift; sourceTree = "<group>"; };
 		5DC0DE0000000000000000E2 /* ScrollTitleHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollTitleHandoff.swift; sourceTree = "<group>"; };
+		5DC0DE0000000000000000F2 /* iPadAdaptive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iPadAdaptive.swift; sourceTree = "<group>"; };
 		5DDF03592C2751670087BA59 /* ContentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentListView.swift; sourceTree = "<group>"; };
 		5DDF035B2C2767750087BA59 /* ContentCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCellView.swift; sourceTree = "<group>"; };
 		5DDF035D2C28B4F10087BA59 /* ContentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDetailView.swift; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 				5DC0DE0000000000000000C2 /* ClockService.swift */,
 				5DC0DE0000000000000000D2 /* TrackingPermission.swift */,
 				5DC0DE0000000000000000E2 /* ScrollTitleHandoff.swift */,
+				5DC0DE0000000000000000F2 /* iPadAdaptive.swift */,
 				3CD532E22A29ADF5009D17F3 /* ModelExt.swift */,
 				5D9681192C5D948100D246B0 /* NewsUtility.swift */,
 				5DF82B252A5F3B29001395C7 /* NotificationUtility.swift */,
@@ -674,6 +677,7 @@
 				5DC0DE0000000000000000C1 /* ClockService.swift in Sources */,
 				5DC0DE0000000000000000D1 /* TrackingPermission.swift in Sources */,
 				5DC0DE0000000000000000E1 /* ScrollTitleHandoff.swift in Sources */,
+				5DC0DE0000000000000000F1 /* iPadAdaptive.swift in Sources */,
 				5DB4E0BA284EA02C0012F6F4 /* Map.swift in Sources */,
 				5DB4E0B8284E9FEF0012F6F4 /* Conference.swift in Sources */,
 				5D9E5753285A3C25001374D4 /* SpeakersView.swift in Sources */,

--- a/hackertracker/Utils/iPadAdaptive.swift
+++ b/hackertracker/Utils/iPadAdaptive.swift
@@ -1,0 +1,56 @@
+//
+//  iPadAdaptive.swift
+//  hackertracker
+//
+//  iPad-only adaptive layout helpers. Detection is by
+//  UIDevice.userInterfaceIdiom == .pad so iPhones (including Pro Max in
+//  landscape, which reports a `.regular` horizontal size class) are
+//  intentionally NOT included -- iPhone UI is unchanged by these modifiers.
+//
+//  Apple HIG references:
+//   - Readable line lengths: aim for roughly 50-75 characters per line.
+//   - Centered content columns with generous side margins on iPad.
+//   - Adaptive grids that grow column count with available width.
+//
+//  Implementation note: cannot use a ViewModifier(content:) struct here
+//  because our hackertracker module has its own `Content` model, which
+//  shadows the ViewModifier protocol's `Content` associated type and
+//  fails name resolution inside `body(content:)`. Use direct View
+//  extensions instead.
+//
+
+import SwiftUI
+
+extension View {
+    /// On iPad: constrains the content to `maxWidth` (default 740pt) and
+    /// centers it horizontally inside the available space. On iPhone: no-op.
+    /// Place this *inside* a ScrollView around the row content so the
+    /// scroll surface stays full-width while the visible content sits in a
+    /// readable centered column.
+    @ViewBuilder
+    func iPadReadableContent(maxWidth: CGFloat = 740) -> some View {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            self
+                .frame(maxWidth: maxWidth)
+                .frame(maxWidth: .infinity)
+        } else {
+            self
+        }
+    }
+}
+
+enum IPadAdaptive {
+    /// `true` when running on iPad. Use sparingly -- prefer the
+    /// `iPadReadableContent` modifier when possible.
+    static var isIPad: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
+
+    /// Grid columns sized by minimum width. Gives 2 columns on every
+    /// iPhone width (170 * 2 + spacing < 390), grows on iPad portrait
+    /// (~4-5 columns at 820pt) and iPad landscape (~6 columns at 1180pt).
+    static func adaptiveGridColumns(minimum: CGFloat = 170,
+                                    alignment: Alignment = .top) -> [GridItem] {
+        [GridItem(.adaptive(minimum: minimum), alignment: alignment)]
+    }
+}

--- a/hackertracker/Views/ConferencesView.swift
+++ b/hackertracker/Views/ConferencesView.swift
@@ -129,6 +129,8 @@ struct ConferencesView: View {
                                 withAnimation { proxy.scrollTo(target, anchor: .top) }
                                 DispatchQueue.main.async { jumpTarget = nil }
                             }
+                            // iPad: readable centered column for rows.
+                            .iPadReadableContent()
                         }
                     }
                 }

--- a/hackertracker/Views/ContentDetailView.swift
+++ b/hackertracker/Views/ContentDetailView.swift
@@ -37,6 +37,7 @@ struct ContentDetailView: View {
         let _ = dfu.tzGeneration
         if let item = viewModel.content.first(where: { $0.id == contentId }) {
             ScrollView {
+                // iPad: constrain content to a readable centered column.
                 VStack(alignment: .leading) {
                     VStack(alignment: .center) {
                         Text(item.title).font(.largeTitle).bold()
@@ -90,6 +91,7 @@ struct ContentDetailView: View {
                 }
                 
             }
+            .iPadReadableContent()
             .analyticsScreen(name: "ContentDetailView")
             .fullScreenCover(isPresented: $showFeedback) {
                 if let form = viewModel.feedbackForms.first(where: {$0.id == item.feedbackFormId}) {

--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -170,6 +170,8 @@ struct ContentListView: View {
                         }
                     }
                     .listStyle(.plain)
+                    // iPad: readable centered column for rows.
+                    .iPadReadableContent()
                 }
             }
             .refreshable {

--- a/hackertracker/Views/DocumentView.swift
+++ b/hackertracker/Views/DocumentView.swift
@@ -48,6 +48,7 @@ struct DocumentView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .iPadReadableContent()
         .analyticsScreen(name: "DocumentView")
         .padding(15)
     }

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -458,6 +458,8 @@ struct EventScrollView: View {
                       }
                   }
                   .listStyle(.plain)
+                  // iPad: readable centered column for rows.
+                  .iPadReadableContent()
                   .onChange(of: dayTag) { _, changedValue in 
                       withAnimation {
                           proxy.scrollTo(changedValue, anchor: .top)

--- a/hackertracker/Views/FAQListView.swift
+++ b/hackertracker/Views/FAQListView.swift
@@ -107,6 +107,8 @@ struct FAQListView: View {
                             withAnimation { proxy.scrollTo(target, anchor: .top) }
                             DispatchQueue.main.async { jumpTarget = nil }
                         }
+                        // iPad: readable centered column for rows.
+                        .iPadReadableContent()
                     }
                 }
             }

--- a/hackertracker/Views/NewsListView.swift
+++ b/hackertracker/Views/NewsListView.swift
@@ -109,6 +109,8 @@ struct NewsListView: View {
                             withAnimation { proxy.scrollTo(target, anchor: .top) }
                             DispatchQueue.main.async { jumpTarget = nil }
                         }
+                        // iPad: readable centered column for rows.
+                        .iPadReadableContent()
                     }
                 }
             }

--- a/hackertracker/Views/OrgsView.swift
+++ b/hackertracker/Views/OrgsView.swift
@@ -23,7 +23,9 @@ struct OrgsView: View {
     @FocusState private var searchFocused: Bool
     @State private var jumpTarget: String?
 
-    let gridItemLayout = [GridItem(.flexible(), alignment: .top), GridItem(.flexible(), alignment: .top)]
+    // iPad: GridItem(.adaptive) yields 2 columns on every iPhone width
+    // and 4-6 columns on iPad portrait/landscape automatically.
+    let gridItemLayout = IPadAdaptive.adaptiveGridColumns(minimum: 170, alignment: .top)
 
     private var filteredOrgs: [Organization] {
         viewModel.orgs.filter { $0.tag_ids.contains(tagId) }.search(text: searchText)

--- a/hackertracker/Views/ProductView.swift
+++ b/hackertracker/Views/ProductView.swift
@@ -152,6 +152,7 @@ struct ProductView: View {
                 .accessibilityLabel("Cart")
             }
         }
+        .iPadReadableContent()
         .analyticsScreen(name: "ProductView")
     }
     

--- a/hackertracker/Views/ProductsView.swift
+++ b/hackertracker/Views/ProductsView.swift
@@ -20,7 +20,9 @@ struct ProductsView: View {
     @FocusState private var searchFocused: Bool
     @State private var jumpTarget: String?
 
-    let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
+    // iPad: GridItem(.adaptive) yields 2 columns on every iPhone width
+    // and 4-6 columns on iPad portrait/landscape automatically.
+    let gridItemLayout = IPadAdaptive.adaptiveGridColumns(minimum: 170)
 
     /// Polish: the merch filter sheet renders Sections per TagType. If no
     /// browsable merch-product / merch-variant tag types exist in the

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -57,6 +57,7 @@ struct SettingsView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
+            .iPadReadableContent()
             .analyticsScreen(name: "SettingsView")
         }
     }

--- a/hackertracker/Views/SpeakerDetailView.swift
+++ b/hackertracker/Views/SpeakerDetailView.swift
@@ -90,6 +90,7 @@ struct SpeakerDetailView: View {
                     }
                 }
             }
+            .iPadReadableContent()
             .analyticsScreen(name: "SpeakerDetailView")
         } else {
             _04View(message: "Speaker \(id) not found")

--- a/hackertracker/Views/SpeakersView.swift
+++ b/hackertracker/Views/SpeakersView.swift
@@ -134,6 +134,8 @@ struct SpeakersView: View {
                             DispatchQueue.main.async { scrollToGroup = nil }
                         }
                     }
+                    // iPad: readable centered column for rows.
+                    .iPadReadableContent()
                 }
             }
             .refreshable {


### PR DESCRIPTION
## Summary

Make the app usable and good-looking on iPad (portrait + landscape) in 4 phases. iPhone UI is intentionally unchanged — all detection routes through `UIDevice.userInterfaceIdiom == .pad`.

### Apple HIG references applied
- **Readable line lengths** (50–75 chars). Detail/document/settings/list content constrained to a ~740pt centered column on iPad.
- **Adaptive grids that grow column count with available width.** Orgs and Merch grids switch from 2 fixed columns to `GridItem(.adaptive(minimum: 170))`.
- **Centered content columns with generous side margins on iPad.** Floating Filter/Sort overlays stay anchored at the screen edges; rows sit in a centered readable column.

### Phases

| # | Scope | Files |
|---|---|---|
| iPad-1 | `Utils/iPadAdaptive.swift` helper — `.iPadReadableContent()` + `IPadAdaptive.adaptiveGridColumns(...)` | 1 |
| iPad-2 | Detail / document / settings → readable column | ContentDetailView, SpeakerDetailView, DocumentView, SettingsView, ProductView |
| iPad-3 | Adaptive grid columns | OrgsView, ProductsView |
| iPad-4 | List screens → readable column | EventsView, ContentListView, SpeakersView, NewsListView, FAQListView, ConferencesView |

### Implementation note

The first attempt used a `ViewModifier(content:)` struct, but the hackertracker module has its own `Content` model in `Models/Content.swift` that shadows `ViewModifier.Content`'s associated type. Switched to a direct `@ViewBuilder` extension on `View` so the type name resolves unambiguously.

## Build status

- Debug builds clean on **iPhone 15** (iOS 17.5), **iPad Pro 11" M4**, **iPad mini (6th gen)**.
- Release build clean.
- Full test suite passes (`hackertrackerTests`, `hackertrackerUITests`, launch tests).
- Zero Swift errors, zero concurrency warnings under SWIFT_VERSION 6.0.

## Test plan

- [ ] Launch on iPad Pro / iPad mini in portrait → list screens have rows in a centered readable column with the floating buttons at screen edges.
- [ ] Rotate to landscape → grid views (Orgs, Merch) get an extra column or two; readable content stays centered.
- [ ] Launch on iPhone (any size) → UI looks identical to before this PR.
- [ ] ContentDetail / SpeakerDetail / About / Settings → text doesn't stretch across the full iPad width.
- [ ] Schedule jump-to-day still scrolls correctly on iPad.
- [ ] Pull-to-refresh, inline search reveal, and floating button taps all still work.

🧙 Built with [WOZCODE](https://wozcode.com)