### PR TITLE
Filters: native chrome + Any/All match + live tally

### DIFF
--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -911,7 +911,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26061401;
+				CURRENT_PROJECT_VERSION = 26061501;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;
@@ -950,7 +950,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26061401;
+				CURRENT_PROJECT_VERSION = 26061501;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;

--- a/hackertracker/Utils/ModelExt.swift
+++ b/hackertracker/Utils/ModelExt.swift
@@ -79,6 +79,22 @@ enum PseudoTagID {
     static let bookmarks: Int = 1337
     static let customEvents: Int = 1338
     static let hasNotes: Int = 1339
+    /// Convenience set so callers can `filters.subtracting(PseudoTagID.all)`
+    /// to recover the real-tag ids.
+    static let all: Set<Int> = [bookmarks, customEvents, hasNotes]
+}
+
+/// Filter-chip composition mode. Read from @AppStorage("filterMatchMode")
+/// by FiltersView (writes) and the predicate consumers (reads). Storing
+/// the raw string lets us swap it cleanly via @AppStorage on multiple
+/// independent views without an envelope object.
+enum FilterMatchMode: String, CaseIterable {
+    case any = "any"
+    case all = "all"
+    static let defaultRaw: String = FilterMatchMode.any.rawValue
+    init(rawOrDefault raw: String) {
+        self = FilterMatchMode(rawValue: raw) ?? .any
+    }
 }
 
 extension [Event] {
@@ -93,7 +109,8 @@ extension [Event] {
         bookmarks: Set<Int32>,
         tagTypes: [TagType],
         eventNoteIDs: Set<Int32> = [],
-        contentNoteIDs: Set<Int32> = []
+        contentNoteIDs: Set<Int32> = [],
+        mode: FilterMatchMode = .any
     ) -> Self {
         if typeIds.isEmpty {
             return self
@@ -108,26 +125,37 @@ extension [Event] {
                     }
                 }
             }
-            // Pseudo-tag OR-composition. A row survives when ANY
-            // selected chip matches it — "Has Notes" + "Custom
-            // Events" returns the union, not the (usually-empty)
-            // intersection. Real-tag chips use a plain set
-            // intersection rather than the per-tag-type AND in
-            // isFiltered(), because OR semantics don't require
-            // hitting EVERY tag type — just any selected tag id.
+            // Each chip category contributes independently. In .any
+            // mode (OR) a row survives when ANY active category
+            // matches it. In .all mode (AND) a row must satisfy
+            // EVERY active category. "Active" = at least one chip
+            // from that category is selected; categories with no
+            // selection don't constrain the result either way.
             let realTagIDs = Set(filterTypes.values.flatMap { $0 })
+            let useTags = !realTagIDs.isEmpty
+            let useBookmarks = typeIds.contains(PseudoTagID.bookmarks)
+            let useCustom = typeIds.contains(PseudoTagID.customEvents)
+            let useHasNotes = typeIds.contains(PseudoTagID.hasNotes)
             return filter { event in
-                let tagMatch = !realTagIDs.isEmpty
-                    && event.tagIds.contains(where: { realTagIDs.contains($0) })
-                let bookmarkMatch = typeIds.contains(PseudoTagID.bookmarks)
-                    && bookmarks.contains(Int32(event.id))
-                let customMatch = typeIds.contains(PseudoTagID.customEvents)
-                    && event.customEventID != nil
-                let hasNotesMatch = typeIds.contains(PseudoTagID.hasNotes) && (
-                    eventNoteIDs.contains(Int32(event.id))
-                    || contentNoteIDs.contains(Int32(event.contentId))
-                )
-                return tagMatch || bookmarkMatch || customMatch || hasNotesMatch
+                let tagMatch: Bool? = useTags
+                    ? event.tagIds.contains(where: { realTagIDs.contains($0) })
+                    : nil
+                let bookmarkMatch: Bool? = useBookmarks
+                    ? bookmarks.contains(Int32(event.id))
+                    : nil
+                let customMatch: Bool? = useCustom
+                    ? (event.customEventID != nil)
+                    : nil
+                let hasNotesMatch: Bool? = useHasNotes
+                    ? (eventNoteIDs.contains(Int32(event.id))
+                       || contentNoteIDs.contains(Int32(event.contentId)))
+                    : nil
+                let checks = [tagMatch, bookmarkMatch, customMatch, hasNotesMatch].compactMap { $0 }
+                guard !checks.isEmpty else { return true }
+                switch mode {
+                case .any: return checks.contains(true)
+                case .all: return checks.allSatisfy { $0 }
+                }
             }
         }
     }

--- a/hackertracker/Utils/ModelExt.swift
+++ b/hackertracker/Utils/ModelExt.swift
@@ -108,25 +108,26 @@ extension [Event] {
                     }
                 }
             }
-            // Pseudo-tag AND-composition. Each chip narrows the
-            // surviving set further. eventNoteIDs is precomputed by
-            // the caller (EventsView fetches Note rows once per
-            // render and passes the set in here) so we don't touch
-            // Core Data inside the predicate body.
+            // Pseudo-tag OR-composition. A row survives when ANY
+            // selected chip matches it — "Has Notes" + "Custom
+            // Events" returns the union, not the (usually-empty)
+            // intersection. Real-tag chips use a plain set
+            // intersection rather than the per-tag-type AND in
+            // isFiltered(), because OR semantics don't require
+            // hitting EVERY tag type — just any selected tag id.
+            let realTagIDs = Set(filterTypes.values.flatMap { $0 })
             return filter { event in
-                guard isFiltered(tagIds: event.tagIds, filterTypes: filterTypes) else { return false }
-                if typeIds.contains(PseudoTagID.bookmarks) && !bookmarks.contains(Int32(event.id)) { return false }
-                if typeIds.contains(PseudoTagID.customEvents) && event.customEventID == nil { return false }
-                if typeIds.contains(PseudoTagID.hasNotes) {
-                    // Match either the event's own id or its parent
-                    // content id — same cross-kind logic the pencil
-                    // badge uses so the filter never disagrees with
-                    // what the cell visibly shows.
-                    let directHit = eventNoteIDs.contains(Int32(event.id))
-                    let parentHit = contentNoteIDs.contains(Int32(event.contentId))
-                    if !(directHit || parentHit) { return false }
-                }
-                return true
+                let tagMatch = !realTagIDs.isEmpty
+                    && event.tagIds.contains(where: { realTagIDs.contains($0) })
+                let bookmarkMatch = typeIds.contains(PseudoTagID.bookmarks)
+                    && bookmarks.contains(Int32(event.id))
+                let customMatch = typeIds.contains(PseudoTagID.customEvents)
+                    && event.customEventID != nil
+                let hasNotesMatch = typeIds.contains(PseudoTagID.hasNotes) && (
+                    eventNoteIDs.contains(Int32(event.id))
+                    || contentNoteIDs.contains(Int32(event.contentId))
+                )
+                return tagMatch || bookmarkMatch || customMatch || hasNotesMatch
             }
         }
     }

--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -15,6 +15,12 @@ struct ContentListView: View {
     /// Perf C: debounced mirror of `searchText`. contentGroup() reads
     /// this so the group/filter pipeline runs once per typing pause.
     @State private var debouncedSearch = ""
+    /// Filter-chip composition mode. Mirrors EventsView so both
+    /// lists honor the same user choice from the Filters sheet.
+    @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    private var filterMatchMode: FilterMatchMode {
+        FilterMatchMode(rawOrDefault: filterMatchModeRaw)
+    }
     @State private var showFilters = false
     @Environment(InfoViewModel.self) private var viewModel
     @EnvironmentObject var filters: Filters
@@ -77,19 +83,33 @@ struct ContentListView: View {
         // with each other (matches any one keeps the row). Real tags
         // hit via tagIds.intersects; pseudo-tags 1337 (Bookmarks),
         // 1339 (Has Notes) hit via their dedicated membership sets.
+        // Each category contributes a Bool? — non-nil only when at
+        // least one chip from that category is selected. Compose by
+        // mode: .any → OR (current default), .all → AND. Categories
+        // without a chip selection don't constrain the result.
+        let realTagIDs = filters.filters.subtracting(PseudoTagID.all)
+        let useTags = !realTagIDs.isEmpty
+        let useBookmarks = filters.filters.contains(PseudoTagID.bookmarks)
+        let useHasNotes = filters.filters.contains(PseudoTagID.hasNotes)
+        let mode = filterMatchMode
         return Dictionary(
             grouping: content.search(text: debouncedSearch).filter { c in
                 if filters.filters.isEmpty { return true }
-                if c.tagIds.intersects(with: filters.filters) { return true }
-                if filters.filters.contains(PseudoTagID.bookmarks),
-                   c.sessions.contains(where: { bookmarkIds.contains(Int32($0.id)) }) {
-                    return true
+                let tagMatch: Bool? = useTags
+                    ? c.tagIds.contains(where: { realTagIDs.contains($0) })
+                    : nil
+                let bookmarkMatch: Bool? = useBookmarks
+                    ? c.sessions.contains(where: { bookmarkIds.contains(Int32($0.id)) })
+                    : nil
+                let hasNotesMatch: Bool? = useHasNotes
+                    ? noteContentIDsForScope.contains(Int32(c.id))
+                    : nil
+                let checks = [tagMatch, bookmarkMatch, hasNotesMatch].compactMap { $0 }
+                guard !checks.isEmpty else { return true }
+                switch mode {
+                case .any: return checks.contains(true)
+                case .all: return checks.allSatisfy { $0 }
                 }
-                if filters.filters.contains(PseudoTagID.hasNotes),
-                   noteContentIDsForScope.contains(Int32(c.id)) {
-                    return true
-                }
-                return false
             },
             by: { $0.title.lowercased().first ?? "-" }
         )

--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -77,6 +77,12 @@ struct ContentListView: View {
     /// iPad-only: identifies the content currently shown in the detail column.
     @State private var ipadSelectedContentId: Int?
 
+    /// Number of Content rows surviving the current filter +
+    /// search pipeline. Same shape as scheduleFilteredCount.
+    private var contentFilteredCount: Int {
+        contentGroup().values.reduce(0) { $0 + $1.count }
+    }
+
     func contentGroup() -> [String.Element: [Content]] {
         let bookmarkIds = Set(bookmarks.map(\.id))
         // Predicate composes search text + filter chips. The chips OR
@@ -266,7 +272,10 @@ struct ContentListView: View {
               EventFilters(
                 tagtypes: viewModel.tagtypes.filter {
                   $0.category == "content" && $0.isBrowsable == true
-                }, showFilters: $showFilters
+                },
+                showFilters: $showFilters,
+                matchedCount: contentFilteredCount,
+                unitLabel: "talk"
               )
             }
         }

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -84,6 +84,12 @@ struct EventsView: View {
     /// the schedule at all. Lives next to the rest of the schedule
     /// state so its value is read inline with the synthesizer.
     @AppStorage("showCustomEvents") private var showCustomEventsInSchedule: Bool = true
+    /// Filter-chip composition mode. Read from the same
+    /// AppStorage key the Filters sheet writes to.
+    @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    private var filterMatchMode: FilterMatchMode {
+        FilterMatchMode(rawOrDefault: filterMatchModeRaw)
+    }
 
     /// Firestore events + synthesized CustomEvents that target the
     /// currently-selected conference. Three Schedule call sites read
@@ -161,7 +167,7 @@ struct EventsView: View {
           // Dates first (ascending; eventDayGroup already sorts that way),
           // then Top / Now / Next / Bottom.
           ForEach(
-              scheduleEvents.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope)
+              scheduleEvents.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
                   .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference), id: \.key
           ) { day, _ in
               Button(day) {
@@ -235,7 +241,7 @@ struct EventsView: View {
         EventScrollView(
           events:
             scheduleEvents
-            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope)
+            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
             .search(text: debouncedSearch, speakers: viewModel.speakers)
             .eventDayGroup(
               showLocaltime: showLocaltime, conference: viewModel.conference
@@ -441,7 +447,7 @@ struct EventsView: View {
         EventScrollView(
           events:
             scheduleEvents
-            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope)
+            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
             .search(text: debouncedSearch, speakers: viewModel.speakers).eventDayGroup(
                 showLocaltime: showLocaltime, conference: viewModel.conference
             ),
@@ -493,7 +499,7 @@ struct EventsView: View {
                   }
                   Divider()
               ForEach(
-                scheduleEvents.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope)
+                scheduleEvents.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
                     .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference), id: \.key
               ) { day, _ in
                 Button(day) {

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -95,6 +95,16 @@ struct EventsView: View {
     /// currently-selected conference. Three Schedule call sites read
     /// this in place of viewModel.events so user-created rows flow
     /// through filters / search / eventDayGroup naturally.
+    /// Live count of events that survive the current filter +
+    /// search selection. Driven into both the Filters sheet's
+    /// tally label and any future toolbar-resident counter.
+    private var scheduleFilteredCount: Int {
+        scheduleEvents
+            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
+            .search(text: debouncedSearch, speakers: viewModel.speakers)
+            .count
+    }
+
     private var scheduleEvents: [Event] {
         guard showCustomEventsInSchedule else { return viewModel.events }
         let code = selected.code
@@ -405,7 +415,10 @@ struct EventsView: View {
         EventFilters(
           tagtypes: viewModel.tagtypes.filter {
             $0.category == "content" && $0.isBrowsable == true
-          }, showFilters: $showFilters
+          },
+          showFilters: $showFilters,
+          matchedCount: scheduleFilteredCount,
+          unitLabel: "event"
         )
       }
       .alert("Schedule Conflicts", isPresented: $showConflictAlertPopup) {
@@ -424,7 +437,10 @@ struct EventsView: View {
         EventFilters(
           tagtypes: viewModel.tagtypes.filter {
             $0.category == "content" && $0.isBrowsable == true
-          }, showFilters: $showFilters
+          },
+          showFilters: $showFilters,
+          matchedCount: scheduleFilteredCount,
+          unitLabel: "event"
         )
       }
       .alert("Schedule Conflicts", isPresented: $showConflictAlertPopup) {
@@ -581,7 +597,10 @@ struct EventScrollView: View {
              EventFilters(
                tagtypes: viewModel.tagtypes.filter {
                  $0.category == "content" && $0.isBrowsable == true
-               }, showFilters: $showFilters
+               },
+               showFilters: $showFilters,
+               matchedCount: scheduleFilteredCount,
+               unitLabel: "event"
              )
            }
        }

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -26,7 +26,7 @@ struct EventFilters: View {
         // app's other modal forms.
         NavigationStack {
             ScrollView {
-                matchModePicker
+                MatchModePickerRow(raw: $filterMatchModeRaw)
                 if showBookmarks {
                     FilterRow(id: PseudoTagID.bookmarks, name: "Bookmarks", color: ThemeColors.blue)
                     FilterRow(id: PseudoTagID.customEvents, name: "Custom Events", color: .purple)
@@ -83,7 +83,10 @@ struct EventFilters: View {
 /// filter list so users read the mode in the same place they see the
 /// chips they're modifying. Persists via @AppStorage so heavy filter
 /// users configure once and forget.
-private struct MatchModePicker: View {
+/// Shared `Match  [ Any | All ]` segmented control. Used by both
+/// FiltersView (Schedule / All Content) and MerchSizeFilter so the
+/// chrome stays identical across all filter sheets.
+struct MatchModePickerRow: View {
     @Binding var raw: String
     var body: some View {
         HStack(spacing: 8) {
@@ -99,12 +102,6 @@ private struct MatchModePicker: View {
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 6)
-    }
-}
-
-extension EventFilters {
-    fileprivate var matchModePicker: some View {
-        MatchModePicker(raw: $filterMatchModeRaw)
     }
 }
 

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -13,60 +13,68 @@ struct EventFilters: View {
     @EnvironmentObject var filters: Filters
     @EnvironmentObject var toTop: ToTop
     var showBookmarks: Bool = true
-    
+
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
 
     var body: some View {
-        HStack(alignment: .center) {
-            Button {
-                filters.filters.removeAll()
-            } label: {
-                Image(systemName: "x.circle")
-                Text("Clear")
-            }
-            Spacer()
-            Text("Filters")
-            Spacer()
-            Button {
-                showFilters = false
-                toTop.val = true
-            } label: {
-                Text("Close")
-                Image(systemName: "checkmark.circle")
-            }
-        }
-        .padding(10)
-            Divider()
+        // Wrap in a NavigationStack so the sheet picks up the system's
+        // rounded top corners + native toolbar treatment. The previous
+        // custom HStack header sat flush against the sheet's sharp edge
+        // and the Clear/Close buttons rendered as raw blue Text +
+        // SF Symbol glyphs that didn't match Cancel/Save/Done in the
+        // app's other modal forms.
+        NavigationStack {
             ScrollView {
                 if showBookmarks {
-                    FilterRow(id: 1337, name: "Bookmarks", color: ThemeColors.blue)
-                    FilterRow(id: 1338, name: "Custom Events", color: .purple)
-                    // Has Notes pseudo-tag (id 1339). When active,
-                    // scheduleEvents narrows to rows with a saved
-                    // private note attached. Composes with the other
-                    // pseudo-tags + real tags via AND.
-                    FilterRow(id: 1339, name: "Has Notes", color: .orange)
+                    FilterRow(id: PseudoTagID.bookmarks, name: "Bookmarks", color: ThemeColors.blue)
+                    FilterRow(id: PseudoTagID.customEvents, name: "Custom Events", color: .purple)
+                    FilterRow(id: PseudoTagID.hasNotes, name: "Has Notes", color: .orange)
                 }
 
                 ForEach(tagtypes.sorted { $0.sortOrder < $1.sortOrder }) { tagtype in
-                    Section(header: Text(tagtype.label)) {
+                    Section { 
                         LazyVGrid(columns: gridItemLayout, alignment: .center, spacing: 10) {
                             ForEach(tagtype.tags.sorted { $0.sortOrder < $1.sortOrder }) { tag in
-                                FilterRow(id: tag.id, name: tag.label, color: Color(UIColor(hex: tag.colorBackground ?? "#2c8f07") ?? .purple))
+                                FilterRow(
+                                    id: tag.id,
+                                    name: tag.label,
+                                    color: Color(UIColor(hex: tag.colorBackground ?? "#2c8f07") ?? .purple)
+                                )
                             }
                         }
+                    } header: {
+                        Text(tagtype.label)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                }.headerProminence(.increased)
+                }
+                .headerProminence(.increased)
             }
-            .listStyle(.plain)
+            .padding(.horizontal, 10)
             .navigationTitle("Filters")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarLeading) {
+                    // Plain text button matching the Cancel/Save/Done pattern
+                    // used by NoteEditorView, CustomEventFormView, etc.
+                    // Disabled when there's nothing to clear so the user
+                    // doesn't tap a no-op.
+                    Button("Clear") {
+                        filters.filters.removeAll()
+                    }
+                    .disabled(filters.filters.isEmpty)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        showFilters = false
+                        toTop.val = true
+                    }
+                    .bold()
                 }
             }
-            .padding(5)
         }
-    //}
+    }
 }
 
 struct FilterRow: View {
@@ -76,7 +84,6 @@ struct FilterRow: View {
     @EnvironmentObject var filters: Filters
 
     var body: some View {
-        
         Button(action: {
             if filters.filters.contains(id) {
                 filters.filters.remove(id)
@@ -97,8 +104,10 @@ struct FilterRow: View {
             .padding(5)
             .background(filters.filters.contains(id) ? color : Color.clear)
             .cornerRadius(10)
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(filters.filters.contains(id) ? Color.clear : color, lineWidth: 2))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(filters.filters.contains(id) ? Color.clear : color, lineWidth: 2)
+            )
         }
-
     }
 }

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -160,11 +160,11 @@ struct FilterMatchCountLabel: View {
         HStack(spacing: 4) {
             Image(systemName: "line.3.horizontal.decrease.circle")
                 .font(.caption)
-            Text("\(count) \(plural) match")
+            Text("\(count) \(plural)")
                 .font(.caption)
         }
         .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .center)
         .padding(.horizontal, 4)
         .padding(.vertical, 2)
     }

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -13,6 +13,14 @@ struct EventFilters: View {
     @EnvironmentObject var filters: Filters
     @EnvironmentObject var toTop: ToTop
     var showBookmarks: Bool = true
+    /// Number of items that would survive the current filter selection.
+    /// Caller computes (uses the same .filters / .search pipeline the
+    /// list view will render with) and passes it in — keeps the sheet
+    /// agnostic about how counts are derived.
+    var matchedCount: Int = 0
+    /// Singular noun used in the live tally label ("event", "talk",
+    /// etc.). Plural is auto-derived with a trailing s.
+    var unitLabel: String = "event"
     @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
 
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
@@ -27,6 +35,7 @@ struct EventFilters: View {
         NavigationStack {
             ScrollView {
                 MatchModePickerRow(raw: $filterMatchModeRaw)
+                FilterMatchCountLabel(count: matchedCount, unit: unitLabel)
                 if showBookmarks {
                     FilterRow(id: PseudoTagID.bookmarks, name: "Bookmarks", color: ThemeColors.blue)
                     FilterRow(id: PseudoTagID.customEvents, name: "Custom Events", color: .purple)
@@ -137,5 +146,26 @@ struct FilterRow: View {
                     .stroke(filters.filters.contains(id) ? Color.clear : color, lineWidth: 2)
             )
         }
+    }
+}
+
+/// Small live tally label below the Match picker. Pluralizes the
+/// supplied noun with a trailing s and renders muted so it doesn't
+/// compete with the chips.
+struct FilterMatchCountLabel: View {
+    let count: Int
+    let unit: String
+    var body: some View {
+        let plural = count == 1 ? unit : unit + "s"
+        HStack(spacing: 4) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.caption)
+            Text("\(count) \(plural) match")
+                .font(.caption)
+        }
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
     }
 }

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -13,6 +13,7 @@ struct EventFilters: View {
     @EnvironmentObject var filters: Filters
     @EnvironmentObject var toTop: ToTop
     var showBookmarks: Bool = true
+    @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
 
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
 
@@ -25,6 +26,7 @@ struct EventFilters: View {
         // app's other modal forms.
         NavigationStack {
             ScrollView {
+                matchModePicker
                 if showBookmarks {
                     FilterRow(id: PseudoTagID.bookmarks, name: "Bookmarks", color: ThemeColors.blue)
                     FilterRow(id: PseudoTagID.customEvents, name: "Custom Events", color: .purple)
@@ -74,6 +76,35 @@ struct EventFilters: View {
                 }
             }
         }
+    }
+}
+
+/// `Match  [ Any | All ]` segmented control. Sits at the top of the
+/// filter list so users read the mode in the same place they see the
+/// chips they're modifying. Persists via @AppStorage so heavy filter
+/// users configure once and forget.
+private struct MatchModePicker: View {
+    @Binding var raw: String
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("Match")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Picker("Match", selection: $raw) {
+                Text("Any").tag(FilterMatchMode.any.rawValue)
+                Text("All").tag(FilterMatchMode.all.rawValue)
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 200)
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 6)
+    }
+}
+
+extension EventFilters {
+    fileprivate var matchModePicker: some View {
+        MatchModePicker(raw: $filterMatchModeRaw)
     }
 }
 

--- a/hackertracker/Views/ProductsView.swift
+++ b/hackertracker/Views/ProductsView.swift
@@ -261,7 +261,8 @@ struct ProductsView: View {
             MerchSizeFilter(
                 sizes: availableSizes,
                 selected: $selectedSizes,
-                showFilters: $showFilters
+                showFilters: $showFilters,
+                matchedCount: visibleProducts.count
             )
         }
         .task(id: searchText) {
@@ -392,6 +393,10 @@ struct MerchSizeFilter: View {
     let sizes: [String]
     @Binding var selected: Set<String>
     @Binding var showFilters: Bool
+    /// Number of products that would survive the current selection.
+    /// Same shape as FiltersView.matchedCount; caller computes from
+    /// the already-filtered list to keep the sheet stateless.
+    var matchedCount: Int = 0
 
     @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]
@@ -403,6 +408,7 @@ struct MerchSizeFilter: View {
         NavigationStack {
             ScrollView {
                 MatchModePickerRow(raw: $filterMatchModeRaw)
+                FilterMatchCountLabel(count: matchedCount, unit: "product")
 
                 LazyVGrid(columns: columns, alignment: .center, spacing: 10) {
                     ForEach(sizes, id: \.self) { size in

--- a/hackertracker/Views/ProductsView.swift
+++ b/hackertracker/Views/ProductsView.swift
@@ -21,6 +21,10 @@ struct ProductsView: View {
     /// label (e.g. "XS"); kept here rather than in the shared Filters
     /// env object so it does not collide with the Schedule tag filters.
     @State private var selectedSizes: Set<String> = []
+    @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    private var filterMatchMode: FilterMatchMode {
+        FilterMatchMode(rawOrDefault: filterMatchModeRaw)
+    }
     @EnvironmentObject var filters: Filters
 
     // Polish parity with schedule / All Content.
@@ -73,8 +77,21 @@ struct ProductsView: View {
                 // do not satisfy the filter so the grid only shows items
                 // the user could actually buy in that size.
                 guard !selectedSizes.isEmpty else { return true }
-                return product.variants.contains { variant in
-                    selectedSizes.contains(variant.title) && variant.stockStatus == "IN"
+                // In-stock variant titles available for this product.
+                let inStockTitles = Set(
+                    product.variants
+                        .filter { $0.stockStatus == "IN" }
+                        .map { $0.title }
+                )
+                switch filterMatchMode {
+                case .any:
+                    // Any of the selected sizes is available.
+                    return !inStockTitles.isDisjoint(with: selectedSizes)
+                case .all:
+                    // Every selected size is available — for users
+                    // who need a specific bundle of sizes (e.g. both
+                    // M and L for two recipients).
+                    return selectedSizes.isSubset(of: inStockTitles)
                 }
             }
     }
@@ -376,30 +393,17 @@ struct MerchSizeFilter: View {
     @Binding var selected: Set<String>
     @Binding var showFilters: Bool
 
+    @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Button {
-                    selected.removeAll()
-                } label: {
-                    Image(systemName: "x.circle")
-                    Text("Clear")
-                }
-                Spacer()
-                Text("Filter by Size").font(.headline)
-                Spacer()
-                Button {
-                    showFilters = false
-                } label: {
-                    Text("Close")
-                    Image(systemName: "checkmark.circle")
-                }
-            }
-            .padding(10)
-            Divider()
+        // Matches the Schedule's FiltersView: NavigationStack-wrapped
+        // for rounded sheet corners + native toolbar buttons; Match
+        // Any/All segmented picker at the top.
+        NavigationStack {
             ScrollView {
+                MatchModePickerRow(raw: $filterMatchModeRaw)
+
                 LazyVGrid(columns: columns, alignment: .center, spacing: 10) {
                     ForEach(sizes, id: \.self) { size in
                         let isOn = selected.contains(size)
@@ -421,6 +425,22 @@ struct MerchSizeFilter: View {
                     }
                 }
                 .padding(10)
+            }
+            .navigationTitle("Filter by Size")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Clear") {
+                        selected.removeAll()
+                    }
+                    .disabled(selected.isEmpty)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { showFilters = false }
+                        .bold()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Filter-sheet polish + UX overhaul covering Schedule (`FiltersView`) and Merch (`MerchSizeFilter`). The two sheets now share chrome, semantics, and live feedback.

> Stacked on top of [#33](https://github.com/junctor/hackertracker-ios/pull/33).

## Highlights

**Native modal chrome**
- Both filter sheets wrap in `NavigationStack` so the sheet picks up rounded top corners + frosted `.ultraThinMaterial` nav bar.
- Clear becomes a plain `Button("Clear")` on `.topBarLeading`, disabled when nothing is selected.
- Close becomes `Button("Done")` on `.confirmationAction`, bolded as the primary CTA. Matches the verb used by `NoteEditorView`, `CustomEventFormView`, `ContentDescriptionPeekSheet`, `CustomEventShareSheet`.
- Section headers tightened to use the modern `Section { } header: { }` closure form with leading-aligned `Text`.

**Match Any / All**
- `[Event].filters` predicate rewritten from category-AND to category-OR (the previous default), then upgraded to user-selectable via a new `FilterMatchMode` enum + `@AppStorage("filterMatchMode")`. Tapping Has Notes + Custom Events now returns the union by default.
- `MatchModePickerRow` segmented control at the top of the filter list, persisted across launches.
- Same mode applies to Merch (`visibleProducts.filter`) — `.any` matches the existing "at least one selected size in stock", `.all` requires every selected size in stock (useful for buying a specific bundle).
- `PseudoTagID` enum gains an `.all` set so the content-list predicate can subtract pseudo-tag ids out of the user's selection cleanly.

**Live tally label**
- New shared `FilterMatchCountLabel` view renders a muted `12 events` / `47 talks` / `3 products` row directly under the Match picker.
- Counts come from each caller's existing filtered list (`scheduleFilteredCount`, `contentFilteredCount`, `visibleProducts.count`), so the tally honors search text, Match mode, and every chip selection — exactly what the list will show after the user taps Done.

## Files changed
- `Utils/ModelExt.swift` — `FilterMatchMode`, `PseudoTagID.all`, `[Event].filters` predicate rewrite
- `Views/FiltersView.swift` — `NavigationStack` chrome, toolbar buttons, `MatchModePickerRow`, `FilterMatchCountLabel`
- `Views/ProductsView.swift` — `MerchSizeFilter` re-styled to match; `.any`/`.all` applied to `visibleProducts`
- `Views/EventsView.swift` — `scheduleFilteredCount`; `EventFilters(...)` call sites pass `matchedCount` + `unitLabel: "event"`
- `Views/ContentListView.swift` — `contentFilteredCount`; call site passes `unitLabel: "talk"`

## Test plan
- [ ] Open Filters from Schedule → native rounded corners + frosted nav bar + Clear/Done buttons.
- [ ] Toggle Has Notes + Custom Events with Match=Any → schedule shows union. Switch to All → shows intersection.
- [ ] Tally below picker updates live as chips toggle.
- [ ] Tally reads "1 event" / "12 events" pluralization correctly.
- [ ] Same picker + tally appears on the Merch filter sheet ("47 products").
- [ ] App relaunch preserves Match=All if it was last set.

🧙 Built with [WOZCODE](https://wozcode.com)