### PR TITLE
AI summaries: on-device talk descriptions in All Content + Schedule

### DIFF
--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		5D4F07B928598AC8006772A2 /* 404View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4F07B828598AC8006772A2 /* 404View.swift */; };
 		5D642D232A4388D50064492D /* PDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D222A4388D50064492D /* PDFView.swift */; };
 		5DC0DE000000000000020002 /* SVGMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000020001 /* SVGMapView.swift */; };
+		5DC0DE000000000000030002 /* AISummaryAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000030001 /* AISummaryAvailability.swift */; };
 		5D642D252A438FB50064492D /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D242A438FB50064492D /* LocationView.swift */; };
 		5D642D272A43AEA00064492D /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D262A43AEA00064492D /* Product.swift */; };
 		5D642D292A44A1960064492D /* ProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D282A44A1960064492D /* ProductsView.swift */; };
@@ -157,6 +158,7 @@
 		5D4F07B828598AC8006772A2 /* 404View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 404View.swift; sourceTree = "<group>"; };
 		5D642D222A4388D50064492D /* PDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFView.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000020001 /* SVGMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGMapView.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000030001 /* AISummaryAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryAvailability.swift; sourceTree = "<group>"; };
 		5D642D242A438FB50064492D /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		5D642D262A43AEA00064492D /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		5D642D282A44A1960064492D /* ProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsView.swift; sourceTree = "<group>"; };
@@ -450,6 +452,7 @@
 				5DF82B252A5F3B29001395C7 /* NotificationUtility.swift */,
 				5D642D222A4388D50064492D /* PDFView.swift */,
 				5DC0DE000000000000020001 /* SVGMapView.swift */,
+				5DC0DE000000000000030001 /* AISummaryAvailability.swift */,
 				3C0E05CE2A53E70200E7154F /* Searchable.swift */,
 				3C07C208285C6F7600CC9469 /* Theme.swift */,
 			);
@@ -702,6 +705,7 @@
 				5DF51ACB28514F70007BCB83 /* EventType.swift in Sources */,
 				5D642D232A4388D50064492D /* PDFView.swift in Sources */,
 				5DC0DE000000000000020002 /* SVGMapView.swift in Sources */,
+				5DC0DE000000000000030002 /* AISummaryAvailability.swift in Sources */,
 				5DF51ABC2851203F007BCB83 /* Document.swift in Sources */,
 				5DDF035E2C28B4F10087BA59 /* ContentDetailView.swift in Sources */,
 				5D9681162C5946E000D246B0 /* FeedbackUtility.swift in Sources */,

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		5D642D232A4388D50064492D /* PDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D222A4388D50064492D /* PDFView.swift */; };
 		5DC0DE000000000000020002 /* SVGMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000020001 /* SVGMapView.swift */; };
 		5DC0DE000000000000030002 /* AISummaryAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000030001 /* AISummaryAvailability.swift */; };
+		5DC0DE000000000000040002 /* TalkSummaryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000040001 /* TalkSummaryCache.swift */; };
 		5D642D252A438FB50064492D /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D242A438FB50064492D /* LocationView.swift */; };
 		5D642D272A43AEA00064492D /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D262A43AEA00064492D /* Product.swift */; };
 		5D642D292A44A1960064492D /* ProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D282A44A1960064492D /* ProductsView.swift */; };
@@ -159,6 +160,7 @@
 		5D642D222A4388D50064492D /* PDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFView.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000020001 /* SVGMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGMapView.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000030001 /* AISummaryAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryAvailability.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000040001 /* TalkSummaryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkSummaryCache.swift; sourceTree = "<group>"; };
 		5D642D242A438FB50064492D /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		5D642D262A43AEA00064492D /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		5D642D282A44A1960064492D /* ProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsView.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 				5D642D222A4388D50064492D /* PDFView.swift */,
 				5DC0DE000000000000020001 /* SVGMapView.swift */,
 				5DC0DE000000000000030001 /* AISummaryAvailability.swift */,
+				5DC0DE000000000000040001 /* TalkSummaryCache.swift */,
 				3C0E05CE2A53E70200E7154F /* Searchable.swift */,
 				3C07C208285C6F7600CC9469 /* Theme.swift */,
 			);
@@ -706,6 +709,7 @@
 				5D642D232A4388D50064492D /* PDFView.swift in Sources */,
 				5DC0DE000000000000020002 /* SVGMapView.swift in Sources */,
 				5DC0DE000000000000030002 /* AISummaryAvailability.swift in Sources */,
+				5DC0DE000000000000040002 /* TalkSummaryCache.swift in Sources */,
 				5DF51ABC2851203F007BCB83 /* Document.swift in Sources */,
 				5DDF035E2C28B4F10087BA59 /* ContentDetailView.swift in Sources */,
 				5D9681162C5946E000D246B0 /* FeedbackUtility.swift in Sources */,

--- a/hackertracker/Utils/AISummaryAvailability.swift
+++ b/hackertracker/Utils/AISummaryAvailability.swift
@@ -1,0 +1,47 @@
+//
+//  AISummaryAvailability.swift
+//  hackertracker
+//
+//  Single source of truth for "can we use Apple Intelligence to summarize
+//  talk descriptions on this build / OS / device?" Every call site that
+//  touches FoundationModels routes through this gate so we don't scatter
+//  `#available` / `canImport` checks throughout the view layer.
+//
+
+import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+@MainActor
+enum AISummaryAvailability {
+    /// Compile-time + runtime check. Returns true when the FoundationModels
+    /// framework is linkable AND we're on iOS 26+ AND the on-device
+    /// language model reports itself ready to serve requests.
+    ///
+    /// This is the capability gate. The user-facing feature flag (the
+    /// `aiSummaries` @AppStorage toggle) is checked separately at each
+    /// call site so we can keep the flag set even when the device
+    /// temporarily can't satisfy a request (e.g. Apple Intelligence is
+    /// downloading the model or the user is in low-power mode).
+    static var isSupported: Bool {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            return SystemLanguageModel.default.availability == .available
+        }
+        #endif
+        return false
+    }
+
+    /// Whether the AI summary path *might* be available later even if it
+    /// isn't right now (model still loading, device assets downloading,
+    /// etc). Useful for deciding whether to hide a Settings row entirely
+    /// (`isSupported == false && isPossiblyAvailable == false`) vs. show
+    /// it disabled with an explanatory caption.
+    static var isPossiblyAvailable: Bool {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) { return true }
+        #endif
+        return false
+    }
+}

--- a/hackertracker/Utils/TalkSummaryCache.swift
+++ b/hackertracker/Utils/TalkSummaryCache.swift
@@ -1,0 +1,243 @@
+//
+//  TalkSummaryCache.swift
+//  hackertracker
+//
+//  On-device summarization of conference talk descriptions via the
+//  Apple Intelligence Foundation Models framework.
+//
+//  The cache is the only thing that touches `FoundationModels` directly.
+//  Call sites just ask for a summary by Content (`summary(for:)`) and
+//  optionally pre-warm the cache (`warm(_:)`); availability gating,
+//  concurrency limits, deduplication, and persistence are all internal.
+//
+//  Persistence: summaries land in UserDefaults as JSON keyed by content
+//  id, with a SHA256 of the description so an edit on the server side
+//  cleanly invalidates the cached summary. Capped at MAX_ENTRIES; oldest
+//  by `createdAt` get pruned when we go over.
+//
+
+import Foundation
+import CryptoKit
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+@MainActor
+final class TalkSummaryCache {
+    static let shared = TalkSummaryCache()
+
+    /// Cap on concurrent in-flight summarization tasks. Apple's on-device
+    /// LLM can serve several requests at once, but going too wide burns
+    /// the user's battery and pushes interactive UI work off the main
+    /// queue. Four is a balance that keeps scroll-induced pre-warms from
+    /// piling up.
+    private let maxConcurrent = 4
+
+    /// Cap on stored entries. UserDefaults handles up to a few MB but we
+    /// don't need to hoard summaries across hundreds of past conferences.
+    /// Eviction is by oldest `createdAt`.
+    private let maxEntries = 1000
+
+    private static let defaultsKey = "aiSummaryCache.v1"
+
+    /// Persisted entry. `descriptionHash` lets us notice when a talk's
+    /// description has changed server-side and re-summarize instead of
+    /// returning stale text.
+    struct Entry: Codable {
+        let descriptionHash: String
+        let summary: String
+        let createdAt: Date
+    }
+
+    private var memory: [Int: Entry] = [:]
+    private var inflight: [Int: Task<Void, Never>] = [:]
+    /// FIFO queue of contents waiting for a slot. Stored as (id, content)
+    /// so we can pump it in order without depending on Dictionary's
+    /// unspecified iteration order.
+    private var pending: [(id: Int, content: Content)] = []
+
+    private init() {
+        load()
+    }
+
+    // MARK: - Public API
+
+    /// Returns the cached summary for `content` if we have one whose
+    /// description hash matches the current description. Returns nil
+    /// when there's no summary yet OR when the description has
+    /// changed since we last summarized (the stale entry is dropped
+    /// to force a re-warm).
+    func summary(for content: Content) -> String? {
+        guard let entry = memory[content.id] else { return nil }
+        let currentHash = Self.stableHash(content.description)
+        if entry.descriptionHash == currentHash {
+            return entry.summary
+        }
+        // Description changed -> stale. Drop and let the next warm refill.
+        memory.removeValue(forKey: content.id)
+        persist()
+        return nil
+    }
+
+    /// Schedule a summary generation for `content`, deduplicated.
+    /// No-op when:
+    ///   - the device can't run FoundationModels right now,
+    ///   - we already have an up-to-date summary,
+    ///   - there's already an inflight task for this id, or
+    ///   - the description is empty.
+    func warm(_ content: Content) {
+        guard AISummaryAvailability.isSupported else { return }
+        guard !content.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard summary(for: content) == nil else { return }
+        guard inflight[content.id] == nil else { return }
+
+        if inflight.count >= maxConcurrent {
+            if !pending.contains(where: { $0.id == content.id }) {
+                pending.append((content.id, content))
+            }
+            return
+        }
+        spawn(for: content)
+    }
+
+    // MARK: - Generation
+
+    private func spawn(for content: Content) {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            spawnReal(for: content)
+            return
+        }
+        #endif
+        // Older OS / no framework: silently do nothing.
+        // `summary(for:)` will keep returning nil and call sites will
+        // fall back to the existing description preview.
+    }
+
+    #if canImport(FoundationModels)
+    @available(iOS 26.0, *)
+    private func spawnReal(for content: Content) {
+        let id = content.id
+        let description = content.description
+        let prompt = Self.prompt(for: description)
+
+        let task = Task { @MainActor [weak self] in
+            defer {
+                self?.inflight.removeValue(forKey: id)
+                self?.pump()
+            }
+            do {
+                let session = LanguageModelSession()
+                let response = try await session.respond(to: prompt)
+                let raw = response.content
+                let summary = Self.cleanup(raw)
+                guard !summary.isEmpty else { return }
+
+                let entry = Entry(
+                    descriptionHash: Self.stableHash(description),
+                    summary: summary,
+                    createdAt: Date()
+                )
+                self?.memory[id] = entry
+                self?.prune()
+                self?.persist()
+                Log.app.debug("AI summary OK for \(id, privacy: .public): \(summary, privacy: .public)")
+            } catch {
+                Log.app.debug("AI summary failed for \(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        inflight[id] = task
+    }
+    #endif
+
+    /// Promote queued items into the inflight set, in arrival order,
+    /// until we hit `maxConcurrent`.
+    private func pump() {
+        while inflight.count < maxConcurrent, !pending.isEmpty {
+            let next = pending.removeFirst()
+            // Re-check we don't already have something for this id.
+            guard inflight[next.id] == nil, summary(for: next.content) == nil else { continue }
+            spawn(for: next.content)
+        }
+    }
+
+    // MARK: - Prompt + cleanup
+
+    /// Conference-flavored single-sentence summary. We bias toward
+    /// "what will the audience actually learn" because organizers
+    /// often write descriptions in marketing voice that fails to
+    /// answer that question on its own.
+    private static func prompt(for description: String) -> String {
+        """
+        Summarize this conference talk description in ONE sentence of
+        about 15 words. Focus on what the audience will learn or what
+        is demonstrated. Be concrete and concise. No hype, no
+        marketing language, no leading phrases like "this talk" or
+        "the speaker"—just the content. Do not add quotation marks.
+
+        Description:
+        \(description)
+        """
+    }
+
+    /// Strip wrapping quotes, leading "Summary:" markers, trailing
+    /// periods+spaces, and collapse newlines. Models occasionally
+    /// hedge with prefatory text even when asked not to.
+    private static func cleanup(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixes = ["Summary:", "summary:", "SUMMARY:", "Summary -", "Summary:"]
+        for p in prefixes {
+            if s.hasPrefix(p) { s = String(s.dropFirst(p.count)).trimmingCharacters(in: .whitespaces) }
+        }
+        if s.hasPrefix("\"") && s.hasSuffix("\"") {
+            s = String(s.dropFirst().dropLast())
+        }
+        // Collapse any internal newlines so the summary fits on 1-2 lines.
+        s = s.replacingOccurrences(of: "\n", with: " ")
+        // Final whitespace squeeze.
+        s = s.split(separator: " ", omittingEmptySubsequences: true).joined(separator: " ")
+        return s
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard let data = UserDefaults.standard.data(forKey: Self.defaultsKey) else { return }
+        do {
+            let decoded = try JSONDecoder().decode([Int: Entry].self, from: data)
+            self.memory = decoded
+            Log.app.debug("TalkSummaryCache loaded \(decoded.count, privacy: .public) summaries")
+        } catch {
+            // Corrupt or schema-changed payload — drop it.
+            UserDefaults.standard.removeObject(forKey: Self.defaultsKey)
+        }
+    }
+
+    private func persist() {
+        do {
+            let data = try JSONEncoder().encode(memory)
+            UserDefaults.standard.set(data, forKey: Self.defaultsKey)
+        } catch {
+            Log.app.error("TalkSummaryCache persist failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func prune() {
+        guard memory.count > maxEntries else { return }
+        // Sort by createdAt asc, drop the oldest until we're back at cap.
+        let sorted = memory.sorted { $0.value.createdAt < $1.value.createdAt }
+        let toDrop = sorted.count - maxEntries
+        for (id, _) in sorted.prefix(toDrop) {
+            memory.removeValue(forKey: id)
+        }
+    }
+
+    // MARK: - Hashing
+
+    /// SHA256 of the UTF8 bytes, hex-encoded. Stable across launches
+    /// (unlike `String.hashValue`, which is randomized).
+    private static func stableHash(_ s: String) -> String {
+        let digest = SHA256.hash(data: Data(s.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/hackertracker/Utils/TalkSummaryCache.swift
+++ b/hackertracker/Utils/TalkSummaryCache.swift
@@ -79,15 +79,22 @@ final class TalkSummaryCache {
         return nil
     }
 
+    /// Minimum description length that warrants summarization.
+    /// Below this, a one-sentence summary won't be shorter than
+    /// (or substantively different from) the source — and burning
+    /// the user's battery on a marginal gain isn't worth it.
+    private let minDescriptionChars = 100
+
     /// Schedule a summary generation for `content`, deduplicated.
     /// No-op when:
     ///   - the device can't run FoundationModels right now,
-    ///   - we already have an up-to-date summary,
-    ///   - there's already an inflight task for this id, or
-    ///   - the description is empty.
+    ///   - the description is missing or under `minDescriptionChars`,
+    ///   - we already have an up-to-date summary, or
+    ///   - there's already an inflight task for this id.
     func warm(_ content: Content) {
         guard AISummaryAvailability.isSupported else { return }
-        guard !content.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let trimmed = content.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= minDescriptionChars else { return }
         guard summary(for: content) == nil else { return }
         guard inflight[content.id] == nil else { return }
 

--- a/hackertracker/Utils/TalkSummaryCache.swift
+++ b/hackertracker/Utils/TalkSummaryCache.swift
@@ -22,6 +22,7 @@ import CryptoKit
 import FoundationModels
 #endif
 
+@Observable
 @MainActor
 final class TalkSummaryCache {
     static let shared = TalkSummaryCache()
@@ -50,11 +51,11 @@ final class TalkSummaryCache {
     }
 
     private var memory: [Int: Entry] = [:]
-    private var inflight: [Int: Task<Void, Never>] = [:]
+    @ObservationIgnored private var inflight: [Int: Task<Void, Never>] = [:]
     /// FIFO queue of contents waiting for a slot. Stored as (id, content)
     /// so we can pump it in order without depending on Dictionary's
     /// unspecified iteration order.
-    private var pending: [(id: Int, content: Content)] = []
+    @ObservationIgnored private var pending: [(id: Int, content: Content)] = []
 
     private init() {
         load()

--- a/hackertracker/Utils/TalkSummaryCache.swift
+++ b/hackertracker/Utils/TalkSummaryCache.swift
@@ -22,6 +22,18 @@ import CryptoKit
 import FoundationModels
 #endif
 
+/// Common shape shared by anything we know how to summarize. Lets
+/// the cache key by stable Int id + accept either a `Content`
+/// (All Content / Talks tab) or an `Event` (Schedule tab) without
+/// duplicating method bodies.
+protocol SummarizableTalk {
+    var id: Int { get }
+    var description: String { get }
+}
+
+extension Content: SummarizableTalk {}
+extension Event: SummarizableTalk {}
+
 @Observable
 @MainActor
 final class TalkSummaryCache {
@@ -52,10 +64,10 @@ final class TalkSummaryCache {
 
     private var memory: [Int: Entry] = [:]
     @ObservationIgnored private var inflight: [Int: Task<Void, Never>] = [:]
-    /// FIFO queue of contents waiting for a slot. Stored as (id, content)
-    /// so we can pump it in order without depending on Dictionary's
-    /// unspecified iteration order.
-    @ObservationIgnored private var pending: [(id: Int, content: Content)] = []
+    /// FIFO queue of items waiting for a slot. We store id + the raw
+    /// description string rather than the SummarizableTalk itself so
+    /// the queue isn't tied to either model type's lifecycle.
+    @ObservationIgnored private var pending: [(id: Int, description: String)] = []
 
     private init() {
         load()
@@ -68,14 +80,14 @@ final class TalkSummaryCache {
     /// when there's no summary yet OR when the description has
     /// changed since we last summarized (the stale entry is dropped
     /// to force a re-warm).
-    func summary(for content: Content) -> String? {
-        guard let entry = memory[content.id] else { return nil }
-        let currentHash = Self.stableHash(content.description)
+    func summary(for item: any SummarizableTalk) -> String? {
+        guard let entry = memory[item.id] else { return nil }
+        let currentHash = Self.stableHash(item.description)
         if entry.descriptionHash == currentHash {
             return entry.summary
         }
         // Description changed -> stale. Drop and let the next warm refill.
-        memory.removeValue(forKey: content.id)
+        memory.removeValue(forKey: item.id)
         persist()
         return nil
     }
@@ -92,28 +104,28 @@ final class TalkSummaryCache {
     ///   - the description is missing or under `minDescriptionChars`,
     ///   - we already have an up-to-date summary, or
     ///   - there's already an inflight task for this id.
-    func warm(_ content: Content) {
+    func warm(_ item: any SummarizableTalk) {
         guard AISummaryAvailability.isSupported else { return }
-        let trimmed = content.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = item.description.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.count >= minDescriptionChars else { return }
-        guard summary(for: content) == nil else { return }
-        guard inflight[content.id] == nil else { return }
+        guard summary(for: item) == nil else { return }
+        guard inflight[item.id] == nil else { return }
 
         if inflight.count >= maxConcurrent {
-            if !pending.contains(where: { $0.id == content.id }) {
-                pending.append((content.id, content))
+            if !pending.contains(where: { $0.id == item.id }) {
+                pending.append((item.id, item.description))
             }
             return
         }
-        spawn(for: content)
+        spawn(id: item.id, description: item.description)
     }
 
     // MARK: - Generation
 
-    private func spawn(for content: Content) {
+    private func spawn(id: Int, description: String) {
         #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
-            spawnReal(for: content)
+            spawnReal(id: id, description: description)
             return
         }
         #endif
@@ -124,9 +136,7 @@ final class TalkSummaryCache {
 
     #if canImport(FoundationModels)
     @available(iOS 26.0, *)
-    private func spawnReal(for content: Content) {
-        let id = content.id
-        let description = content.description
+    private func spawnReal(id: Int, description: String) {
         let prompt = Self.prompt(for: description)
 
         let task = Task { @MainActor [weak self] in
@@ -163,9 +173,13 @@ final class TalkSummaryCache {
     private func pump() {
         while inflight.count < maxConcurrent, !pending.isEmpty {
             let next = pending.removeFirst()
-            // Re-check we don't already have something for this id.
-            guard inflight[next.id] == nil, summary(for: next.content) == nil else { continue }
-            spawn(for: next.content)
+            // Re-check we don't already have a fresh entry by hashing.
+            // We can't call summary(for:) here without a SummarizableTalk,
+            // but checking the stored hash directly is equivalent.
+            let h = Self.stableHash(next.description)
+            if let e = memory[next.id], e.descriptionHash == h { continue }
+            guard inflight[next.id] == nil else { continue }
+            spawn(id: next.id, description: next.description)
         }
     }
 

--- a/hackertracker/Views/ContentCellView.swift
+++ b/hackertracker/Views/ContentCellView.swift
@@ -14,6 +14,11 @@ struct ContentCell: View {
     @Environment(InfoViewModel.self) private var viewModel
     let dfu = DateFormatterUtility.shared
     @AppStorage("notifyAt") var notifyAt: Int = 20
+    /// Step 3 of the AI summary spike: warm the on-device LLM
+    /// cache when this cell materializes IF the user has opted in.
+    /// TalkSummaryCache.warm is a no-op when the device can't run
+    /// FoundationModels, so this stays safe on iOS < 26.
+    @AppStorage("aiSummaries") private var aiSummaries: Bool = false
 
     func bookmarkAction() {
         for s in content.sessions {
@@ -81,11 +86,22 @@ struct ContentCell: View {
                     .buttonStyle(PlainButtonStyle())
                 }
             }
-        }.swipeActions {
+        }
+        .swipeActions {
             Button(isBookmarked ? "Remove Bookmark" : "Bookmark") {
                 bookmarkAction()
             }.buttonStyle(DefaultButtonStyle())
                 .tint(isBookmarked ? .red : .yellow)
+        }
+        // LazyVStack inside ContentListView materializes cells as they
+        // scroll into view; this .task runs once per materialization.
+        // Cheap no-op when aiSummaries is off or the device can't run
+        // FoundationModels, and the cache itself dedups concurrent
+        // requests so there's no risk of spamming.
+        .task {
+            if aiSummaries {
+                TalkSummaryCache.shared.warm(content)
+            }
         }
     }
     

--- a/hackertracker/Views/ContentCellView.swift
+++ b/hackertracker/Views/ContentCellView.swift
@@ -19,6 +19,11 @@ struct ContentCell: View {
     /// TalkSummaryCache.warm is a no-op when the device can't run
     /// FoundationModels, so this stays safe on iOS < 26.
     @AppStorage("aiSummaries") private var aiSummaries: Bool = false
+    /// Whether to present the original description sheet in response
+    /// to a long-press. Only used when an AI summary is shown — long-
+    /// pressing a cell with no summary is a no-op so we don't compete
+    /// with the row's regular NavigationLink tap.
+    @State private var showingOriginalDescription: Bool = false
 
     func bookmarkAction() {
         for s in content.sessions {
@@ -70,6 +75,27 @@ struct ContentCell: View {
                                     .font(.subheadline)
                                     .multilineTextAlignment(.leading)
                             }
+                            // AI summary slot: only shown when the user
+                            // toggle is on AND the cache has a fresh
+                            // summary for this content. The sparkle icon
+                            // matches the system convention Mail/Messages
+                            // use to mark AI-generated text.
+                            if aiSummaries,
+                               let summary = TalkSummaryCache.shared.summary(for: content) {
+                                HStack(alignment: .top, spacing: 4) {
+                                    Image(systemName: "sparkles")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .padding(.top, 2)
+                                    Text(summary)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                        .multilineTextAlignment(.leading)
+                                }
+                                .accessibilityElement(children: .combine)
+                                .accessibilityLabel("AI summary: \(summary)")
+                            }
                             ShowEventCellTags(tagIds: content.tagIds, minWidth: 150)
                         }
                     }
@@ -103,6 +129,20 @@ struct ContentCell: View {
                 TalkSummaryCache.shared.warm(content)
             }
         }
+        // Long-press to peek at the original description, but only
+        // when there's a summary on the row to compare against — a
+        // bare long-press on a non-AI cell would feel inconsistent.
+        .onLongPressGesture(minimumDuration: 0.5) {
+            if aiSummaries, TalkSummaryCache.shared.summary(for: content) != nil {
+                showingOriginalDescription = true
+            }
+        }
+        .sheet(isPresented: $showingOriginalDescription) {
+            ContentDescriptionPeekSheet(
+                title: content.title,
+                description: content.description
+            )
+        }
     }
     
     func getEventTagColorBackground() -> Color {
@@ -121,5 +161,40 @@ extension Sequence where Iterator.Element : Hashable {
     {
         let sequenceSet = Set(sequence)
         return self.contains(where: sequenceSet.contains)
+    }
+}
+
+/// Lightweight peek sheet shown via long-press on an AI-summarized
+/// row. Surfaces the full source description so the user can verify
+/// what the LLM compressed.
+struct ContentDescriptionPeekSheet: View {
+    let title: String
+    let description: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(title)
+                        .font(.title2.weight(.semibold))
+                    Label("Original description", systemImage: "text.alignleft")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(description)
+                        .font(.body)
+                        .textSelection(.enabled)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .presentationDetents([.medium, .large])
     }
 }

--- a/hackertracker/Views/ContentCellView.swift
+++ b/hackertracker/Views/ContentCellView.swift
@@ -183,6 +183,8 @@ struct ContentDescriptionPeekSheet: View {
                         .foregroundStyle(.secondary)
                     Text(description)
                         .font(.body)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .textSelection(.enabled)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -15,6 +15,10 @@ struct EventCell: View {
     let dfu = DateFormatterUtility.shared
     @AppStorage("notifyAt") var notifyAt: Int = 20
     @AppStorage("show24hourtime") var show24hourtime: Bool = true
+    /// Mirror of ContentCellView's AI summary plumbing — Schedule
+    /// tab rows now opt into on-device summaries the same way.
+    @AppStorage("aiSummaries") private var aiSummaries: Bool = false
+    @State private var showingOriginalDescription: Bool = false
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
     
 
@@ -70,6 +74,25 @@ struct EventCell: View {
                                 Text(l.name).font(.caption2)
                                     .multilineTextAlignment(.leading)
                             }
+                            // AI summary slot. Same gating and styling as
+                            // ContentCellView so Schedule + All Content
+                            // share the affordance.
+                            if aiSummaries,
+                               let summary = TalkSummaryCache.shared.summary(for: event) {
+                                HStack(alignment: .top, spacing: 4) {
+                                    Image(systemName: "sparkles")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .padding(.top, 2)
+                                    Text(summary)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                        .multilineTextAlignment(.leading)
+                                }
+                                .accessibilityElement(children: .combine)
+                                .accessibilityLabel("AI summary: \(summary)")
+                            }
                             ShowEventCellTags(tagIds: event.tagIds)
                         }
                     }
@@ -87,11 +110,33 @@ struct EventCell: View {
                 }
             }
 
-        }.swipeActions {
+        }
+        .swipeActions {
             Button(bookmarkIds.contains(Int32(event.id)) ? "Remove Bookmark" : "Bookmark") {
                 bookmarkAction()
             }.buttonStyle(DefaultButtonStyle())
                 .tint(bookmarkIds.contains(Int32(event.id)) ? .red : .yellow)
+        }
+        // Opportunistic warm on cell materialization, mirroring
+        // ContentCellView. Gated on user toggle + cache's own
+        // capability + 100-char checks.
+        .task {
+            if aiSummaries {
+                TalkSummaryCache.shared.warm(event)
+            }
+        }
+        // Long-press peeks at the original description, but only
+        // when a summary is being displayed.
+        .onLongPressGesture(minimumDuration: 0.5) {
+            if aiSummaries, TalkSummaryCache.shared.summary(for: event) != nil {
+                showingOriginalDescription = true
+            }
+        }
+        .sheet(isPresented: $showingOriginalDescription) {
+            ContentDescriptionPeekSheet(
+                title: event.title,
+                description: event.description
+            )
         }
     }
     

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -51,6 +51,7 @@ struct SettingsView: View {
                         VStack(spacing: 12) {
                             VStack(spacing: 0) { StartScreenPickerView() }
                             VStack(spacing: 0) { NotificationSettingsView() }
+                            VStack(spacing: 0) { AISummarySettingsView() }
                             VStack(spacing: 0) { EasterEggSettingsView() }
                             Spacer(minLength: 0)
                         }
@@ -64,6 +65,7 @@ struct SettingsView: View {
                     ShowPastEventsSettingsView()
                     ShowNewsSettingsView()
                     NotificationSettingsView()
+                    AISummarySettingsView()
                     EasterEggSettingsView()
                 }
             }
@@ -436,5 +438,40 @@ struct ShowLocaltimeSettingsView: View {
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         SettingsView()
+    }
+}
+
+/// Toggle for the on-device Apple Intelligence summary feature.
+/// Visibility rules:
+///   - Hidden entirely on older iOS / unsupported builds
+///     (AISummaryAvailability.isPossiblyAvailable == false), so we
+///     don't tease a feature the user can't ever turn on.
+///   - Shown but disabled when the OS supports the framework but the
+///     model isn't currently available (e.g. still downloading,
+///     low-power mode). Caption explains why.
+///   - Fully interactive otherwise.
+struct AISummarySettingsView: View {
+    @AppStorage("aiSummaries") var aiSummaries: Bool = false
+
+    var body: some View {
+        if AISummaryAvailability.isPossiblyAvailable {
+            VStack(alignment: .leading, spacing: 4) {
+                Toggle("AI Summaries", isOn: $aiSummaries)
+                    .disabled(!AISummaryAvailability.isSupported)
+                    .onChange(of: aiSummaries) { _, value in
+                        Log.ui.debug("aiSummaries=\(value)")
+                    }
+                Text("Show one-sentence summaries of talk descriptions, generated on-device by Apple Intelligence. Summaries are cached and only generated for descriptions longer than 100 characters.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if !AISummaryAvailability.isSupported {
+                    Text("Apple Intelligence isn\u{2019}t available on this device right now.")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(5)
+            Divider()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Five-step spike adding on-device AI summarization of conference talk descriptions, plus follow-up extensions to the Schedule view and the long-press peek sheet. Everything is gated so the build stays inert on iOS < 26 and devices without Apple Intelligence.

> Stacked on [#30](https://github.com/junctor/hackertracker-ios/pull/30) which merged earlier today. This PR is just the AI spike on top of main.

## What's in the PR

| Commit | Step | Contents |
|---|---|---|
| [aee89a7](https://github.com/junctor/hackertracker-ios/commit/aee89a7) | 1/5 | `Utils/AISummaryAvailability.swift` — `@MainActor enum` with `isSupported` + `isPossiblyAvailable` queries that wrap `canImport(FoundationModels)` + `#available(iOS 26.0, *)` + `SystemLanguageModel.default.availability` in one place |
| [766ca71](https://github.com/junctor/hackertracker-ios/commit/766ca71) | 2/5 | `Utils/TalkSummaryCache.swift` — `@MainActor` singleton with `LanguageModelSession`, 4-concurrent throttle, FIFO queue, SHA256-keyed persistence in UserDefaults, 1000-entry cap with oldest-first eviction |
| [fca6a2d](https://github.com/junctor/hackertracker-ios/commit/fca6a2d) | 3/5 | Opportunistic `.task` warm in `ContentCellView`, plus a 100-char description minimum so we don't burn battery summarizing already-short blurbs |
| [f3ed6ac](https://github.com/junctor/hackertracker-ios/commit/f3ed6ac) | 4/5 | `@Observable` cache, sparkle + one-line summary slot in cells, long-press 0.5s opens `ContentDescriptionPeekSheet` (medium detent, selectable text, full original) |
| [4558949](https://github.com/junctor/hackertracker-ios/commit/4558949) | 5/5 | `AISummarySettingsView` toggle slotted into iPhone single-column + iPad two-column layouts; capability-aware visibility (hidden / disabled / enabled tiers) |
| [aeed001](https://github.com/junctor/hackertracker-ios/commit/aeed001) | — | Extend to Schedule via `SummarizableTalk` protocol; `Content` + `Event` both conform; same gating + affordance in `EventCellView` |
| [21616de](https://github.com/junctor/hackertracker-ios/commit/21616de) | — | Peek sheet: force `.multilineTextAlignment(.leading)` + full-width frame so the original description always reads flush left |

## Gating layers (any one of these blocks all generation)

1. **User toggle** — `@AppStorage("aiSummaries")`, defaults false; controlled by `AISummarySettingsView`.
2. **OS + SDK** — `canImport(FoundationModels)` at compile time, `#available(iOS 26.0, *)` at runtime.
3. **Device capability** — `SystemLanguageModel.default.availability == .available`.
4. **Content size** — descriptions must trim to ≥ 100 characters or `warm(_:)` no-ops.

## Persistence + eviction

- UserDefaults key `aiSummaryCache.v1`, JSON-encoded `[Int: Entry]`.
- Each entry stores `descriptionHash` (SHA256 hex of source description) so a server-side edit invalidates cleanly.
- Cap 1000 entries; eviction sorts by `createdAt` ascending.

## UI surfaces

| Where | Affordance |
|---|---|
| **All Content rows** | Sparkle ✨ + one-line summary below speakers, above tags |
| **Schedule rows** | Same affordance, slotted between location and tag chips |
| **Long-press (0.5 s)** on a row with a visible summary | Opens `ContentDescriptionPeekSheet` — medium detent, original full description, selectable text, Done button |
| **Settings** | `AI Summaries` toggle with caption explaining on-device generation + 100-char minimum; hidden entirely on iOS < 26, disabled with explanatory caption when capability is intermittent |

## Build matrix

- ✅ iPhone 16 (iOS 18.2) — Debug. `AISummaryAvailability.isPossiblyAvailable` returns false, so the Settings row is hidden, no LLM calls run, no cell decoration appears. Identical to main.
- 🟡 iOS 26 hardware with Apple Intelligence — not yet verified by me; spike is ready for QA.

## Test plan

- [ ] iOS 18 device / sim: build is identical to main (no Settings toggle, no row decoration, no perf change).
- [ ] iOS 26 device with Apple Intelligence enabled: Settings → AI Summaries appears and is enabled.
- [ ] Toggle on, open All Content: sparkle + summary fills in within ~3s on visible rows; scrolling pre-warms; rapid scroll doesn't pile up tasks (≤4 concurrent).
- [ ] Long-press a row with a summary: peek sheet appears with original full description, left-aligned, selectable. Done button dismisses.
- [ ] Long-press a row without a summary: no-op (tap still navigates).
- [ ] Schedule view shows same affordance.
- [ ] Quit + relaunch: previously-generated summaries appear instantly (UserDefaults rehydrates).
- [ ] Edit a description server-side: stale summary clears, new one regenerates.
- [ ] Toggle off: rows revert to no AI line; cache persists silently.

🧙 Built with [WOZCODE](https://wozcode.com)