### PR TITLE
Custom Events: local + iCloud-synced user-created schedule items

### DIFF
--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		5DC0DE000000000000020002 /* SVGMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000020001 /* SVGMapView.swift */; };
 		5DC0DE000000000000030002 /* AISummaryAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000030001 /* AISummaryAvailability.swift */; };
 		5DC0DE000000000000040002 /* TalkSummaryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000040001 /* TalkSummaryCache.swift */; };
+		5DC0DE000000000000050002 /* CustomEventUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000050001 /* CustomEventUtility.swift */; };
 		5D642D252A438FB50064492D /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D242A438FB50064492D /* LocationView.swift */; };
 		5D642D272A43AEA00064492D /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D262A43AEA00064492D /* Product.swift */; };
 		5D642D292A44A1960064492D /* ProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D282A44A1960064492D /* ProductsView.swift */; };
@@ -161,6 +162,7 @@
 		5DC0DE000000000000020001 /* SVGMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGMapView.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000030001 /* AISummaryAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryAvailability.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000040001 /* TalkSummaryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkSummaryCache.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000050001 /* CustomEventUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventUtility.swift; sourceTree = "<group>"; };
 		5D642D242A438FB50064492D /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		5D642D262A43AEA00064492D /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		5D642D282A44A1960064492D /* ProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsView.swift; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 				5DC0DE000000000000020001 /* SVGMapView.swift */,
 				5DC0DE000000000000030001 /* AISummaryAvailability.swift */,
 				5DC0DE000000000000040001 /* TalkSummaryCache.swift */,
+				5DC0DE000000000000050001 /* CustomEventUtility.swift */,
 				3C0E05CE2A53E70200E7154F /* Searchable.swift */,
 				3C07C208285C6F7600CC9469 /* Theme.swift */,
 			);
@@ -710,6 +713,7 @@
 				5DC0DE000000000000020002 /* SVGMapView.swift in Sources */,
 				5DC0DE000000000000030002 /* AISummaryAvailability.swift in Sources */,
 				5DC0DE000000000000040002 /* TalkSummaryCache.swift in Sources */,
+				5DC0DE000000000000050002 /* CustomEventUtility.swift in Sources */,
 				5DF51ABC2851203F007BCB83 /* Document.swift in Sources */,
 				5DDF035E2C28B4F10087BA59 /* ContentDetailView.swift in Sources */,
 				5D9681162C5946E000D246B0 /* FeedbackUtility.swift in Sources */,

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		5DC0DE000000000000050002 /* CustomEventUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000050001 /* CustomEventUtility.swift */; };
 		5DC0DE000000000000060002 /* CustomEventFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000060001 /* CustomEventFormView.swift */; };
 		5DC0DE000000000000060004 /* CustomEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000060003 /* CustomEventDetailView.swift */; };
+		5DC0DE000000000000070002 /* CustomEventShare.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000070001 /* CustomEventShare.swift */; };
+		5DC0DE000000000000070004 /* CustomEventShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000070003 /* CustomEventShareSheet.swift */; };
 		5D642D252A438FB50064492D /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D242A438FB50064492D /* LocationView.swift */; };
 		5D642D272A43AEA00064492D /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D262A43AEA00064492D /* Product.swift */; };
 		5D642D292A44A1960064492D /* ProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D282A44A1960064492D /* ProductsView.swift */; };
@@ -167,6 +169,8 @@
 		5DC0DE000000000000050001 /* CustomEventUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventUtility.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000060001 /* CustomEventFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventFormView.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000060003 /* CustomEventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventDetailView.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000070001 /* CustomEventShare.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventShare.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000070003 /* CustomEventShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventShareSheet.swift; sourceTree = "<group>"; };
 		5D642D242A438FB50064492D /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		5D642D262A43AEA00064492D /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		5D642D282A44A1960064492D /* ProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsView.swift; sourceTree = "<group>"; };
@@ -381,6 +385,7 @@
 				5DC0DE000000000000010004 /* SharedScheduleView.swift */,
 				5DC0DE000000000000060001 /* CustomEventFormView.swift */,
 				5DC0DE000000000000060003 /* CustomEventDetailView.swift */,
+				5DC0DE000000000000070003 /* CustomEventShareSheet.swift */,
 				5DDF035B2C2767750087BA59 /* ContentCellView.swift */,
 				5DDF035D2C28B4F10087BA59 /* ContentDetailView.swift */,
 				5DDF03592C2751670087BA59 /* ContentListView.swift */,
@@ -465,6 +470,7 @@
 				5DC0DE000000000000030001 /* AISummaryAvailability.swift */,
 				5DC0DE000000000000040001 /* TalkSummaryCache.swift */,
 				5DC0DE000000000000050001 /* CustomEventUtility.swift */,
+				5DC0DE000000000000070001 /* CustomEventShare.swift */,
 				3C0E05CE2A53E70200E7154F /* Searchable.swift */,
 				3C07C208285C6F7600CC9469 /* Theme.swift */,
 			);
@@ -722,6 +728,8 @@
 				5DC0DE000000000000050002 /* CustomEventUtility.swift in Sources */,
 				5DC0DE000000000000060002 /* CustomEventFormView.swift in Sources */,
 				5DC0DE000000000000060004 /* CustomEventDetailView.swift in Sources */,
+				5DC0DE000000000000070002 /* CustomEventShare.swift in Sources */,
+				5DC0DE000000000000070004 /* CustomEventShareSheet.swift in Sources */,
 				5DF51ABC2851203F007BCB83 /* Document.swift in Sources */,
 				5DDF035E2C28B4F10087BA59 /* ContentDetailView.swift in Sources */,
 				5D9681162C5946E000D246B0 /* FeedbackUtility.swift in Sources */,

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		5DC0DE000000000000030002 /* AISummaryAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000030001 /* AISummaryAvailability.swift */; };
 		5DC0DE000000000000040002 /* TalkSummaryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000040001 /* TalkSummaryCache.swift */; };
 		5DC0DE000000000000050002 /* CustomEventUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000050001 /* CustomEventUtility.swift */; };
+		5DC0DE000000000000060002 /* CustomEventFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000060001 /* CustomEventFormView.swift */; };
+		5DC0DE000000000000060004 /* CustomEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC0DE000000000000060003 /* CustomEventDetailView.swift */; };
 		5D642D252A438FB50064492D /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D242A438FB50064492D /* LocationView.swift */; };
 		5D642D272A43AEA00064492D /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D262A43AEA00064492D /* Product.swift */; };
 		5D642D292A44A1960064492D /* ProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D282A44A1960064492D /* ProductsView.swift */; };
@@ -163,6 +165,8 @@
 		5DC0DE000000000000030001 /* AISummaryAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryAvailability.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000040001 /* TalkSummaryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkSummaryCache.swift; sourceTree = "<group>"; };
 		5DC0DE000000000000050001 /* CustomEventUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventUtility.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000060001 /* CustomEventFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventFormView.swift; sourceTree = "<group>"; };
+		5DC0DE000000000000060003 /* CustomEventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventDetailView.swift; sourceTree = "<group>"; };
 		5D642D242A438FB50064492D /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		5D642D262A43AEA00064492D /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		5D642D282A44A1960064492D /* ProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsView.swift; sourceTree = "<group>"; };
@@ -375,6 +379,8 @@
 				5DF51AB92850310B007BCB83 /* ConferenceRow.swift */,
 				5D9E57442857B398001374D4 /* ConferencesView.swift */,
 				5DC0DE000000000000010004 /* SharedScheduleView.swift */,
+				5DC0DE000000000000060001 /* CustomEventFormView.swift */,
+				5DC0DE000000000000060003 /* CustomEventDetailView.swift */,
 				5DDF035B2C2767750087BA59 /* ContentCellView.swift */,
 				5DDF035D2C28B4F10087BA59 /* ContentDetailView.swift */,
 				5DDF03592C2751670087BA59 /* ContentListView.swift */,
@@ -714,6 +720,8 @@
 				5DC0DE000000000000030002 /* AISummaryAvailability.swift in Sources */,
 				5DC0DE000000000000040002 /* TalkSummaryCache.swift in Sources */,
 				5DC0DE000000000000050002 /* CustomEventUtility.swift in Sources */,
+				5DC0DE000000000000060002 /* CustomEventFormView.swift in Sources */,
+				5DC0DE000000000000060004 /* CustomEventDetailView.swift in Sources */,
 				5DF51ABC2851203F007BCB83 /* Document.swift in Sources */,
 				5DDF035E2C28B4F10087BA59 /* ContentDetailView.swift in Sources */,
 				5D9681162C5946E000D246B0 /* FeedbackUtility.swift in Sources */,

--- a/hackertracker/Models/Event.swift
+++ b/hackertracker/Models/Event.swift
@@ -25,6 +25,11 @@ struct Event: Codable, Identifiable {
     /// rows from Firestore-decoded ones. NOT part of CodingKeys, so
     /// Firestore-decoded Events leave this nil automatically.
     var customEventID: UUID? = nil
+    /// Custom-event row stripe color, copied from CustomEvent.colorHex
+    /// by the synthesizer. Same NOT-in-CodingKeys treatment so Firestore
+    /// events stay nil and the cell helpers fall through to the existing
+    /// tag-color lookup.
+    var customColorHex: String? = nil
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -90,7 +95,8 @@ extension Event {
             people: [],
             tagIds: [],
             relatedIds: nil,
-            customEventID: id
+            customEventID: id,
+            customColorHex: custom.colorHex
         )
     }
 }

--- a/hackertracker/Models/Event.swift
+++ b/hackertracker/Models/Event.swift
@@ -19,6 +19,12 @@ struct Event: Codable, Identifiable {
     var people: [Person]
     var tagIds: [Int]
     var relatedIds: [Int]?
+    /// Non-nil when this Event was synthesized from a locally-stored
+    /// CustomEvent. Lets cells render the row with its own accent
+    /// color and lets the schedule pipeline distinguish user-created
+    /// rows from Firestore-decoded ones. NOT part of CodingKeys, so
+    /// Firestore-decoded Events leave this nil automatically.
+    var customEventID: UUID? = nil
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -54,4 +60,37 @@ struct EventSpeaker: Codable, Identifiable {
 struct EventLocation: Codable, Identifiable {
     var id: Int
     var name: String
+}
+
+extension Event {
+    /// Synthesize an Event from a locally-stored CustomEvent for the
+    /// supplied conference code. Returns nil when the custom event
+    /// doesn't target this conference, or when required fields are
+    /// missing (Core Data optional storage).
+    ///
+    /// `conferenceCodes` on the source: empty array means "any
+    /// conference" (a personal event that should appear on every
+    /// schedule the user opens); non-empty means "only these
+    /// conferences".
+    static func from(custom: CustomEvent, conferenceCode: String) -> Event? {
+        guard let id = custom.id,
+              let title = custom.title,
+              let begin = custom.beginTimestamp,
+              let end = custom.endTimestamp else { return nil }
+        let codes = (custom.conferenceCodes as? [String]) ?? []
+        if !codes.isEmpty && !codes.contains(conferenceCode) { return nil }
+        return Event(
+            id: CustomEventUtility.notificationID(for: custom),
+            contentId: 0,
+            description: custom.eventDescription ?? "",
+            beginTimestamp: begin,
+            endTimestamp: end,
+            title: title,
+            locationId: 0,
+            people: [],
+            tagIds: [],
+            relatedIds: nil,
+            customEventID: id
+        )
+    }
 }

--- a/hackertracker/Utils/CustomEventShare.swift
+++ b/hackertracker/Utils/CustomEventShare.swift
@@ -1,0 +1,141 @@
+//
+//  CustomEventShare.swift
+//  hackertracker
+//
+//  Encode + decode CustomEvent payloads for the QR-code share flow.
+//
+//  Share URL shape:
+//      hackertracker://import/customEvent?t=<title>&b=<unix>&e=<unix>
+//                       [&d=<desc>][&l=<loc>][&c=<hex>][&k=A,B][&x=0|1]
+//
+//  Keys are kept short so the resulting QR code stays a low-density
+//  version that's reliably scannable by the iOS camera even when the
+//  description carries a paragraph or two.
+//
+//  Notes are intentionally NOT shared — they're a private journal
+//  field on the source device, not part of the public event identity.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Plain-old-value drafting struct used to pre-fill CustomEventFormView
+/// after a scanned URL is decoded. Mirrors the CustomEvent attributes
+/// the form lets the user edit.
+struct CustomEventDraft {
+    var title: String
+    var eventDescription: String?
+    var begin: Date
+    var end: Date
+    var location: String?
+    var conferenceCodes: [String]
+    var colorHex: String?
+    var notificationsEnabled: Bool
+}
+
+enum CustomEventShare {
+    /// URL host used for non-conference deep-link routes.
+    static let importHost = "import"
+    /// URL path that triggers the customEvent import flow.
+    static let importPath = "/customEvent"
+    /// Full prefix consumers can pattern-match against.
+    static let importURLPrefix = "hackertracker://import/customEvent?"
+
+    // MARK: - Encode
+
+    /// Build a deep-link URL representing the supplied event. Returns
+    /// nil only when the source is missing required title / time fields.
+    static func url(for event: CustomEvent) -> URL? {
+        guard let title = event.title,
+              !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let begin = event.beginTimestamp,
+              let end = event.endTimestamp else { return nil }
+
+        var comps = URLComponents()
+        comps.scheme = "hackertracker"
+        comps.host = importHost
+        comps.path = importPath
+
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "t", value: title),
+            URLQueryItem(name: "b", value: String(Int(begin.timeIntervalSince1970))),
+            URLQueryItem(name: "e", value: String(Int(end.timeIntervalSince1970))),
+        ]
+        if let d = event.eventDescription, !d.isEmpty {
+            items.append(URLQueryItem(name: "d", value: d))
+        }
+        if let l = event.location, !l.isEmpty {
+            items.append(URLQueryItem(name: "l", value: l))
+        }
+        if let c = event.colorHex, !c.isEmpty {
+            // Drop the leading '#' so the QR doesn't waste a byte on it.
+            let trimmed = c.hasPrefix("#") ? String(c.dropFirst()) : c
+            items.append(URLQueryItem(name: "c", value: trimmed))
+        }
+        let codes = (event.conferenceCodes as? [String]) ?? []
+        if !codes.isEmpty {
+            items.append(URLQueryItem(name: "k", value: codes.joined(separator: ",")))
+        }
+        // Always include x so the receiver knows the sender's intent.
+        items.append(URLQueryItem(name: "x", value: event.notificationsEnabled ? "1" : "0"))
+
+        comps.queryItems = items
+        return comps.url
+    }
+
+    // MARK: - Decode
+
+    /// Parse a deep-link URL produced by `url(for:)` into a CustomEventDraft.
+    /// Returns nil when required fields are missing or malformed.
+    static func draft(from url: URL) -> CustomEventDraft? {
+        guard url.scheme == "hackertracker",
+              url.host == importHost,
+              url.path == importPath,
+              let comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+        let items = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+
+        guard let title = items["t"], !title.isEmpty,
+              let bRaw = items["b"], let bSec = Int(bRaw),
+              let eRaw = items["e"], let eSec = Int(eRaw) else { return nil }
+
+        let begin = Date(timeIntervalSince1970: TimeInterval(bSec))
+        let end = Date(timeIntervalSince1970: TimeInterval(eSec))
+
+        var colorHex: String? = nil
+        if let raw = items["c"], !raw.isEmpty {
+            // We strip the '#' on encode; put it back so consumers see the
+            // same hex shape that lives on CustomEvent.colorHex on the
+            // sender's device.
+            colorHex = raw.hasPrefix("#") ? raw : "#" + raw
+        }
+
+        let codes: [String]
+        if let raw = items["k"], !raw.isEmpty {
+            codes = raw.split(separator: ",").map(String.init)
+        } else {
+            codes = []
+        }
+
+        let notify = items["x"] == "1"
+
+        return CustomEventDraft(
+            title: title,
+            eventDescription: items["d"].flatMap { $0.isEmpty ? nil : $0 },
+            begin: begin,
+            end: max(end, begin), // never let end precede begin after decode
+            location: items["l"].flatMap { $0.isEmpty ? nil : $0 },
+            conferenceCodes: codes,
+            colorHex: colorHex,
+            notificationsEnabled: notify
+        )
+    }
+}
+
+// .sheet(item:) requires Identifiable. We don't have a stable id on
+// the draft itself, so synthesize one from the title + begin epoch —
+// good enough since drafts are short-lived UI state, not persisted.
+extension CustomEventDraft: Identifiable {
+    var id: String { "\(title)|\(Int(begin.timeIntervalSince1970))" }
+}

--- a/hackertracker/Utils/CustomEventUtility.swift
+++ b/hackertracker/Utils/CustomEventUtility.swift
@@ -14,6 +14,33 @@ import Foundation
 import SwiftUI
 
 enum CustomEventUtility {
+    // MARK: - Notification helpers
+
+    /// Schedule or refresh a notification for the supplied event.
+    /// No-op when notificationsEnabled is false or when the event
+    /// is missing required fields. Uses the global "Before Event"
+    /// minutes setting (@AppStorage("notifyAt")), defaulting to 20
+    /// to match the rest of the app.
+    private static func scheduleNotificationIfNeeded(_ event: CustomEvent) {
+        guard event.notificationsEnabled,
+              let begin = event.beginTimestamp,
+              let title = event.title else { return }
+        let notifyAt = UserDefaults.standard.object(forKey: "notifyAt") as? Int ?? 20
+        let date = begin.addingTimeInterval(Double(-notifyAt) * 60)
+        let id = notificationID(for: event)
+        let location = event.location ?? ""
+        // Cancel any previous schedule under the same id, then re-add.
+        NotificationUtility.removeNotification(id: id)
+        NotificationUtility.scheduleNotification(date: date, id: id, title: title, location: location)
+    }
+
+    /// Remove any pending notification associated with the supplied
+    /// event. Safe to call regardless of notificationsEnabled — the
+    /// id is deterministic so we always know what to cancel.
+    private static func cancelNotification(_ event: CustomEvent) {
+        NotificationUtility.removeNotification(id: notificationID(for: event))
+    }
+
     // MARK: - Create
 
     /// Insert a new CustomEvent with the supplied fields. Returns the
@@ -47,7 +74,9 @@ enum CustomEventUtility {
         event.notificationsEnabled = notificationsEnabled
         event.createdAt = now
         event.updatedAt = now
-        return save(context: context, op: "create") ? event : nil
+        guard save(context: context, op: "create") else { return nil }
+        scheduleNotificationIfNeeded(event)
+        return event
     }
 
     // MARK: - Update
@@ -58,13 +87,22 @@ enum CustomEventUtility {
     @discardableResult
     static func touchAndSave(context: NSManagedObjectContext, event: CustomEvent) -> Bool {
         event.updatedAt = Date()
-        return save(context: context, op: "update")
+        let ok = save(context: context, op: "update")
+        if ok {
+            if event.notificationsEnabled {
+                scheduleNotificationIfNeeded(event)
+            } else {
+                cancelNotification(event)
+            }
+        }
+        return ok
     }
 
     // MARK: - Delete
 
     @discardableResult
     static func delete(context: NSManagedObjectContext, event: CustomEvent) -> Bool {
+        cancelNotification(event)
         context.delete(event)
         return save(context: context, op: "delete")
     }
@@ -75,7 +113,10 @@ enum CustomEventUtility {
         fr.predicate = NSPredicate(format: "id == %@", id as CVarArg)
         do {
             if let rows = try context.fetch(fr) as? [NSManagedObject] {
-                for r in rows { context.delete(r) }
+                for r in rows {
+                    if let ce = r as? CustomEvent { cancelNotification(ce) }
+                    context.delete(r)
+                }
             }
         } catch {
             Log.coreData.error("CustomEvent delete by id fetch failed: \(error as NSError, privacy: .public)")

--- a/hackertracker/Utils/CustomEventUtility.swift
+++ b/hackertracker/Utils/CustomEventUtility.swift
@@ -1,0 +1,158 @@
+//
+//  CustomEventUtility.swift
+//  hackertracker
+//
+//  CRUD + fetch helpers for the local `CustomEvent` entity. Mirrors the
+//  shape of `BookmarkUtility` so the rest of the app can use the same
+//  call pattern. Persistence lives in the same NSPersistentCloudKitContainer
+//  Bookmarks uses, so saved custom events sync across the user's
+//  iCloud-signed-in devices for free.
+//
+
+import CoreData
+import Foundation
+import SwiftUI
+
+enum CustomEventUtility {
+    // MARK: - Create
+
+    /// Insert a new CustomEvent with the supplied fields. Returns the
+    /// new managed object so the caller can navigate to a detail view
+    /// without an extra fetch.
+    @discardableResult
+    static func create(
+        context: NSManagedObjectContext,
+        title: String,
+        eventDescription: String?,
+        beginTimestamp: Date,
+        endTimestamp: Date,
+        location: String?,
+        notes: String?,
+        conferenceCodes: [String],
+        colorHex: String?,
+        notificationsEnabled: Bool
+    ) -> CustomEvent? {
+        let now = Date()
+        let event = CustomEvent(context: context)
+        event.id = UUID()
+        event.title = title
+        event.eventDescription = eventDescription
+        event.beginTimestamp = beginTimestamp
+        event.endTimestamp = endTimestamp
+        event.location = location
+        event.notes = notes
+        // NSArray of NSString — stored via NSSecureUnarchiveFromDataTransformer.
+        event.conferenceCodes = conferenceCodes as NSArray
+        event.colorHex = colorHex
+        event.notificationsEnabled = notificationsEnabled
+        event.createdAt = now
+        event.updatedAt = now
+        return save(context: context, op: "create") ? event : nil
+    }
+
+    // MARK: - Update
+
+    /// Mutate the supplied event in place and persist. Caller is responsible
+    /// for setting the fields it wants to change before invoking; this
+    /// helper just stamps `updatedAt` and saves.
+    @discardableResult
+    static func touchAndSave(context: NSManagedObjectContext, event: CustomEvent) -> Bool {
+        event.updatedAt = Date()
+        return save(context: context, op: "update")
+    }
+
+    // MARK: - Delete
+
+    @discardableResult
+    static func delete(context: NSManagedObjectContext, event: CustomEvent) -> Bool {
+        context.delete(event)
+        return save(context: context, op: "delete")
+    }
+
+    @discardableResult
+    static func delete(context: NSManagedObjectContext, id: UUID) -> Bool {
+        let fr = NSFetchRequest<NSFetchRequestResult>(entityName: "CustomEvent")
+        fr.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        do {
+            if let rows = try context.fetch(fr) as? [NSManagedObject] {
+                for r in rows { context.delete(r) }
+            }
+        } catch {
+            Log.coreData.error("CustomEvent delete by id fetch failed: \(error as NSError, privacy: .public)")
+            CrashReport.record(error as NSError, context: ["op": "deleteCustomEventByID"])
+            return false
+        }
+        return save(context: context, op: "deleteByID")
+    }
+
+    // MARK: - Fetch
+
+    /// All custom events, sorted by begin time ascending. Schedule
+    /// integration calls this and folds the result into the existing
+    /// Event pipeline.
+    static func all(context: NSManagedObjectContext) -> [CustomEvent] {
+        let fr = NSFetchRequest<CustomEvent>(entityName: "CustomEvent")
+        fr.sortDescriptors = [NSSortDescriptor(key: "beginTimestamp", ascending: true)]
+        do {
+            return try context.fetch(fr)
+        } catch {
+            Log.coreData.error("CustomEvent fetch all failed: \(error as NSError, privacy: .public)")
+            CrashReport.record(error as NSError, context: ["op": "fetchAllCustomEvents"])
+            return []
+        }
+    }
+
+    /// Custom events that target the supplied conference code (i.e. its
+    /// `conferenceCodes` array contains the code, OR the array is empty
+    /// meaning "any conference"). Filter applied in memory because Core
+    /// Data can't predicate over Transformable arrays.
+    static func forConference(context: NSManagedObjectContext, code: String) -> [CustomEvent] {
+        all(context: context).filter { event in
+            guard let raw = event.conferenceCodes as? [String], !raw.isEmpty else {
+                return true // empty array → applies to every conference
+            }
+            return raw.contains(code)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Lookup helper used by the form's "applies to" multi-select.
+    static func conferenceCodes(of event: CustomEvent) -> [String] {
+        (event.conferenceCodes as? [String]) ?? []
+    }
+
+    /// A deterministic Int derived from the UUID's first 4 bytes so the
+    /// existing NotificationUtility (which keys by Int32-castable Int)
+    /// can be reused without breaking on UUIDs. Top bit cleared so the
+    /// result fits in an Int32 positive range, avoiding collisions with
+    /// Firestore event ids that are also positive Ints.
+    ///
+    /// The high-bit-set range (0x8000_0000..<0xFFFF_FFFF mapped via |=)
+    /// is reserved for custom events; Firestore allocates ids out of
+    /// the lower half, so the two name-spaces don't collide.
+    static func notificationID(for event: CustomEvent) -> Int {
+        guard let uuid = event.id else { return 0 }
+        let bytes = withUnsafeBytes(of: uuid.uuid) { Array($0.prefix(4)) }
+        var v: UInt32 = 0
+        for b in bytes { v = (v << 8) | UInt32(b) }
+        v &= 0x7FFF_FFFF      // ensure non-negative when cast to Int32
+        v |= 0x4000_0000      // mark as a custom-event id (top bit of 32-bit range)
+        return Int(v)
+    }
+
+    // MARK: - Save plumbing
+
+    @discardableResult
+    private static func save(context: NSManagedObjectContext, op: String) -> Bool {
+        do {
+            try context.save()
+            return true
+        } catch {
+            let nsError = error as NSError
+            Log.coreData.error("CustomEvent \(op, privacy: .public) save failed: \(nsError, privacy: .public)")
+            CrashReport.record(nsError, context: ["op": "customEvent_\(op)"])
+            return false
+        }
+    }
+}

--- a/hackertracker/Utils/ModelExt.swift
+++ b/hackertracker/Utils/ModelExt.swift
@@ -95,13 +95,16 @@ extension [Event] {
                 }
             }
             
-            if typeIds.contains(1337) {
-                return filter {
-                    isFiltered(tagIds: $0.tagIds, filterTypes: filterTypes)
-                    && bookmarks.contains(Int32($0.id))
-                }
-            } else {
-                return filter { isFiltered(tagIds: $0.tagIds, filterTypes: filterTypes) }
+            // Custom-events pseudo-tag (1338). Same AND-with-tags
+            // semantics as Bookmarks: when active, narrow to
+            // events synthesized from CustomEvents (customEventID
+            // is non-nil). Stacked with 1337 means "bookmarked
+            // custom events".
+            return filter { event in
+                guard isFiltered(tagIds: event.tagIds, filterTypes: filterTypes) else { return false }
+                if typeIds.contains(1337) && !bookmarks.contains(Int32(event.id)) { return false }
+                if typeIds.contains(1338) && event.customEventID == nil { return false }
+                return true
             }
         }
     }

--- a/hackertracker/Views/ContentCellView.swift
+++ b/hackertracker/Views/ContentCellView.swift
@@ -146,11 +146,15 @@ struct ContentCell: View {
     }
     
     func getEventTagColorBackground() -> Color {
-        if let tag = viewModel.tagsById[content.tagIds[0]],
-           let colorHex = tag.colorBackground, let uicolor = UIColor(hex: colorHex) {
-            return Color(uiColor: uicolor)
+        // Mirrors the EventCellView guard. Content with an empty
+        // tagIds array would otherwise crash on the [0] subscript.
+        guard let firstTagId = content.tagIds.first,
+              let tag = viewModel.tagsById[firstTagId],
+              let colorHex = tag.colorBackground,
+              let uicolor = UIColor(hex: colorHex) else {
+            return .purple
         }
-        return .purple
+        return Color(uiColor: uicolor)
     }
 }
 

--- a/hackertracker/Views/CustomEventDetailView.swift
+++ b/hackertracker/Views/CustomEventDetailView.swift
@@ -2,14 +2,20 @@
 //  CustomEventDetailView.swift
 //  hackertracker
 //
-//  Destination for a tap on a custom event row in the schedule. Shows
-//  the human-readable fields and offers Edit / Delete via the toolbar.
-//  Fetches by UUID via @FetchRequest so the view auto-refreshes when
-//  the underlying Core Data row is edited or deleted (e.g. CloudKit
-//  sync arrives from another device).
+//  Destination for a tap on a custom event row in the schedule.
+//  Visually mirrors EventDetailView so the two detail experiences
+//  feel like one design system:
+//    - Centered large-title header
+//    - Frosted gray card with time + location rows and the tags grid
+//      (which includes the synthetic "Custom Event" chip)
+//    - Markdown body
+//    - Editable / deletable via toolbar Edit + a destructive Delete
+//      at the bottom (the only piece that differs from EventDetailView,
+//      since Firestore events have no edit lifecycle).
 //
 
 import CoreData
+import MarkdownUI
 import SwiftUI
 
 struct CustomEventDetailView: View {
@@ -20,9 +26,8 @@ struct CustomEventDetailView: View {
     @FetchRequest private var events: FetchedResults<CustomEvent>
     @State private var showingEditor: Bool = false
     @State private var showingDeleteConfirm: Bool = false
+    let dfu = DateFormatterUtility.shared
 
-    /// FetchRequest needs a predicate referencing `eventID`. Init wires
-    /// it up so each instance scopes to a single row.
     init(eventID: UUID) {
         self.eventID = eventID
         _events = FetchRequest<CustomEvent>(
@@ -32,6 +37,9 @@ struct CustomEventDetailView: View {
     }
 
     var body: some View {
+        // Phase 4 follow-up: observe DateFormatterUtility so SwiftUI
+        // re-renders this view when the active timezone changes.
+        let _ = dfu.tzGeneration
         Group {
             if let event = events.first {
                 detail(for: event)
@@ -44,12 +52,9 @@ struct CustomEventDetailView: View {
                 .frame(maxHeight: .infinity)
             }
         }
-        .navigationTitle("Event")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
+        .navigationBarTitle(Text(""), displayMode: .inline)
         .toolbar {
-            if let event = events.first {
+            if events.first != nil {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         showingEditor = true
@@ -57,8 +62,6 @@ struct CustomEventDetailView: View {
                         Image(systemName: "pencil")
                     }
                     .accessibilityLabel("Edit event")
-                    .accessibilityIdentifier("EditCustomEvent")
-                    .opacity(event.id == nil ? 0 : 1) // hide if mid-deletion race
                 }
             }
         }
@@ -68,56 +71,73 @@ struct CustomEventDetailView: View {
             }
         }
         .iPadReadableContent()
+        .analyticsScreen(name: "CustomEventDetailView")
     }
 
     @ViewBuilder private func detail(for event: CustomEvent) -> some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                if let title = event.title, !title.isEmpty {
-                    Text(title)
-                        .font(.largeTitle.weight(.bold))
-                        .multilineTextAlignment(.leading)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+            // Header card: title + time + location + tag chips.
+            // Mirrors the EventDetailView layout exactly so the two
+            // detail screens read as the same component family.
+            VStack(alignment: .leading) {
+                VStack(alignment: .center) {
+                    Text(event.title ?? "Untitled Event")
+                        .font(.largeTitle).bold()
+                    VStack(alignment: .leading) {
+                        whenRow(event: event)
+                        if let location = event.location, !location.isEmpty {
+                            locationRow(text: location)
+                        }
+                        ShowEventCellTags(
+                            tagIds: [],
+                            minWidth: 150,
+                            customEvent: true,
+                            customColorHex: event.colorHex
+                        )
+                    }
                 }
-                whenSection(event: event)
-                if let location = event.location, !location.isEmpty {
-                    Label(location, systemImage: "mappin.and.ellipse")
-                        .font(.body)
-                        .foregroundStyle(.secondary)
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(15)
+            }
+
+            // Description (Markdown-rendered, matches EventDetailView).
+            if let desc = event.eventDescription, !desc.isEmpty {
+                VStack(alignment: .leading) {
+                    Markdown(desc)
+                        .padding()
                 }
-                if let desc = event.eventDescription, !desc.isEmpty {
-                    Divider()
-                    Text("Description")
-                        .font(.headline)
-                    Text(desc)
-                        .font(.body)
-                        .multilineTextAlignment(.leading)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
-                }
-                if let notes = event.notes, !notes.isEmpty {
-                    Divider()
+            }
+
+            // Notes — private to the user; EventDetailView has no
+            // parallel concept, so render under its own header.
+            if let notes = event.notes, !notes.isEmpty {
+                Divider()
+                VStack(alignment: .leading, spacing: 8) {
                     Text("Notes")
                         .font(.headline)
                     Text(notes)
                         .font(.body)
+                        .foregroundStyle(.secondary)
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .foregroundStyle(.secondary)
                         .textSelection(.enabled)
                 }
-                conferenceBadges(event: event)
-                notificationsRow(event: event)
-                Divider()
-                Button(role: .destructive) {
-                    showingDeleteConfirm = true
-                } label: {
-                    Label("Delete this event", systemImage: "trash")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .tint(.red)
+                .padding()
             }
+
+            Divider()
+            metadataFooter(event: event)
+            Divider()
+
+            Button(role: .destructive) {
+                showingDeleteConfirm = true
+            } label: {
+                Label("Delete this event", systemImage: "trash")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(.red)
             .padding()
         }
         .confirmationDialog(
@@ -133,23 +153,47 @@ struct CustomEventDetailView: View {
         }
     }
 
-    @ViewBuilder private func whenSection(event: CustomEvent) -> some View {
-        let dfu = DateFormatterUtility.shared
+    // MARK: - Header rows
+
+    @ViewBuilder private func whenRow(event: CustomEvent) -> some View {
         let begin = event.beginTimestamp ?? Date()
         let end = event.endTimestamp ?? begin
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Image(systemName: "calendar")
-                Text(dfu.dayMonthDayOfWeekFormatter.string(from: begin))
-            }
-            HStack {
-                Image(systemName: "clock")
-                Text("\(dfu.hourMinuteTimeFormatter.string(from: begin)) – \(dfu.hourMinuteTimeFormatter.string(from: end))")
-                    .monospacedDigit()
-            }
+        HStack {
+            Image(systemName: "clock")
+            Text("\(dfu.shortDayMonthDayTimeOfWeekFormatter.string(from: begin)) - \(dfu.shortDayMonthDayTimeOfWeekFormatter.string(from: end))")
+                .font(.subheadline).bold()
         }
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
+        .padding(.leading, 10)
+        .padding(.trailing, 5)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background)
+        .cornerRadius(10)
+        .padding(.bottom, 5)
+    }
+
+    @ViewBuilder private func locationRow(text: String) -> some View {
+        HStack {
+            Image(systemName: "map")
+            Text(text).font(.subheadline).bold()
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 5)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background)
+        .cornerRadius(10)
+        .padding(.bottom, 5)
+    }
+
+    // MARK: - Metadata footer
+
+    @ViewBuilder private func metadataFooter(event: CustomEvent) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            conferenceBadges(event: event)
+            notificationsRow(event: event)
+        }
+        .padding(.horizontal)
     }
 
     @ViewBuilder private func conferenceBadges(event: CustomEvent) -> some View {

--- a/hackertracker/Views/CustomEventDetailView.swift
+++ b/hackertracker/Views/CustomEventDetailView.swift
@@ -1,0 +1,180 @@
+//
+//  CustomEventDetailView.swift
+//  hackertracker
+//
+//  Destination for a tap on a custom event row in the schedule. Shows
+//  the human-readable fields and offers Edit / Delete via the toolbar.
+//  Fetches by UUID via @FetchRequest so the view auto-refreshes when
+//  the underlying Core Data row is edited or deleted (e.g. CloudKit
+//  sync arrives from another device).
+//
+
+import CoreData
+import SwiftUI
+
+struct CustomEventDetailView: View {
+    let eventID: UUID
+
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.dismiss) private var dismiss
+    @FetchRequest private var events: FetchedResults<CustomEvent>
+    @State private var showingEditor: Bool = false
+    @State private var showingDeleteConfirm: Bool = false
+
+    /// FetchRequest needs a predicate referencing `eventID`. Init wires
+    /// it up so each instance scopes to a single row.
+    init(eventID: UUID) {
+        self.eventID = eventID
+        _events = FetchRequest<CustomEvent>(
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "id == %@", eventID as CVarArg)
+        )
+    }
+
+    var body: some View {
+        Group {
+            if let event = events.first {
+                detail(for: event)
+            } else {
+                ContentUnavailableView(
+                    "Event Removed",
+                    systemImage: "trash",
+                    description: Text("This custom event no longer exists. It may have been deleted on another device.")
+                )
+                .frame(maxHeight: .infinity)
+            }
+        }
+        .navigationTitle("Event")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbar {
+            if let event = events.first {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showingEditor = true
+                    } label: {
+                        Image(systemName: "pencil")
+                    }
+                    .accessibilityLabel("Edit event")
+                    .accessibilityIdentifier("EditCustomEvent")
+                    .opacity(event.id == nil ? 0 : 1) // hide if mid-deletion race
+                }
+            }
+        }
+        .sheet(isPresented: $showingEditor) {
+            if let event = events.first {
+                CustomEventFormView(existing: event)
+            }
+        }
+        .iPadReadableContent()
+    }
+
+    @ViewBuilder private func detail(for event: CustomEvent) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let title = event.title, !title.isEmpty {
+                    Text(title)
+                        .font(.largeTitle.weight(.bold))
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                whenSection(event: event)
+                if let location = event.location, !location.isEmpty {
+                    Label(location, systemImage: "mappin.and.ellipse")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+                if let desc = event.eventDescription, !desc.isEmpty {
+                    Divider()
+                    Text("Description")
+                        .font(.headline)
+                    Text(desc)
+                        .font(.body)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+                if let notes = event.notes, !notes.isEmpty {
+                    Divider()
+                    Text("Notes")
+                        .font(.headline)
+                    Text(notes)
+                        .font(.body)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+                conferenceBadges(event: event)
+                notificationsRow(event: event)
+                Divider()
+                Button(role: .destructive) {
+                    showingDeleteConfirm = true
+                } label: {
+                    Label("Delete this event", systemImage: "trash")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+            }
+            .padding()
+        }
+        .confirmationDialog(
+            "Delete this event?",
+            isPresented: $showingDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                _ = CustomEventUtility.delete(context: viewContext, event: event)
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+    }
+
+    @ViewBuilder private func whenSection(event: CustomEvent) -> some View {
+        let dfu = DateFormatterUtility.shared
+        let begin = event.beginTimestamp ?? Date()
+        let end = event.endTimestamp ?? begin
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: "calendar")
+                Text(dfu.dayMonthDayOfWeekFormatter.string(from: begin))
+            }
+            HStack {
+                Image(systemName: "clock")
+                Text("\(dfu.hourMinuteTimeFormatter.string(from: begin)) – \(dfu.hourMinuteTimeFormatter.string(from: end))")
+                    .monospacedDigit()
+            }
+        }
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder private func conferenceBadges(event: CustomEvent) -> some View {
+        let codes = CustomEventUtility.conferenceCodes(of: event)
+        if codes.isEmpty {
+            Label("Applies to every conference", systemImage: "globe")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Image(systemName: "checkmark.circle")
+                    .foregroundStyle(.secondary)
+                Text(codes.joined(separator: ", "))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder private func notificationsRow(event: CustomEvent) -> some View {
+        Label(
+            event.notificationsEnabled ? "Notifications on" : "Notifications off",
+            systemImage: event.notificationsEnabled ? "bell.fill" : "bell.slash"
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+}

--- a/hackertracker/Views/CustomEventDetailView.swift
+++ b/hackertracker/Views/CustomEventDetailView.swift
@@ -27,7 +27,20 @@ struct CustomEventDetailView: View {
     @State private var showingEditor: Bool = false
     @State private var showingDeleteConfirm: Bool = false
     @State private var showingShareSheet: Bool = false
+    /// Live bookmark state shared with EventDetailView / EventCellView.
+    /// Custom events bookmark under the SAME synthesized Int id that
+    /// `Event.from(custom:...)` uses, so toggling the bookmark here
+    /// makes the row pop in the Bookmarks (1337) filter too.
+    @FetchRequest(sortDescriptors: []) private var bookmarks: FetchedResults<Bookmarks>
     let dfu = DateFormatterUtility.shared
+
+    private func bookmarkInt(_ event: CustomEvent) -> Int {
+        CustomEventUtility.notificationID(for: event)
+    }
+    private func isBookmarked(_ event: CustomEvent) -> Bool {
+        let id = Int32(bookmarkInt(event))
+        return bookmarks.contains(where: { $0.id == id })
+    }
 
     init(eventID: UUID) {
         self.eventID = eventID
@@ -55,8 +68,27 @@ struct CustomEventDetailView: View {
         }
         .navigationBarTitle(Text(""), displayMode: .inline)
         .toolbar {
-            if events.first != nil {
+            if let event = events.first {
                 ToolbarItemGroup(placement: .topBarTrailing) {
+                    // Bookmark toggle. Custom events live on the
+                    // schedule unconditionally; bookmarking them is
+                    // about opting them into the Bookmarks (1337)
+                    // filter rather than visibility.
+                    Button {
+                        toggleBookmark(event)
+                    } label: {
+                        Image(systemName: isBookmarked(event) ? "bookmark.fill" : "bookmark")
+                    }
+                    .accessibilityLabel(isBookmarked(event) ? "Remove bookmark" : "Add bookmark")
+                    // One-tap notifications toggle. Goes through
+                    // touchAndSave so scheduling / cancellation is
+                    // handled by CustomEventUtility automatically.
+                    Button {
+                        toggleNotifications(event)
+                    } label: {
+                        Image(systemName: event.notificationsEnabled ? "bell.fill" : "bell.slash")
+                    }
+                    .accessibilityLabel(event.notificationsEnabled ? "Turn off notifications" : "Turn on notifications")
                     Button {
                         showingShareSheet = true
                     } label: {
@@ -232,5 +264,21 @@ struct CustomEventDetailView: View {
         )
         .font(.caption)
         .foregroundStyle(.secondary)
+    }
+
+    // MARK: - Actions
+
+    private func toggleBookmark(_ event: CustomEvent) {
+        let id = bookmarkInt(event)
+        if isBookmarked(event) {
+            BookmarkUtility.deleteBookmark(context: viewContext, id: id)
+        } else {
+            BookmarkUtility.addBookmark(context: viewContext, id: id)
+        }
+    }
+
+    private func toggleNotifications(_ event: CustomEvent) {
+        event.notificationsEnabled.toggle()
+        _ = CustomEventUtility.touchAndSave(context: viewContext, event: event)
     }
 }

--- a/hackertracker/Views/CustomEventDetailView.swift
+++ b/hackertracker/Views/CustomEventDetailView.swift
@@ -26,6 +26,7 @@ struct CustomEventDetailView: View {
     @FetchRequest private var events: FetchedResults<CustomEvent>
     @State private var showingEditor: Bool = false
     @State private var showingDeleteConfirm: Bool = false
+    @State private var showingShareSheet: Bool = false
     let dfu = DateFormatterUtility.shared
 
     init(eventID: UUID) {
@@ -55,7 +56,13 @@ struct CustomEventDetailView: View {
         .navigationBarTitle(Text(""), displayMode: .inline)
         .toolbar {
             if events.first != nil {
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
+                        showingShareSheet = true
+                    } label: {
+                        Image(systemName: "qrcode")
+                    }
+                    .accessibilityLabel("Share via QR code")
                     Button {
                         showingEditor = true
                     } label: {
@@ -68,6 +75,11 @@ struct CustomEventDetailView: View {
         .sheet(isPresented: $showingEditor) {
             if let event = events.first {
                 CustomEventFormView(existing: event)
+            }
+        }
+        .sheet(isPresented: $showingShareSheet) {
+            if let event = events.first {
+                CustomEventShareSheet(event: event)
             }
         }
         .iPadReadableContent()

--- a/hackertracker/Views/CustomEventFormView.swift
+++ b/hackertracker/Views/CustomEventFormView.swift
@@ -16,6 +16,10 @@ struct CustomEventFormView: View {
     /// otherwise. We snapshot the live values into local @State so
     /// edits can be cancelled cleanly without partial writes.
     let existing: CustomEvent?
+    /// Optional pre-fill values, used when the form is launched
+    /// from a deep-link import (QR code scan). Ignored when `existing`
+    /// is non-nil so edit mode keeps its existing semantics.
+    var draft: CustomEventDraft? = nil
 
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.dismiss) private var dismiss
@@ -184,8 +188,8 @@ struct CustomEventFormView: View {
         )
     }
 
-    /// Populate @State from `existing` on appear (edit mode) or pre-fill
-    /// the current conference (create mode).
+    /// Populate @State from `existing` (edit mode) > `draft` (inbound
+    /// QR import) > defaults (fresh create).
     private func hydrateFromExisting() {
         if let e = existing {
             title = e.title ?? ""
@@ -199,6 +203,24 @@ struct CustomEventFormView: View {
                 accentColor = Color(uiColor: ui)
             }
             selectedConferences = Set(CustomEventUtility.conferenceCodes(of: e))
+        } else if let d = draft {
+            // Pre-fill from a scanned QR. Notes are intentionally not
+            // shared so they stay empty.
+            title = d.title
+            eventDescription = d.eventDescription ?? ""
+            begin = d.begin
+            end = d.end
+            location = d.location ?? ""
+            notificationsEnabled = d.notificationsEnabled
+            if let hex = d.colorHex, let ui = UIColor(hex: hex) {
+                accentColor = Color(uiColor: ui)
+            }
+            // Default to the union of the scanned codes and the user's
+            // current conference, so a scanned event from a different
+            // conference can land on the user's active one too.
+            var codes = Set(d.conferenceCodes)
+            codes.insert(selected.code)
+            selectedConferences = codes
         } else {
             // Default to the currently-selected conference so the common
             // case ("add an event to THIS conference") is one tap.

--- a/hackertracker/Views/CustomEventFormView.swift
+++ b/hackertracker/Views/CustomEventFormView.swift
@@ -1,0 +1,221 @@
+//
+//  CustomEventFormView.swift
+//  hackertracker
+//
+//  Create or edit a locally-stored CustomEvent. Same screen serves
+//  both flows: pass `existing: nil` to create, `existing: <event>` to
+//  edit. CRUD goes through CustomEventUtility so persistence + the
+//  CloudKit sync ride entirely on the existing Core Data stack.
+//
+
+import CoreData
+import SwiftUI
+
+struct CustomEventFormView: View {
+    /// nil when the form is in create mode; the event being edited
+    /// otherwise. We snapshot the live values into local @State so
+    /// edits can be cancelled cleanly without partial writes.
+    let existing: CustomEvent?
+
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var selected: SelectedConference
+    @Environment(ConferencesViewModel.self) private var consViewModel
+
+    // MARK: - Field state
+
+    @State private var title: String = ""
+    @State private var eventDescription: String = ""
+    @State private var begin: Date = Date()
+    @State private var end: Date = Date().addingTimeInterval(60 * 60)
+    @State private var location: String = ""
+    @State private var notes: String = ""
+    @State private var notificationsEnabled: Bool = false
+    @State private var accentColor: Color = .purple
+    /// Set of conference codes this event applies to. Empty set means
+    /// "every conference" (mirrors Event.from(custom:conferenceCode:)).
+    @State private var selectedConferences: Set<String> = []
+
+    @State private var showingDeleteConfirm: Bool = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Event title", text: $title)
+                        .textInputAutocapitalization(.words)
+                } header: { Text("Title") }
+
+                Section {
+                    DatePicker("Starts", selection: $begin)
+                    DatePicker("Ends", selection: $end, in: begin...)
+                } header: { Text("When") }
+
+                Section {
+                    TextField("Location (optional)", text: $location)
+                        .textInputAutocapitalization(.words)
+                } header: { Text("Where") }
+
+                Section {
+                    TextEditor(text: $eventDescription)
+                        .frame(minHeight: 80)
+                } header: { Text("Description") }
+
+                Section {
+                    TextEditor(text: $notes)
+                        .frame(minHeight: 60)
+                } header: { Text("Notes (private)") }
+
+                Section {
+                    ColorPicker("Accent color", selection: $accentColor, supportsOpacity: false)
+                } header: { Text("Appearance") }
+
+                Section {
+                    Toggle("Send a notification before this event", isOn: $notificationsEnabled)
+                } footer: {
+                    Text("Uses the global \"Before Event\" minutes setting. Defaults off.")
+                }
+
+                Section {
+                    if consViewModel.conferences.isEmpty {
+                        Text("No conferences loaded yet.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(consViewModel.conferences, id: \.code) { conf in
+                            Toggle(conf.name, isOn: bindingFor(code: conf.code))
+                        }
+                    }
+                } header: { Text("Applies to") } footer: {
+                    Text("Pick one or more conferences. If none are picked, this event shows on every conference's schedule.")
+                }
+
+                if existing != nil {
+                    Section {
+                        Button(role: .destructive) {
+                            showingDeleteConfirm = true
+                        } label: {
+                            Label("Delete event", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+            .navigationTitle(existing == nil ? "New Event" : "Edit Event")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save", action: save)
+                        .disabled(!isValid)
+                }
+            }
+            .onAppear { hydrateFromExisting() }
+            .confirmationDialog(
+                "Delete this event?",
+                isPresented: $showingDeleteConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("Delete", role: .destructive) { deleteAndDismiss() }
+                Button("Cancel", role: .cancel) {}
+            }
+        }
+    }
+
+    // MARK: - Validation + save
+
+    /// Bare-minimum gate: title is non-blank and end >= begin.
+    private var isValid: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && end >= begin
+    }
+
+    private func save() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDescription = eventDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedLocation = location.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+        let codes = Array(selectedConferences).sorted()
+        let hex = accentColor.toHexString()
+
+        if let existing {
+            existing.title = trimmedTitle
+            existing.eventDescription = trimmedDescription.isEmpty ? nil : trimmedDescription
+            existing.beginTimestamp = begin
+            existing.endTimestamp = end
+            existing.location = trimmedLocation.isEmpty ? nil : trimmedLocation
+            existing.notes = trimmedNotes.isEmpty ? nil : trimmedNotes
+            existing.conferenceCodes = codes as NSArray
+            existing.colorHex = hex
+            existing.notificationsEnabled = notificationsEnabled
+            _ = CustomEventUtility.touchAndSave(context: viewContext, event: existing)
+        } else {
+            _ = CustomEventUtility.create(
+                context: viewContext,
+                title: trimmedTitle,
+                eventDescription: trimmedDescription.isEmpty ? nil : trimmedDescription,
+                beginTimestamp: begin,
+                endTimestamp: end,
+                location: trimmedLocation.isEmpty ? nil : trimmedLocation,
+                notes: trimmedNotes.isEmpty ? nil : trimmedNotes,
+                conferenceCodes: codes,
+                colorHex: hex,
+                notificationsEnabled: notificationsEnabled
+            )
+        }
+        dismiss()
+    }
+
+    private func deleteAndDismiss() {
+        guard let existing else { return }
+        _ = CustomEventUtility.delete(context: viewContext, event: existing)
+        dismiss()
+    }
+
+    // MARK: - Helpers
+
+    private func bindingFor(code: String) -> Binding<Bool> {
+        Binding(
+            get: { selectedConferences.contains(code) },
+            set: { isOn in
+                if isOn { selectedConferences.insert(code) }
+                else    { selectedConferences.remove(code) }
+            }
+        )
+    }
+
+    /// Populate @State from `existing` on appear (edit mode) or pre-fill
+    /// the current conference (create mode).
+    private func hydrateFromExisting() {
+        if let e = existing {
+            title = e.title ?? ""
+            eventDescription = e.eventDescription ?? ""
+            begin = e.beginTimestamp ?? Date()
+            end = e.endTimestamp ?? begin.addingTimeInterval(60 * 60)
+            location = e.location ?? ""
+            notes = e.notes ?? ""
+            notificationsEnabled = e.notificationsEnabled
+            if let hex = e.colorHex, let ui = UIColor(hex: hex) {
+                accentColor = Color(uiColor: ui)
+            }
+            selectedConferences = Set(CustomEventUtility.conferenceCodes(of: e))
+        } else {
+            // Default to the currently-selected conference so the common
+            // case ("add an event to THIS conference") is one tap.
+            selectedConferences = [selected.code]
+        }
+    }
+}
+
+private extension Color {
+    /// Best-effort conversion to a stable hex string for Core Data
+    /// persistence. SwiftUI Color doesn't expose RGBA directly; round-trip
+    /// through UIColor.
+    func toHexString() -> String? {
+        let ui = UIColor(self)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        guard ui.getRed(&r, green: &g, blue: &b, alpha: &a) else { return nil }
+        let R = Int(round(r * 255)), G = Int(round(g * 255)), B = Int(round(b * 255))
+        return String(format: "#%02X%02X%02X", R, G, B)
+    }
+}

--- a/hackertracker/Views/CustomEventShareSheet.swift
+++ b/hackertracker/Views/CustomEventShareSheet.swift
@@ -1,0 +1,101 @@
+//
+//  CustomEventShareSheet.swift
+//  hackertracker
+//
+//  Modal that presents a QR-code-encoded deep link for a CustomEvent.
+//  Anyone scanning the QR with the iOS camera lands in HackerTracker
+//  with the form pre-filled, ready to save the same event on their
+//  own device.
+//
+
+import SwiftUI
+
+struct CustomEventShareSheet: View {
+    let event: CustomEvent
+
+    @Environment(\.dismiss) private var dismiss
+
+    private var shareURL: URL? { CustomEventShare.url(for: event) }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if let url = shareURL {
+                    content(for: url)
+                } else {
+                    ContentUnavailableView(
+                        "Cannot Share",
+                        systemImage: "qrcode.viewfinder",
+                        description: Text("This event is missing a title or time, so it can\u{2019}t be encoded into a QR code yet. Edit the event and try again.")
+                    )
+                    .padding(.top, 60)
+                }
+            }
+            .navigationTitle("Share Event")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private func content(for url: URL) -> some View {
+        VStack(spacing: 20) {
+            Text(event.title ?? "")
+                .font(.title2.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            // White-on-white card so the QR has a known background — some
+            // dark-mode themes invert the SwiftUI Image's transparency and
+            // make the code unscannable. The fixed white block prevents
+            // that.
+            QRCodeView(qrString: url.absoluteString)
+                .padding(16)
+                .background(Color.white)
+                .cornerRadius(12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+                )
+
+            Text("Open the iPhone camera, point it at this code, and tap the link that appears. The other device will open HackerTracker with this event pre-filled.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            // Always offer a system Share — lets the user AirDrop or
+            // copy the link as text when scanning isn’t practical.
+            ShareLink(item: url) {
+                Label("Share Link\u{2026}", systemImage: "square.and.arrow.up")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+
+            urlPreview(url: url)
+        }
+        .padding(.vertical, 24)
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder private func urlPreview(url: URL) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Link")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(url.absoluteString)
+                .font(.footnote.monospaced())
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(Color(.systemGray6))
+                .cornerRadius(8)
+                .textSelection(.enabled)
+        }
+        .padding(.horizontal)
+    }
+}

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -93,7 +93,11 @@ struct EventCell: View {
                                 .accessibilityElement(children: .combine)
                                 .accessibilityLabel("AI summary: \(summary)")
                             }
-                            ShowEventCellTags(tagIds: event.tagIds)
+                            ShowEventCellTags(
+                                tagIds: event.tagIds,
+                                customEvent: event.customEventID != nil,
+                                customColorHex: event.customColorHex
+                            )
                         }
                     }
                     
@@ -165,10 +169,31 @@ struct EventCell: View {
 struct ShowEventCellTags: View {
     var tagIds: [Int]
     var minWidth: CGFloat = 100
+    /// When true, prepend a synthetic "Custom Event" chip ahead of
+    /// the regular tag chips. Honors `customColorHex` when set so the
+    /// chip's dot matches the row stripe color the user picked.
+    var customEvent: Bool = false
+    var customColorHex: String? = nil
     @Environment(InfoViewModel.self) private var viewModel
+
+    private var customChipColor: Color {
+        if let hex = customColorHex, let ui = UIColor(hex: hex) {
+            return Color(uiColor: ui)
+        }
+        return .purple
+    }
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: minWidth))], alignment: .leading, spacing: 1) {
+            if customEvent {
+                HStack {
+                    Circle().foregroundColor(customChipColor)
+                        .frame(width: 8, height: 8, alignment: .center)
+                    Text("Custom Event").font(.caption)
+                        .multilineTextAlignment(.leading)
+                        .frame(alignment: .leading)
+                }
+            }
             ForEach(tagIds, id: \.self) { tagId in
                 if let tag = viewModel.tagsById[tagId] {
                     VStack {

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -141,11 +141,16 @@ struct EventCell: View {
     }
     
     func getEventTagColorBackground() -> Color {
-        if let tag = viewModel.tagsById[event.tagIds[0]],
-           let colorHex = tag.colorBackground, let uicolor = UIColor(hex: colorHex) {
-            return Color(uiColor: uicolor)
+        // First tag id can be missing entirely (custom events have an
+        // empty tagIds array). Guard with .first to avoid an index
+        // crash. Default is .purple, matching the original fallback.
+        guard let firstTagId = event.tagIds.first,
+              let tag = viewModel.tagsById[firstTagId],
+              let colorHex = tag.colorBackground,
+              let uicolor = UIColor(hex: colorHex) else {
+            return .purple
         }
-        return .purple
+        return Color(uiColor: uicolor)
     }
 }
 

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -141,9 +141,17 @@ struct EventCell: View {
     }
     
     func getEventTagColorBackground() -> Color {
-        // First tag id can be missing entirely (custom events have an
-        // empty tagIds array). Guard with .first to avoid an index
-        // crash. Default is .purple, matching the original fallback.
+        // Custom events override the tag-derived color with whatever
+        // the user picked in the form. Falls back to the default if
+        // the stored hex is unparseable.
+        if let customHex = event.customColorHex,
+           let ui = UIColor(hex: customHex) {
+            return Color(uiColor: ui)
+        }
+        // Otherwise: first-tag color, guarded with .first so an empty
+        // tagIds array (custom event with no override, or any sparse
+        // Firestore data) can't crash. Default is .purple to match
+        // the historical fallback.
         guard let firstTagId = event.tagIds.first,
               let tag = viewModel.tagsById[firstTagId],
               let colorHex = tag.colorBackground,

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -32,11 +32,17 @@ struct EventsView: View {
     /// button. Same state used by both the iPhone and iPad code paths.
     @State private var showingCustomEventForm: Bool = false
 
+    /// User toggle (defaulting on) for whether custom events appear in
+    /// the schedule at all. Lives next to the rest of the schedule
+    /// state so its value is read inline with the synthesizer.
+    @AppStorage("showCustomEvents") private var showCustomEventsInSchedule: Bool = true
+
     /// Firestore events + synthesized CustomEvents that target the
     /// currently-selected conference. Three Schedule call sites read
     /// this in place of viewModel.events so user-created rows flow
     /// through filters / search / eventDayGroup naturally.
     private var scheduleEvents: [Event] {
+        guard showCustomEventsInSchedule else { return viewModel.events }
         let code = selected.code
         let synthesized = customEvents.compactMap { Event.from(custom: $0, conferenceCode: code) }
         return viewModel.events + synthesized

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -21,12 +21,16 @@ struct EventsView: View {
     let dfu = DateFormatterUtility.shared
     var includeNav: Bool = true
     var navTitle: String = ""
+    @Environment(\.managedObjectContext) private var viewContext
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
     /// Locally-stored custom events. Merged into the Schedule pipeline
     /// at query time via the `scheduleEvents` helper below — Firestore
     /// events stay on viewModel.events untouched.
     @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \CustomEvent.beginTimestamp, ascending: true)])
     var customEvents: FetchedResults<CustomEvent>
+    /// Drives the Add Custom Event modal sheet from the toolbar +
+    /// button. Same state used by both the iPhone and iPad code paths.
+    @State private var showingCustomEventForm: Bool = false
 
     /// Firestore events + synthesized CustomEvents that target the
     /// currently-selected conference. Three Schedule call sites read
@@ -262,12 +266,22 @@ struct EventsView: View {
           }
         }
         ToolbarItemGroup(placement: .navigationBarTrailing) {
+          Button {
+            showingCustomEventForm = true
+          } label: {
+            Image(systemName: "plus")
+          }
+          .accessibilityLabel("Add custom event")
           searchToggleButton
         }
       }
       .task(id: searchText) {
         try? await Task.sleep(nanoseconds: 250_000_000)
         if !Task.isCancelled { debouncedSearch = searchText }
+      }
+      .sheet(isPresented: $showingCustomEventForm) {
+        CustomEventFormView(existing: nil)
+          .environment(\.managedObjectContext, viewContext)
       }
     }
   }
@@ -609,7 +623,16 @@ struct EventData: View {
           }, id: \.id
         ) { event in
           if showPastEvents || event.endTimestamp >= Date() {
-            if let sel = iPadContentSelection {
+            // Custom-event rows always route to their own detail screen;
+            // they have no parent Content document to push.
+            if let cid = event.customEventID {
+              NavigationLink(destination: CustomEventDetailView(eventID: cid)) {
+                EventCell(event: event, showDay: false)
+                  .id(event.id)
+                  .foregroundColor(.primary)
+                  .padding(1)
+              }
+            } else if let sel = iPadContentSelection {
               Button {
                 sel.wrappedValue = event.contentId
               } label: {

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -22,6 +22,21 @@ struct EventsView: View {
     var includeNav: Bool = true
     var navTitle: String = ""
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
+    /// Locally-stored custom events. Merged into the Schedule pipeline
+    /// at query time via the `scheduleEvents` helper below — Firestore
+    /// events stay on viewModel.events untouched.
+    @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \CustomEvent.beginTimestamp, ascending: true)])
+    var customEvents: FetchedResults<CustomEvent>
+
+    /// Firestore events + synthesized CustomEvents that target the
+    /// currently-selected conference. Three Schedule call sites read
+    /// this in place of viewModel.events so user-created rows flow
+    /// through filters / search / eventDayGroup naturally.
+    private var scheduleEvents: [Event] {
+        let code = selected.code
+        let synthesized = customEvents.compactMap { Event.from(custom: $0, conferenceCode: code) }
+        return viewModel.events + synthesized
+    }
     // @Binding var tappedScheduleTwice: Bool
     // @Binding var schedule: UUID
 
@@ -84,7 +99,7 @@ struct EventsView: View {
           // Dates first (ascending; eventDayGroup already sorts that way),
           // then Top / Now / Next / Bottom.
           ForEach(
-              viewModel.events.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes)
+              scheduleEvents.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes)
                   .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference), id: \.key
           ) { day, _ in
               Button(day) {
@@ -157,7 +172,7 @@ struct EventsView: View {
         inlineSearchBar
         EventScrollView(
           events:
-            viewModel.events
+            scheduleEvents
             .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes)
             .search(text: debouncedSearch, speakers: viewModel.speakers)
             .eventDayGroup(
@@ -331,7 +346,7 @@ struct EventsView: View {
         inlineSearchBar
         EventScrollView(
           events:
-            viewModel.events
+            scheduleEvents
             .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes)
             .search(text: debouncedSearch, speakers: viewModel.speakers).eventDayGroup(
                 showLocaltime: showLocaltime, conference: viewModel.conference
@@ -384,7 +399,7 @@ struct EventsView: View {
                   }
                   Divider()
               ForEach(
-                viewModel.events.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes)
+                scheduleEvents.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes)
                     .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference), id: \.key
               ) { day, _ in
                 Button(day) {

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -40,6 +40,10 @@ struct EventFilters: View {
             ScrollView {
                 if showBookmarks {
                     FilterRow(id: 1337, name: "Bookmarks", color: ThemeColors.blue)
+                    // Custom Events pseudo-tag (id 1338). Same AND-with-
+                    // tag-filters semantics as Bookmarks; when active,
+                    // scheduleEvents narrows to user-created rows only.
+                    FilterRow(id: 1338, name: "Custom Events", color: .purple)
                 }
 
                 ForEach(tagtypes.sorted { $0.sortOrder < $1.sortOrder }) { tagtype in

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -29,6 +29,10 @@ struct InfoView: View {
     /// routes. Presents _04View as a sheet so the QA path doesn't have
     /// to fight NavigationStack races during cold launch.
     @State private var debug404Visible: Bool = false
+    /// Inbound CustomEventDraft decoded from a `hackertracker://import/customEvent`
+    /// deep link. When non-nil, the form sheet below presents in
+    /// create-mode pre-filled with this draft.
+    @State private var pendingCustomEventDraft: CustomEventDraft? = nil
     @State private var sharedEvents:[Event] = []
     /// Combined-bookmarks-across-conferences store. Refreshed via .task(id:)
     /// whenever bookmarks or the conferences list changes.
@@ -323,6 +327,18 @@ struct InfoView: View {
                 .analyticsScreen(name: "InfoView")
                 .environment(sharedSchedule)
                 .onOpenURL(perform: { url in
+                    // Custom-event import: bypasses the conference router
+                    // entirely. Decoded draft drives the create-mode form.
+                    if url.host == CustomEventShare.importHost,
+                       url.path == CustomEventShare.importPath {
+                        if let draft = CustomEventShare.draft(from: url) {
+                            Log.app.info("deep link: custom event import \(draft.title, privacy: .public)")
+                            pendingCustomEventDraft = draft
+                        } else {
+                            Log.app.error("deep link: invalid customEvent payload \(url, privacy: .public)")
+                        }
+                        return
+                    }
                     if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
                         let queryItems = urlComponents.queryItems
                         //let path = urlComponents.path
@@ -422,6 +438,10 @@ struct InfoView: View {
             }
             .sheet(isPresented: $debug404Visible) {
                 _04View(message: "Debug 404 ghost")
+            }
+            .sheet(item: $pendingCustomEventDraft) { draft in
+                CustomEventFormView(existing: nil, draft: draft)
+                    .environment(\.managedObjectContext, viewContext)
             }
             .overlay {
                 if easterEggOverlayVisible {

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -52,6 +52,7 @@ struct SettingsView: View {
                             VStack(spacing: 0) { StartScreenPickerView() }
                             VStack(spacing: 0) { NotificationSettingsView() }
                             VStack(spacing: 0) { AISummarySettingsView() }
+                            VStack(spacing: 0) { ShowCustomEventsSettingsView() }
                             VStack(spacing: 0) { EasterEggSettingsView() }
                             Spacer(minLength: 0)
                         }
@@ -66,6 +67,7 @@ struct SettingsView: View {
                     ShowNewsSettingsView()
                     NotificationSettingsView()
                     AISummarySettingsView()
+                    ShowCustomEventsSettingsView()
                     EasterEggSettingsView()
                 }
             }
@@ -473,5 +475,24 @@ struct AISummarySettingsView: View {
             .padding(5)
             Divider()
         }
+    }
+}
+
+/// Settings row that lets the user hide custom events en masse.
+/// Hidden by EventsView.scheduleEvents — synthesizer skips when this
+/// is false. Defaults true: opting in to create custom events implies
+/// wanting them visible.
+struct ShowCustomEventsSettingsView: View {
+    @AppStorage("showCustomEvents") var showCustomEvents: Bool = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle("Custom Events on Schedule", isOn: $showCustomEvents)
+            Text("Hide your custom events from the conference schedule. They\u{2019}re still stored locally and synced to your other devices.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(5)
+        Divider()
     }
 }

--- a/hackertracker/Views/SpeakerDetailView.swift
+++ b/hackertracker/Views/SpeakerDetailView.swift
@@ -255,13 +255,15 @@ struct SpeakerEventView: View {
         // re-renders this view when the active timezone changes.
         let _ = dfu.tzGeneration
         HStack {
-            // Speaker event chip stripe: fall back to .purple when the
-            // event has no tagIds. Same defensive shape as the cell
-            // helpers above; protects custom events from crashing the
-            // speaker schedule when they share a tag with a speaker.
-            Rectangle().fill(
-                event.tagIds.first.map { getEventTagColorBackground(id: $0) } ?? .purple
-            )
+            // Speaker event chip stripe. Custom events win with their
+            // user-chosen color; otherwise fall through to the
+            // first-tag color, and finally .purple if nothing's set.
+            Rectangle().fill({
+                if let hex = event.customColorHex, let ui = UIColor(hex: hex) {
+                    return Color(uiColor: ui)
+                }
+                return event.tagIds.first.map { getEventTagColorBackground(id: $0) } ?? .purple
+            }())
                 .frame(width: 6)
             VStack(alignment: .leading, spacing: 3) {
                 Text(event.title)

--- a/hackertracker/Views/SpeakerDetailView.swift
+++ b/hackertracker/Views/SpeakerDetailView.swift
@@ -255,7 +255,13 @@ struct SpeakerEventView: View {
         // re-renders this view when the active timezone changes.
         let _ = dfu.tzGeneration
         HStack {
-            Rectangle().fill(getEventTagColorBackground(id: event.tagIds[0]))
+            // Speaker event chip stripe: fall back to .purple when the
+            // event has no tagIds. Same defensive shape as the cell
+            // helpers above; protects custom events from crashing the
+            // speaker schedule when they share a tag with a speaker.
+            Rectangle().fill(
+                event.tagIds.first.map { getEventTagColorBackground(id: $0) } ?? .purple
+            )
                 .frame(width: 6)
             VStack(alignment: .leading, spacing: 3) {
                 Text(event.title)
@@ -267,7 +273,8 @@ struct SpeakerEventView: View {
                     Text(l.name).font(.caption2)
                 }
                 // if let tagtype = viewModel.tagTypeByTagId[tagId], let tag = tagtype.tags.first(where: {$0.id == tagId})
-                if let tag = viewModel.tagsById[event.tagIds[0]] {
+                if let firstTagId = event.tagIds.first,
+                   let tag = viewModel.tagsById[firstTagId] {
                     VStack {
                         HStack {
                             Circle().foregroundColor(Color(UIColor(hex: tag.colorBackground ?? "#2c8f07") ?? .purple))

--- a/hackertracker/hackertracker.xcdatamodeld/hackertracker.xcdatamodel/contents
+++ b/hackertracker/hackertracker.xcdatamodeld/hackertracker.xcdatamodel/contents
@@ -8,6 +8,20 @@
         <attribute name="price" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variantId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
+    <entity name="CustomEvent" representedClassName="CustomEvent" syncable="YES" codeGenerationType="class">
+        <attribute name="beginTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="colorHex" optional="YES" attributeType="String"/>
+        <attribute name="conferenceCodes" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer" customClassName="NSArray"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="endTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="eventDescription" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="location" optional="YES" attributeType="String"/>
+        <attribute name="notes" optional="YES" attributeType="String"/>
+        <attribute name="notificationsEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
     <entity name="Feedbacks" representedClassName="Feedbacks" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>


### PR DESCRIPTION
## Summary

End-to-end feature for user-created events on the schedule. Stored in Core Data via the existing NSPersistentCloudKitContainer (so iCloud sync rides for free), synthesized into the schedule pipeline alongside Firestore events, fully editable, sharable via QR code, and toggleable for visibility / notifications.

## Phases

| Commit | Phase | Contents |
|---|---|---|
| [6f3d07c](https://github.com/junctor/hackertracker-ios/commit/6f3d07c) | 1 | Core Data `CustomEvent` entity + `CustomEventUtility` (CRUD, conference filter, deterministic notification id) |
| [ac5c32f](https://github.com/junctor/hackertracker-ios/commit/ac5c32f) | 2 | `Event.customEventID` discriminator + `Event.from(custom:conferenceCode:)` factory + `scheduleEvents` synthesizer in EventsView |
| [15e5ceb](https://github.com/junctor/hackertracker-ios/commit/15e5ceb) | 3 | `CustomEventFormView` + `CustomEventDetailView` + `+` toolbar entry + row tap branching |
| [5b66766](https://github.com/junctor/hackertracker-ios/commit/5b66766) | 3 fix | Crash on empty `tagIds[0]` — guard with `.first` across EventCellView / ContentCellView / SpeakerDetailView |
| [06d9d4a](https://github.com/junctor/hackertracker-ios/commit/06d9d4a) | 3 polish | Thread `customColorHex` from CustomEvent → Event → row stripe |
| [a3947c4](https://github.com/junctor/hackertracker-ios/commit/a3947c4) | 4 | Filter chip (id 1338), notification scheduling, "Show Custom Events on Schedule" toggle |
| [12ac6e8](https://github.com/junctor/hackertracker-ios/commit/12ac6e8) | polish | Detail view matched to EventDetailView's layout; "Custom Event" chip in `ShowEventCellTags` |
| [59683dc](https://github.com/junctor/hackertracker-ios/commit/59683dc) | share | QR-code share + scan-to-import round trip via `hackertracker://import/customEvent` deep link |
| [fcbb0a6](https://github.com/junctor/hackertracker-ios/commit/fcbb0a6) | polish | Bookmark + one-tap notifications toolbar on detail view |

## Highlights

- **Data layer**: `CustomEvent` entity is CloudKit-syncable (all optional / default-valued). `CustomEventUtility` mirrors `BookmarkUtility`'s API surface with `create / touchAndSave / delete / all / forConference`. Notification id derived from the UUID via a high-bit Int range so it can never collide with Firestore event ids.
- **Pipeline**: `Event.customEventID: UUID?` is a non-CodingKey discriminator. The synthesizer in `EventsView.scheduleEvents` folds CustomEvents into the existing `.filters().search().eventDayGroup()` chain. Non-Schedule readers (`InfoView`, `SpeakerDetailView`, `OrgView`, `ShareBookmarksView`) keep using `viewModel.events` untouched.
- **Filters**: New chip "Custom Events" (id 1338) composes with the Bookmarks chip and tag filters via a rewritten `[Event].filters` predicate.
- **UI**: Detail view visually mirrors `EventDetailView` (large title + frosted gray card + Markdown body). `ShowEventCellTags` accepts `customEvent: Bool` + `customColorHex: String?` to render a "Custom Event" chip alongside any real tag chips. Toolbar carries bookmark, notifications, QR share, and edit actions.
- **Notifications**: One-tap toggle from the detail screen routes through `CustomEventUtility.touchAndSave`, which schedules / cancels via the existing `NotificationUtility` automatically.
- **Sharing**: QR code encodes the event as `hackertracker://import/customEvent?t=…&b=…&e=…` with short keys to keep QR density low. iOS Camera scan → InfoView deep-link router → `CustomEventFormView` pre-filled via `CustomEventDraft`. Notes are deliberately excluded from share — private journal field.
- **Settings**: New "Custom Events on Schedule" toggle (defaults on) lets users hide their custom events en masse from the schedule without deleting them.

## Build matrix

- ✅ iPhone 16 (iOS 18.2) — Debug.
- ✅ Zero new warnings.
- ✅ All call sites of `event.tagIds[0]` guarded against empty arrays (was crashing on custom events).

## Test plan

- [ ] Tap `+` on Schedule → fill title + times → Save → row appears on the right day.
- [ ] Stripe color matches what you picked in the ColorPicker.
- [ ] "Custom Event" chip appears on the row tag list.
- [ ] Detail view layout matches EventDetailView: centered title, gray card with time + location + tags grid.
- [ ] Bookmark toolbar toggles state; Bookmarks (1337) filter chip surfaces the custom event when on.
- [ ] Notifications toolbar bell toggles between bell.slash and bell.fill; flipping on with `notifyAt = 20` schedules a UNNotification at `begin - 20min`.
- [ ] QR share: tap qrcode → sheet shows the QR + URL preview + ShareLink. Scan on a second device → form opens pre-filled. Save → row appears on the receiver's schedule.
- [ ] Settings → "Custom Events on Schedule" off → custom events disappear from the schedule (data preserved).
- [ ] Filter sheet shows "Custom Events" chip next to Bookmarks. Selecting it narrows to custom rows only.
- [ ] Delete from detail view: confirmation dialog → row gone + bookmark cleared + scheduled notification cancelled.
- [ ] Edit from detail view: pencil opens form pre-filled with current values; Save updates the row + reschedules notification.
- [ ] iCloud sync: edit on Device A → appears on Device B within ~30s. Delete on A → vanishes on B.
- [ ] Multi-conference: attach to two conferences → row appears in both schedules.

🧙 Built with [WOZCODE](https://wozcode.com)