### PR TITLE
Combined Bookmark Schedule (cross-conference)

### DIFF
--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		5DC0DE0000000000000000D1 /* TrackingPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE0000000000000000D2 /* TrackingPermission.swift */; };
 		5DC0DE0000000000000000E1 /* ScrollTitleHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE0000000000000000E2 /* ScrollTitleHandoff.swift */; };
 		5DC0DE0000000000000000F1 /* iPadAdaptive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE0000000000000000F2 /* iPadAdaptive.swift */; };
+		5DC0DE000000000000010001 /* SharedScheduleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000010002 /* SharedScheduleStore.swift */; };
+		5DC0DE000000000000010003 /* SharedScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000010004 /* SharedScheduleView.swift */; };
 		5DDF035A2C2751670087BA59 /* ContentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDF03592C2751670087BA59 /* ContentListView.swift */; };
 		5DDF035C2C2767750087BA59 /* ContentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDF035B2C2767750087BA59 /* ContentCellView.swift */; };
 		5DDF035E2C28B4F10087BA59 /* ContentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDF035D2C28B4F10087BA59 /* ContentDetailView.swift */; };
@@ -213,6 +215,8 @@
 		5DC0DE0000000000000000D2 /* TrackingPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingPermission.swift; sourceTree = "<group>"; };
 		5DC0DE0000000000000000E2 /* ScrollTitleHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollTitleHandoff.swift; sourceTree = "<group>"; };
 		5DC0DE0000000000000000F2 /* iPadAdaptive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iPadAdaptive.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000010002 /* SharedScheduleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedScheduleStore.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000010004 /* SharedScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedScheduleView.swift; sourceTree = "<group>"; };
 		5DDF03592C2751670087BA59 /* ContentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentListView.swift; sourceTree = "<group>"; };
 		5DDF035B2C2767750087BA59 /* ContentCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCellView.swift; sourceTree = "<group>"; };
 		5DDF035D2C28B4F10087BA59 /* ContentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDetailView.swift; sourceTree = "<group>"; };
@@ -362,6 +366,7 @@
 				5D642D452A59F0B50064492D /* CartView.swift */,
 				5DF51AB92850310B007BCB83 /* ConferenceRow.swift */,
 				5D9E57442857B398001374D4 /* ConferencesView.swift */,
+				5DC0DE000000000000010004 /* SharedScheduleView.swift */,
 				5DDF035B2C2767750087BA59 /* ContentCellView.swift */,
 				5DDF035D2C28B4F10087BA59 /* ContentDetailView.swift */,
 				5DDF03592C2751670087BA59 /* ContentListView.swift */,
@@ -453,6 +458,7 @@
 			children = (
 				5D9E575E285CFDF0001374D4 /* EventViewModel.swift */,
 				5D0A5A562A32BD8F00BD5ECE /* InfoViewModel.swift */,
+				5DC0DE000000000000010002 /* SharedScheduleStore.swift */,
 				5DA0F6952A741EA400A093B5 /* ConferencesViewModel.swift */,
 			);
 			path = ViewModels;
@@ -678,6 +684,8 @@
 				5DC0DE0000000000000000D1 /* TrackingPermission.swift in Sources */,
 				5DC0DE0000000000000000E1 /* ScrollTitleHandoff.swift in Sources */,
 				5DC0DE0000000000000000F1 /* iPadAdaptive.swift in Sources */,
+				5DC0DE000000000000010001 /* SharedScheduleStore.swift in Sources */,
+				5DC0DE000000000000010003 /* SharedScheduleView.swift in Sources */,
 				5DB4E0BA284EA02C0012F6F4 /* Map.swift in Sources */,
 				5DB4E0B8284E9FEF0012F6F4 /* Conference.swift in Sources */,
 				5D9E5753285A3C25001374D4 /* SpeakersView.swift in Sources */,

--- a/hackertracker/ViewModels/SharedScheduleStore.swift
+++ b/hackertracker/ViewModels/SharedScheduleStore.swift
@@ -1,0 +1,185 @@
+//
+//  SharedScheduleStore.swift
+//  hackertracker
+//
+//  Combined "Bookmarks across conferences" feature. Available only when:
+//   1. At least two conferences in ConferencesViewModel.conferences have
+//      overlapping date ranges (a HIG-DEFCON week with DC + BSidesLV +
+//      BlackHat simultaneously is the motivating use case).
+//   2. The local Bookmarks Core Data store contains event IDs that match
+//      events in at least two of those overlapping conferences.
+//
+//  The store fetches content one-shot per overlapping conference (vs the
+//  long-lived snapshot listeners InfoViewModel uses for the active
+//  conference) because cross-conference data is rarely-edited and the
+//  one-shot path is simpler. Firestore's per-device offline cache covers
+//  repeat visits.
+//
+//  Caveat: event IDs aren't guaranteed globally unique across conferences
+//  in this schema. If a bookmark ID collides between two conferences,
+//  both rows surface in the combined view -- the conference badge on
+//  each row lets the user pick the one they meant.
+//
+
+import Foundation
+import FirebaseFirestore
+import Observation
+
+@Observable
+@MainActor
+final class SharedScheduleStore {
+
+    /// One bookmarked event tagged with its source conference.
+    struct Entry: Identifiable {
+        let event: Event
+        let conferenceCode: String
+        let conferenceName: String
+        var id: String { "\(conferenceCode)/\(event.id)" }
+    }
+
+    /// All matching entries, sorted ascending by event begin timestamp.
+    var entries: [Entry] = []
+
+    /// Conferences that contributed at least one entry. The combined view is
+    /// considered "available" only when this contains 2 or more.
+    var sourceConferences: [Conference] = []
+
+    /// True iff the combined view should be reachable from InfoView.
+    var isAvailable: Bool { sourceConferences.count >= 2 }
+
+    /// Last refresh state, used to gate spinner UI in the view.
+    var isLoading: Bool = false
+
+    @ObservationIgnored private let db = Firestore.firestore()
+
+    /// Refresh entries against the given bookmark IDs and the full conference
+    /// list (typically `ConferencesViewModel.conferences`). Safe to call
+    /// repeatedly; idempotent.
+    func refresh(bookmarkIds: Set<Int>, allConferences: [Conference]) async {
+        // 1. Find conferences whose date ranges overlap with at least one other.
+        let overlapping = Self.overlappingConferences(from: allConferences)
+        guard overlapping.count >= 2, !bookmarkIds.isEmpty else {
+            // Not enough conferences to ever combine, or no bookmarks at all.
+            self.entries = []
+            self.sourceConferences = []
+            return
+        }
+
+        self.isLoading = true
+        defer { self.isLoading = false }
+
+        // 2. Fan out: fetch each overlapping conference's content in parallel,
+        //    convert sessions to Event objects, filter by bookmarkIds.
+        //    Conference isn't Sendable (the @DocumentID Firestore wrapper), so
+        //    pass only the code+name (Strings) across the actor boundary and
+        //    let the main actor re-associate.
+        let confLookup = Dictionary(uniqueKeysWithValues: overlapping.map { ($0.code, $0) })
+        let codeAndName: [(code: String, name: String)] = overlapping.map { ($0.code, $0.name) }
+
+        var allEntries: [Entry] = []
+        var contributingConfs: [Conference] = []
+
+        let fetchResults: [(String, [Event])] = await withTaskGroup(of: (String, [Event]).self) { group in
+            for pair in codeAndName {
+                let code = pair.code
+                let ids = bookmarkIds
+                group.addTask {
+                    let events = await self.fetchBookmarkedEvents(
+                        conferenceCode: code,
+                        bookmarkIds: ids
+                    )
+                    return (code, events)
+                }
+            }
+            var collected: [(String, [Event])] = []
+            for await pair in group {
+                collected.append(pair)
+            }
+            return collected
+        }
+
+        for (code, events) in fetchResults {
+            guard !events.isEmpty, let conf = confLookup[code] else { continue }
+            contributingConfs.append(conf)
+            for ev in events {
+                allEntries.append(Entry(
+                    event: ev,
+                    conferenceCode: conf.code,
+                    conferenceName: conf.name
+                ))
+            }
+        }
+
+        // 3. Require at least 2 distinct contributing conferences.
+        guard contributingConfs.count >= 2 else {
+            self.entries = []
+            self.sourceConferences = []
+            return
+        }
+
+        // 4. Sort by start time ascending.
+        self.entries = allEntries.sorted { $0.event.beginTimestamp < $1.event.beginTimestamp }
+        self.sourceConferences = contributingConfs.sorted { $0.startTimestamp < $1.startTimestamp }
+    }
+
+    // MARK: - Helpers
+
+    /// Conferences whose `[start_timestamp, end_timestamp)` range overlaps
+    /// with at least one other conference in the input.
+    static func overlappingConferences(from confs: [Conference]) -> [Conference] {
+        guard confs.count >= 2 else { return [] }
+        var hits: Set<String> = []
+        for i in confs.indices {
+            for j in (i + 1)..<confs.endIndex {
+                let a = confs[i]
+                let b = confs[j]
+                // Half-open interval overlap test: matches Phase 1 bookmarkConflicts.
+                if a.startTimestamp < b.endTimestamp && b.startTimestamp < a.endTimestamp {
+                    hits.insert(a.code)
+                    hits.insert(b.code)
+                }
+            }
+        }
+        return confs.filter { hits.contains($0.code) }
+    }
+
+    /// One-shot fetch of every content document in a conference's `content`
+    /// collection, returning the Event-flattened subset whose `id` is in
+    /// `bookmarkIds`. Mirrors the logic in InfoViewModel.fetchContent.
+    private func fetchBookmarkedEvents(conferenceCode: String,
+                                       bookmarkIds: Set<Int>) async -> [Event] {
+        do {
+            let snap = try await db.collection("conferences")
+                .document(conferenceCode)
+                .collection("content")
+                .getDocuments()
+            var events: [Event] = []
+            var seen: Set<Int> = []
+            for doc in snap.documents {
+                guard let content = try? doc.data(as: Content.self) else { continue }
+                for session in content.sessions where bookmarkIds.contains(session.id) {
+                    guard !seen.contains(session.id) else { continue }
+                    seen.insert(session.id)
+                    let event = Event(
+                        id: session.id,
+                        contentId: content.id,
+                        description: content.description,
+                        beginTimestamp: session.beginTimestamp,
+                        endTimestamp: session.endTimestamp,
+                        title: content.title,
+                        locationId: session.locationId,
+                        people: content.people,
+                        tagIds: content.tagIds,
+                        relatedIds: content.relatedIds
+                    )
+                    events.append(event)
+                }
+            }
+            return events
+        } catch {
+            Log.firestore.error("shared schedule fetch failed for \(conferenceCode, privacy: .public): \(error, privacy: .public)")
+            CrashReport.record(error, context: ["op": "fetchSharedSchedule", "code": conferenceCode])
+            return []
+        }
+    }
+}

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -26,6 +26,9 @@ struct InfoView: View {
     @State private var showOpenUrl = false
     @State private var path = NavigationPath()
     @State private var sharedEvents:[Event] = []
+    /// Combined-bookmarks-across-conferences store. Refreshed via .task(id:)
+    /// whenever bookmarks or the conferences list changes.
+    @State private var sharedSchedule = SharedScheduleStore()
     @State private var eventDay = ""
     @State private var searchText = ""
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
@@ -163,6 +166,13 @@ struct InfoView: View {
                             } label: {
                                 CardView(systemImage: "map", text: "Maps", color: colorMode ? theme.carousel() : Color(.systemGray6))
                             }
+                            // Combined-schedule entry-point: only when SharedScheduleStore
+                            // has resolved >=2 overlapping conferences with bookmarks in each.
+                            if sharedSchedule.isAvailable {
+                                NavigationLink(destination: SharedScheduleView()) {
+                                    CardView(systemImage: "calendar.badge.plus", text: "Combined Schedule", color: colorMode ? theme.carousel() : Color(.systemGray6))
+                                }
+                            }
                             NavigationLink(destination: SpeakersView(speakers: viewModel.speakers)) {
                                 CardView(systemImage: "person.crop.rectangle", text: "Speakers", color: colorMode ? theme.carousel() : Color(.systemGray6))
                             }
@@ -281,12 +291,26 @@ struct InfoView: View {
                         Log.app.debug("InfoView filters changed")
                     }
                 } */
+                .task(id: SharedScheduleRefreshKey(
+                    bookmarkCount: bookmarks.count,
+                    confCount: consViewModel.conferences.count
+                )) {
+                    // Polish: refresh combined-schedule data when the bookmark
+                    // set or conferences list changes. Triggers on first appear
+                    // (id changes from nil) plus any subsequent edit.
+                    let ids = Set(bookmarks.map { Int($0.id) })
+                    await sharedSchedule.refresh(
+                        bookmarkIds: ids,
+                        allConferences: consViewModel.conferences
+                    )
+                }
                 .onAppear {
                     Log.app.debug("InfoView selectedCode=\(selected.code, privacy: .public)")
                     if colorMode { theme.index = 0 }
                     checkAppUpdate()
                 }
                 .analyticsScreen(name: "InfoView")
+                .environment(sharedSchedule)
                 .onOpenURL(perform: { url in
                     if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
                         let queryItems = urlComponents.queryItems
@@ -621,4 +645,12 @@ struct InfoView_Previews: PreviewProvider {
     static var previews: some View {
         Text("Info View")
     }
+}
+
+/// Composed identity used by InfoView's .task(id:) to trigger a
+/// SharedScheduleStore refresh whenever the bookmark count or the conferences
+/// list changes. Hashable so SwiftUI can use it as a task identity.
+private struct SharedScheduleRefreshKey: Hashable {
+    let bookmarkCount: Int
+    let confCount: Int
 }

--- a/hackertracker/Views/SharedScheduleView.swift
+++ b/hackertracker/Views/SharedScheduleView.swift
@@ -1,0 +1,177 @@
+//
+//  SharedScheduleView.swift
+//  hackertracker
+//
+//  Combined "Bookmarks across conferences" screen. Reached from InfoView
+//  only when SharedScheduleStore.isAvailable.
+//
+//  Renders entries grouped by day (rendered in device-current timezone so
+//  cross-conference comparison reads naturally), with a per-row conference
+//  badge so attendees can tell DC32 from BSidesLV at a glance.
+//
+
+import SwiftUI
+
+struct SharedScheduleView: View {
+    @Environment(SharedScheduleStore.self) private var sharedSchedule
+    let dfu = DateFormatterUtility.shared
+
+    // Polish parity with the schedule.
+    @State private var jumpTarget: String?
+
+    // Group entries by day-string (in device-current TZ for cross-conference
+    // clarity), preserving the sorted order within each day.
+    private var grouped: [(day: String, entries: [SharedScheduleStore.Entry])] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE, MMMM d"
+        formatter.timeZone = TimeZone.current
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        var order: [String] = []
+        var bucket: [String: [SharedScheduleStore.Entry]] = [:]
+        for entry in sharedSchedule.entries {
+            let key = formatter.string(from: entry.event.beginTimestamp)
+            if bucket[key] == nil {
+                bucket[key] = []
+                order.append(key)
+            }
+            bucket[key]!.append(entry)
+        }
+        return order.map { ($0, bucket[$0] ?? []) }
+    }
+
+    @ViewBuilder private var jumpMenu: some View {
+        Menu {
+            Button {
+                jumpTarget = "__top"
+            } label: { Label("Top", systemImage: "arrow.up") }
+            Button {
+                jumpTarget = "__bottom"
+            } label: { Label("Bottom", systemImage: "arrow.down") }
+        } label: {
+            Image(systemName: "arrow.up.arrow.down")
+        }
+        .menuOrder(.fixed)
+    }
+
+    var body: some View {
+        // Phase 4 follow-up: observe DateFormatterUtility tz changes.
+        let _ = dfu.tzGeneration
+
+        ScrollView {
+            if sharedSchedule.entries.isEmpty {
+                if sharedSchedule.isLoading {
+                    ProgressView()
+                        .padding(.top, 60)
+                } else {
+                    ContentUnavailableView(
+                        "No Combined Bookmarks",
+                        systemImage: "calendar.badge.exclamationmark",
+                        description: Text("Bookmark events in at least two overlapping conferences to see them combined here.")
+                    )
+                    .padding(.top, 60)
+                }
+            } else {
+                ScrollViewReader { proxy in
+                    LazyVStack(alignment: .leading, spacing: 12, pinnedViews: [.sectionHeaders]) {
+                        Color.clear.frame(height: 1).id("__top")
+                        ForEach(grouped, id: \.day) { group in
+                            Section(header: dayHeader(group.day)) {
+                                ForEach(group.entries) { entry in
+                                    SharedScheduleRow(entry: entry)
+                                        .padding(.horizontal, 12)
+                                }
+                            }
+                        }
+                        Color.clear.frame(height: 1).id("__bottom")
+                    }
+                    .onChange(of: jumpTarget) { _, target in
+                        guard let target else { return }
+                        withAnimation { proxy.scrollTo(target, anchor: .top) }
+                        DispatchQueue.main.async { jumpTarget = nil }
+                    }
+                }
+                .iPadReadableContent()
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if !sharedSchedule.entries.isEmpty {
+                HStack {
+                    Spacer()
+                    jumpMenu
+                        .font(.title2)
+                        .foregroundStyle(.primary)
+                        .frame(width: 48, height: 48)
+                        .background(.regularMaterial, in: Circle())
+                        .accessibilityLabel("Jump")
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 12)
+            }
+        }
+        .navigationTitle("Combined Schedule")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .analyticsScreen(name: "SharedScheduleView")
+    }
+
+    @ViewBuilder
+    private func dayHeader(_ day: String) -> some View {
+        Text(day.uppercased())
+            .font(.subheadline)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.ultraThinMaterial)
+    }
+}
+
+/// One row in the combined schedule. Renders the source conference as a
+/// small color-tinted badge so attendees can disambiguate across DC,
+/// BSidesLV, BlackHat, etc. without studying the time block.
+struct SharedScheduleRow: View {
+    let entry: SharedScheduleStore.Entry
+    let dfu = DateFormatterUtility.shared
+    @AppStorage("show24hourtime") var show24hourtime: Bool = true
+
+    /// Format event start time in the device-current zone so the combined
+    /// view stays self-consistent regardless of which conference the row
+    /// came from.
+    private func timeString(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = show24hourtime ? "HH:mm" : "h:mm a"
+        f.timeZone = TimeZone.current
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f.string(from: date)
+    }
+
+    var body: some View {
+        let _ = dfu.tzGeneration
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(entry.conferenceName)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(ThemeColors.blue.opacity(0.25))
+                    .foregroundStyle(.primary)
+                    .cornerRadius(6)
+                Spacer()
+                Text("\(timeString(entry.event.beginTimestamp)) – \(timeString(entry.event.endTimestamp))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Text(entry.event.title)
+                .font(.headline)
+                .multilineTextAlignment(.leading)
+            // Note: Event.people is [Person] (id+sortOrder+tagId only). Rendering
+            // speaker names here would require a cross-conference speaker lookup
+            // we don't currently maintain. Skip for now -- the title + conference
+            // badge + time block is enough to identify each entry.
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.systemGray6))
+        .cornerRadius(12)
+    }
+}


### PR DESCRIPTION
## Summary

New screen that merges a user's bookmarked events across **overlapping** conferences — motivating use case: DEF CON week with DC + BSidesLV + BlackHat simultaneously. Gated so the entry point only appears when there's a real reason.

> **Note:** this PR is stacked on top of [#25](https://github.com/junctor/hackertracker-ios/pull/25). The combined schedule view uses the `.iPadReadableContent()` helper introduced there. GitHub will auto-retarget to `main` once #25 lands.

## Availability rules

The "Combined Schedule" entry card on InfoView only renders when both:
1. **2+ conferences with overlapping date ranges** — half-open interval test on `[start_timestamp, end_timestamp)`, matching the Phase 1 `bookmarkConflicts` fix.
2. **Each contributes at least one bookmark match** — local `Bookmarks` Core Data IDs that match events in 2+ overlapping conferences.

## New files

| File | Purpose |
|---|---|
| `ViewModels/SharedScheduleStore.swift` | `@Observable @MainActor` store. One-shot `getDocuments()` per overlapping conference (no long-lived listeners — cross-conf data rarely changes). Fans out via `TaskGroup`. |
| `Views/SharedScheduleView.swift` | Day-grouped chronological list in device-current timezone. Each row carries a tinted conference badge. Standard polished chrome (frosted nav bar, iPad readable column, floating Top/Bottom sort, `ContentUnavailableView` empty state). |

## Wiring

InfoView gains:
- `@State private var sharedSchedule = SharedScheduleStore()`
- `.task(id: SharedScheduleRefreshKey(bookmarkCount, confCount))` — refreshes on first appear and whenever bookmarks or conferences change.
- Entry-point `CardView` (`calendar.badge.plus`, "Combined Schedule") in the home feature grid, conditional on `sharedSchedule.isAvailable`.
- `.environment(sharedSchedule)` propagates the store into the pushed `SharedScheduleView`.

## Caveats (intentional)

- **Event IDs aren't globally unique across conferences** in the current Firestore schema. If a bookmark id collides between two conferences, both rows surface — the conference badge lets the user disambiguate.
- **People names aren't rendered** in the combined row. `Event.people` is `[Person]` (id+tagId only); names live in `viewModel.speakers` which is per-conference. Title + conference badge + time block is enough to identify each entry without cross-conference speaker plumbing.

## Build matrix

- ✅ iPhone 15 (iOS 17.5) — Debug + Release.
- ✅ iPad Pro 11" M4 — Debug.
- ✅ Full test suite passes.
- ✅ Zero Swift errors, zero concurrency warnings under SWIFT_VERSION 6.0.

## Test plan

- [ ] Bookmark events in only one conference → home grid does NOT show "Combined Schedule" card.
- [ ] Bookmark events in two conferences whose dates DON'T overlap → still hidden.
- [ ] Bookmark events in two conferences whose dates DO overlap → card appears.
- [ ] Tap card → screen renders, day headers in device timezone, conference badges on each row.
- [ ] Remove all bookmarks from one of the contributing conferences → card disappears on next refresh (returning to InfoView triggers `.task(id:)`).
- [ ] Floating Top/Bottom sort circle works.
- [ ] Empty state renders if the store hasn't found entries yet (loading) vs no entries (truly empty).

🧙 Built with [WOZCODE](https://wozcode.com)