### PR TITLE
docs: stand up user guide under /docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,77 @@
+# HackerTracker iOS — User Guide
+
+The official guide to using HackerTracker on iPhone and iPad. Covers everyday use, every feature, the iPad-specific layout, and how your data is handled.
+
+If you're looking for the **5-minute version**, start with [Quick Start](quickstart.md).
+
+---
+
+## Contents
+
+### Getting around
+- [Quick Start](quickstart.md) — install, pick a conference, see your first schedule
+- [Tabs and navigation](navigation.md) — the four tabs and what each one does
+- [Schedule view](schedule.md) — the main agenda
+- [iPad-specific layout](ipad.md) — split view, two-column Settings, two-up Maps
+
+### Personal data
+- [Bookmarking events](bookmarks.md) — saving talks you want to attend
+- [Combined Bookmark Schedule](combined-schedule.md) — cross-conference timeline of just your saved events
+- [Private notes](notes.md) — Markdown notes on any event or talk
+- [Custom events](custom-events.md) — your own schedule entries, multi-conference, sharable via QR
+
+### Discovery
+- [Search and filter](search-and-filter.md) — finding talks, tags, the Any/All match toggle
+- [AI summaries](ai-summaries.md) — on-device summaries on iOS 26+
+- [Maps](maps.md) — venue floor plans, search, share
+
+### Other
+- [Privacy and tracking](privacy.md) — what we collect, what we don't
+- [Easter eggs](easter-eggs.md) — there is one. See if you can find it.
+- [Troubleshooting](troubleshooting.md) — common problems and fixes
+
+### For developers
+- See [`CLAUDE.md`](../CLAUDE.md) at the repo root for build commands, architecture, and conventions.
+
+---
+
+## What's new in 6.0
+
+Highlights from this release. The full changelog is below; for the in-app version, **Settings → About**.
+
+**Major new features**
+- **Custom events** — create your own schedule entries, sync via iCloud, share by QR code.
+- **Private notes** on any event, talk, or custom event. Markdown-formatted, iCloud-synced.
+- **On-device AI summaries** of talk descriptions (iOS 26+ with Apple Intelligence).
+- **Combined Bookmark Schedule** — cross-conference timeline when bookmarks overlap.
+- **Searchable SVG maps** when the conference publishes them.
+
+**iPad overhaul**
+- Split view across Schedule, All Content, Speakers, Communities, Merch — same 500pt sidebar across all of them.
+- Two-column Settings.
+- Two-up landscape mode on Maps.
+
+**Filters**
+- Match Any / Match All segmented toggle on every filter sheet.
+- Live count of matching items shown under the picker.
+- New chips: Bookmarks, Custom Events, Has Notes.
+
+**Privacy**
+- No ATT prompt — we no longer link the IDFA-capable Firebase SDK.
+- Settings → Privacy & Tracking screen with full disclosure.
+
+**Performance**
+- O(1) speaker/location/tag lookups.
+- Schedule swipe and search debounced.
+- Map PDFs pre-warmed into a cache on conference load.
+
+---
+
+## Need help?
+
+- **Open an issue**: [github.com/junctor/hackertracker-ios/issues](https://github.com/junctor/hackertracker-ios/issues)
+- **Email**: hackertracker@defcon.org
+
+---
+
+*This guide tracks the app's actual behavior at the time of writing. Each page links to the source file when relevant so you can verify or contribute fixes. If something here doesn't match what you see in the app, [open an issue](https://github.com/junctor/hackertracker-ios/issues/new).*

--- a/docs/ai-summaries.md
+++ b/docs/ai-summaries.md
@@ -1,0 +1,64 @@
+# AI summaries
+
+One-sentence summaries of talk descriptions generated on-device by Apple Intelligence. Optional, gated behind a Settings toggle.
+
+## Requirements
+
+- **iOS 26 or later** (the FoundationModels framework first ships in iOS 26).
+- A device that supports **Apple Intelligence** (iPhone 15 Pro / Pro Max, iPhone 16 family, M-series iPad Pro / Air / mini, all later devices).
+- The user has Apple Intelligence enabled in iOS Settings → Apple Intelligence & Siri.
+
+On devices that don't meet the requirements, the Settings toggle is hidden entirely.
+
+## Turning it on
+
+**Settings → AI Summaries** → toggle on.
+
+The toggle has a footer explaining the feature:
+
+> Show one-sentence summaries of talk descriptions, generated on-device by Apple Intelligence. Summaries are cached and only generated for descriptions longer than 100 characters.
+
+## What you see
+
+When enabled, each talk row gets a new line below the speaker names:
+
+```
+✨  AI-generated one-sentence summary, lineLimit(2).
+```
+
+The summary appears in `.foregroundStyle(.secondary)` so it reads as ambient metadata rather than primary content.
+
+## Long-press peek
+
+Sometimes the summary skips a detail you care about. Long-press a row with a visible summary → opens a sheet showing the **original full description** with selectable text. Tap **Done** to dismiss.
+
+The peek sheet only triggers on long-press for rows that have a visible summary. Long-pressing other rows behaves normally (no-op for the navigation tap).
+
+## How it works
+
+Generation is triggered opportunistically when a row materializes in the LazyVStack — i.e., when you scroll close enough that the row is about to be visible.
+
+Each row's generation runs in a background `Task`, deduplicated per row id. The cache is a global `TalkSummaryCache` actor that:
+
+- Stores summaries in `UserDefaults` as JSON, keyed by content id with a SHA256 of the source description.
+- Returns cached summaries instantly on subsequent visits.
+- Re-generates when the source description's hash changes (the talk got edited server-side).
+- Caps at 1,000 entries; evicts oldest first.
+- Throttles to 4 concurrent generations to keep battery cost reasonable.
+
+The prompt is biased toward "what will the audience learn" instead of marketing copy, with a cleanup pass that strips prefatory text ("Summary:", surrounding quotes) some model outputs still emit.
+
+## What stays the same
+
+- The original talk description is **never modified** — the summary lives alongside it.
+- AI summaries are **never sent to a server** — generation is entirely on-device via Apple's bundled model.
+- The 100-character minimum on source descriptions means short blurbs (e.g. "Hands-on workshop") don't waste a model call.
+
+## Disabling
+
+**Settings → AI Summaries** off — rows hide the sparkle line. Cached summaries persist (no point throwing them away) but new ones won't generate.
+
+## See also
+
+- [Privacy and tracking](privacy.md)
+- [Schedule view](schedule.md)

--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -1,0 +1,51 @@
+# Bookmarking events
+
+Bookmarks are the simplest way to build your personal agenda.
+
+## How to bookmark
+
+On any list row (Schedule, All Content, Combined Schedule) the **bookmark icon** is on the right side:
+
+- **Outline** — not bookmarked.
+- **Filled** — bookmarked.
+- **Filled and red** — bookmarked AND in conflict with another bookmarked event.
+
+Tap the icon to toggle. The change persists immediately and syncs to your other devices via iCloud.
+
+You can also **swipe a row left** to toggle the bookmark — useful when scrolling quickly.
+
+## Where bookmarks live
+
+Bookmarks are stored in **Core Data** locally and synced to your Apple ID's **iCloud private database**. We never see them. They survive uninstalls (assuming you sign back into iCloud).
+
+A bookmark is just an event ID; the source event itself comes from Firestore on each app launch.
+
+## Bookmark conflicts
+
+Two events overlap in time → both bookmarks turn **red**. The Schedule toolbar also shows a red warning-triangle icon if you have any active conflicts in the current conference.
+
+Tap the toolbar triangle to see a list of conflicting bookmarks and resolve them.
+
+## Bookmark conflict alert toggle
+
+Tired of seeing red? **Settings → Show Schedule Conflict Alert** off — the red triangle and conflict popup are suppressed. The red bookmark icons themselves stay (they're informational on the row).
+
+## Filtering to bookmarks
+
+Open the filter sheet (bottom-left circle on Schedule or All Content). Tap the **Bookmarks** chip to narrow the list to just your saved events. Combine with other chips using the [Match Any / All toggle](search-and-filter.md).
+
+## Sharing your bookmarked schedule
+
+**Schedule toolbar → menu → Share Schedule** generates a QR code containing all your bookmark IDs. A friend scanning it gets a one-shot view of your selected events without permanently importing anything.
+
+The URL is `hackertracker://CONF_CODE/s?ids=1,2,3,…`.
+
+## Cross-conference bookmarks
+
+If you bookmark events across multiple conferences whose dates overlap, the [Combined Bookmark Schedule](combined-schedule.md) card appears on the home screen.
+
+## See also
+
+- [Combined Bookmark Schedule](combined-schedule.md)
+- [Search and filter](search-and-filter.md)
+- [Schedule view](schedule.md)

--- a/docs/combined-schedule.md
+++ b/docs/combined-schedule.md
@@ -1,0 +1,36 @@
+# Combined Bookmark Schedule
+
+Cross-conference timeline of just your bookmarks. Appears automatically when the timing makes sense.
+
+## When it shows up
+
+The **Combined Schedule** card appears on the **Info** tab (home screen) only when **both** are true:
+
+1. You have **2+ conferences with overlapping dates** loaded into the app.
+2. You have **bookmarks in at least 2 of the overlapping conferences**.
+
+The classic case: DEF CON, BSidesLV, and Black Hat all running the same week in Las Vegas. Bookmark talks in two or all three, and the card appears.
+
+## What you see
+
+Tap the card to open a single day-grouped timeline showing every bookmarked event from all qualifying conferences. Each row carries a **conference badge** (tinted to that conference's accent color) so you can tell where each event lives.
+
+Times are rendered in **your device's local timezone** — so if conferences span timezones (rare) or you're remote, the wall-clock times are sensible.
+
+## Limitations
+
+- **Event IDs aren't globally unique across conferences** in the underlying Firestore data. In the unlikely case of a collision, both events appear; the conference badge disambiguates.
+- **Speaker names aren't shown** in this view. Cross-conference speaker lookup adds complexity for marginal benefit; the title + conference badge + time identify each entry clearly.
+
+## What it doesn't do
+
+It doesn't let you bookmark from this screen — that happens in each conference's own Schedule. It doesn't sync some new flavor of "global bookmark" to iCloud — it's a derived view of bookmarks that already sync.
+
+## Removing it
+
+Remove all bookmarks from one of the contributing conferences. On next refresh (returning to InfoView triggers it), the card disappears.
+
+## See also
+
+- [Bookmarking events](bookmarks.md)
+- [Schedule view](schedule.md)

--- a/docs/custom-events.md
+++ b/docs/custom-events.md
@@ -1,0 +1,87 @@
+# Custom events
+
+Create your own schedule entries that show up alongside the official conference program.
+
+Custom events are perfect for:
+- Coffee with a specific person at 11am.
+- A meetup at a particular bar Friday night.
+- A reminder about a workshop you signed up for outside the official schedule.
+
+## Creating one
+
+1. Open the **Schedule** tab (calendar icon).
+2. Tap the **+** in the top-right of the toolbar.
+3. Fill in the form. **Title**, **Starts**, and **Ends** are required.
+4. **Save**.
+
+Your event appears immediately in the Schedule, sorted into the right time slot.
+
+## Form fields
+
+- **Title** — what to call it. Required.
+- **Starts / Ends** — DatePickers. End can't precede start.
+- **Where** — free-text location.
+- **Description** — Markdown-supported, multi-line.
+- **Appearance → Accent color** — picks the colored stripe on the left side of the schedule row.
+- **Send a notification before this event** — uses the global "Before Event" minutes from Settings. **Off by default** — flip it on per event when you want a reminder.
+- **Applies to** — one or more conferences. Defaults to the currently-selected one. Pick none to make the event show on every conference's schedule (a "personal recurring" event).
+
+## Visual indicators
+
+A custom event row carries:
+- Your chosen **accent color** as the left stripe (instead of the conference tag color).
+- A small **"Custom Event"** chip in the tag area.
+- A **pencil** to its left if it also has a [private note](notes.md).
+- The same bookmark icon as normal events (though custom events show in your schedule unconditionally, regardless of bookmark state).
+
+## Editing or deleting
+
+Tap a custom event row to open its detail view. The toolbar has:
+
+| Icon | Action |
+|---|---|
+| **Bookmark** | Toggle bookmark (mostly cosmetic for custom events; useful when you filter by Bookmarks) |
+| **Bell** | Toggle notifications on/off. One-tap, no edit form required. |
+| **QR code** | Open the share sheet to give this event to someone else (see below) |
+| **Pencil** | Open the form in edit mode |
+
+Inside the form, edit mode adds a destructive **Delete event** row at the bottom with a confirmation dialog.
+
+## Sharing a custom event via QR code
+
+Each custom event detail screen has a **QR code** icon in the toolbar.
+
+1. Tap it to present the share sheet.
+2. The sheet shows a QR code on a white card (so dark-mode themes can't garble it).
+3. Recipient opens **iOS Camera** and points it at the QR code, OR you can tap **Share Link…** to AirDrop or copy the URL.
+4. The recipient's phone opens HackerTracker with the form **pre-filled**: title, time, location, description, color, conferences, notifications setting.
+5. They tap **Save** to add it to their own device.
+
+The URL format is `hackertracker://import/customEvent?t=…&b=…&e=…` — see [Tabs and navigation](navigation.md) for the full deep-link reference. **Notes are intentionally not shared** — they're a private journal field, not part of the event's public identity.
+
+## Multi-conference attachment
+
+Custom events store a list of **conference codes** they apply to:
+
+- Empty list → applies to every conference.
+- One or more codes → only shows on those conferences' schedules.
+
+This is one event row, not duplicated copies. Edit it once and the changes appear across all attached conferences.
+
+## Privacy and sync
+
+Custom events live in Core Data backed by **NSPersistentCloudKitContainer**. They sync to your iCloud private database (assuming you're signed in) and propagate across your devices automatically.
+
+We never see them — Apple's CloudKit puts them in your private storage; we don't have the key.
+
+## Filtering and hiding
+
+The filter sheet has a **Custom Events** chip — selecting it narrows the schedule to user-created rows only.
+
+To hide custom events from the schedule entirely without deleting them, **Settings → Custom Events on Schedule** off. The local data is untouched.
+
+## See also
+
+- [Schedule view](schedule.md)
+- [Private notes](notes.md)
+- [Search and filter](search-and-filter.md)

--- a/docs/easter-eggs.md
+++ b/docs/easter-eggs.md
@@ -1,0 +1,32 @@
+# Easter eggs
+
+A few delights hidden in the app.
+
+## The Beezle watermark
+
+**Settings → Easter Eggs** on → a faint silhouette of Beezle (the app's ghost mascot) gently breathes in and out behind the main UI. The pulse period and peak opacity are configurable in the same Settings section:
+
+- **Peak Opacity** slider — 0.05 to 1.00, in 0.05 steps. Default 0.20.
+- **Pulse Period** stepper — 0 to 60 seconds. 0 holds Beezle steady at the peak opacity (no pulse). Default 12s.
+
+When **Easter Eggs AND Colorful Mode** are both on, Beezle cycles through the rainbow as it pulses.
+
+## The home tab swap
+
+With Easter Eggs on, the Home tab icon in the tab bar swaps from the default SF Symbol house to a custom Beezle icon. Subtle, but rewarding once you notice.
+
+## The 7-tap chord
+
+On the **Info** tab (home screen), scroll to the bottom and find the small version label that reads `#hackertracker iOS v6.0` (or whatever version you're on).
+
+**Tap it seven times.** What follows is a small celebration and an iconic 1987 music video. You've been warned.
+
+The seven-tap chord also flips on both Easter Eggs and Colorful Mode for you.
+
+## How to find more
+
+The hacker conference audience is good at finding hidden things. Some are mentioned here, some aren't. The source code is open — `grep` is your friend.
+
+## Source
+
+The Beezle watermark renderer lives in [`hackertracker/Views/ContentView.swift`](../hackertracker/Views/ContentView.swift) as `BeezleEasterEggOverlay`. The seven-tap handler is in [`hackertracker/Views/InfoView.swift`](../hackertracker/Views/InfoView.swift).

--- a/docs/ipad.md
+++ b/docs/ipad.md
@@ -1,0 +1,62 @@
+# iPad-specific layout
+
+HackerTracker adapts its layout for iPad. Most screens follow a **two-pane split view** that puts the list on the left and the detail on the right. iPhone uses the same screens stacked vertically with NavigationStack pushes.
+
+## Split view across list screens
+
+The following five screens use the iPad split layout:
+
+- **Schedule** (calendar tab)
+- **All Content** (talks list, via Info tab → All Content card)
+- **Speakers** (Info tab → Speakers card)
+- **Communities / Villages** (Info tab → various organizer cards)
+- **Merch** (Info tab → Merch card)
+
+In all five, the **sidebar is 500pt wide** (set in [`IPadAdaptive.sidebarWidth`](../hackertracker/Utils/iPadAdaptive.swift)) and the right pane fills the remainder.
+
+Tap a row in the left list → the right pane updates instantly without pushing onto the navigation stack. Switching to another row replaces the right pane.
+
+This applies to **custom events** too — they route to the right pane just like Firestore events do, not over the sidebar.
+
+## Two-column Settings
+
+Settings on iPad uses an **explicit HStack of two VStack columns** rather than the iPhone's single-column scroll. The conference picker and About card span both columns at the top; the settings rows split below:
+
+**Left column**: Light/Color modes, Show Local Timezone, Show Past Events, News on Home Screen.
+**Right column**: Start Screen picker, Notifications, AI Summaries, Custom Events on Schedule, Easter Eggs.
+
+This is automatic — there's no manual layout selection.
+
+## Maps on iPad
+
+The current build uses a **single-page paged layout** on iPad regardless of orientation. An earlier 6.0 beta experimented with a two-up landscape mode; that's been removed in favor of consistent one-map-at-a-time UX.
+
+The floating zoom pill sits in the bottom-left of the map area and is bumped up to clear the page indicator dots.
+
+## Toolbar consistency
+
+iPad detail panes fill **edge-to-edge** in the right column. There's no inner readable-width cap — the column itself is already at a comfortable reading width given the 500pt sidebar.
+
+iPhone detail screens render full-width as expected (no split layout possible at iPhone widths).
+
+## Why 500pt?
+
+A 500pt sidebar lands at roughly **42% of an 11" iPad's landscape width**, matching the visual balance of the Communities tile grid. Earlier 6.0 betas used 380-420pt sidebars which left detail panes feeling sparse.
+
+This value is the single source of truth — `IPadAdaptive.sidebarWidth`. If you ever want a wider or narrower sidebar, it's a one-line edit.
+
+## Custom events in the split
+
+Tap a custom event row in the iPad Schedule sidebar → the right pane shows the custom event detail (title card, time, location, tags including the "Custom Event" chip, description, notes block, conference badges, notifications status, and the edit/share/delete actions).
+
+## Source
+
+Most of the iPad logic lives in:
+
+- [`hackertracker/Utils/iPadAdaptive.swift`](../hackertracker/Utils/iPadAdaptive.swift) — width constant, environment keys for split selections
+- [`hackertracker/Views/EventsView.swift`](../hackertracker/Views/EventsView.swift) — the Schedule split implementation; mirror pattern in the other four list screens
+
+## See also
+
+- [Quick Start](quickstart.md)
+- [Tabs and navigation](navigation.md)

--- a/docs/maps.md
+++ b/docs/maps.md
@@ -1,0 +1,55 @@
+# Maps
+
+Conference venue floor plans. Available from the map icon in the tab bar.
+
+## Layout
+
+A horizontally-swipeable stack of maps. Page indicator dots at the bottom show your position. The title bar shows the current map's name.
+
+## Controls
+
+**Floating zoom pill** — bottom-left of the map area. Three icons stacked horizontally:
+
+| Icon | Action |
+|---|---|
+| **+ magnifier** | Zoom in 25% |
+| **− magnifier** | Zoom out 25% |
+| **↔ magnifier** | Reset to fit-to-page |
+
+Pinch gestures work too. Double-tap to zoom in / out at a specific point.
+
+**Toolbar buttons**
+
+- **Leading (top-left)** — **Share** the active map as a PDF via the system share sheet. AirDrop, Save to Files, Copy, etc.
+- **Trailing (top-right)** — **Search** (only visible when the current map has SVG support — see below).
+
+## SVG search
+
+When the conference publishes a **searchable SVG version** of a map alongside the PDF, the app prefers the SVG. You'll see a magnifying-glass icon in the trailing toolbar.
+
+Tap it to open a search field at the top of the map. Type to find text on the floor plan — room numbers, village names, etc. The first match is highlighted with a yellow box; the count shows next to the input ("3 hits" / "no match").
+
+The search is **case-insensitive** and matches `<text>`, `<tspan>`, and `<title>` elements in the SVG — so a room labeled "228" in the visible text is findable by typing "228", AND a room whose visible label is "228" but whose accessibility `<title>` is "Hardware Hacking Village" is findable by typing "hardware."
+
+Search only works on SVG maps. PDF maps don't have selectable text in this dataset; the search button hides when only the PDF is available.
+
+## Performance
+
+Maps are downloaded on conference load and cached locally at `<documents>/<conference_code>/<filename>`. Subsequent visits are instant.
+
+On the conference's first download, the **tab icon pulses** until all maps have arrived. The empty state shows a bobbing Beezle ghost + "Map downloading…" with a Refresh button.
+
+**Pre-warming**: PDFs are parsed into a process-lifetime cache during conference load, so the first swipe between maps is instant rather than stalling on a per-page parse.
+
+## Memory
+
+The Map of your **last-viewed page index** is remembered per conference. Open Maps in DEFCON33, swipe to page 3, open Maps in BSidesLV → DEFCON33 → reopen Maps → you're back on page 3.
+
+## iPad layout
+
+On iPad in landscape, the Maps view stays single-page (one map fills the screen). Earlier 6.0 betas experimented with two-up landscape; the current build uses a single page with the floating zoom pill above the page indicator dots.
+
+## See also
+
+- [Quick Start](quickstart.md)
+- [Privacy and tracking](privacy.md) (no map analytics specifically)

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,48 @@
+# Tabs and navigation
+
+The HackerTracker tab bar has four tabs. Each tab is independent — switching tabs doesn't lose your place inside another tab.
+
+## Info (house icon)
+
+The home screen. Shows:
+- The conference banner, name, and tagline.
+- A **News** card with the most recent article (toggle off in Settings if you'd rather not see it).
+- A grid of feature cards: **Schedule**, **All Content** (talks list), **Speakers**, **Communities/Villages**, **Locations**, **FAQ**, **Merch**, **Shared Schedule**, **Emergency Info**, **About**, and conference-specific menus.
+- Beneath the grid, a version label at the bottom — tap it seven times for an [Easter Egg](easter-eggs.md).
+
+## Schedule (calendar icon)
+
+The day-by-day agenda. See [Schedule view](schedule.md).
+
+## Maps (map icon)
+
+The venue floor plans. See [Maps](maps.md).
+
+## Settings (gear icon)
+
+App preferences: select conference, theme, time format, notification offset, and feature toggles. See the individual feature pages for the relevant Settings entries.
+
+## Returning to the top of a list
+
+Most list screens (Schedule, All Content, Speakers, Orgs, Merch) have a **Top / Bottom** jump menu in the lower-right corner. Useful in long conferences.
+
+## Conference switching
+
+**Settings → Select Conference** opens the conferences list. Active conferences (current or upcoming) appear at the top; past conferences are below.
+
+Switching conferences re-fetches the schedule, content, speakers, maps, and tags. Your bookmarks, custom events, and private notes stay with you across switches (they're tagged with conference codes when relevant, but the storage is global).
+
+## Deep links
+
+HackerTracker registers the `hackertracker://` URL scheme:
+
+| URL | Effect |
+|---|---|
+| `hackertracker://DEFCON33` | Switch to DEFCON33 if available |
+| `hackertracker://DEFCON33/content?id=42` | Open All Content → talk 42 |
+| `hackertracker://DEFCON33/event?id=42` | Resolve event 42 to its parent talk, then open it |
+| `hackertracker://DEFCON33/s?ids=1,2,3` | Open a Shared Schedule view of those bookmark ids |
+| `hackertracker://import/customEvent?t=…&b=…&e=…` | Import a [custom event](custom-events.md) from a scanned QR code |
+| `hackertracker://DEFCON33/404` | (Debug) present the empty-state ghost screen |
+
+Useful for sharing direct links to specific talks or for the custom-event QR import.

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,0 +1,68 @@
+# Private notes
+
+Markdown-formatted notes attached to any event, talk, or custom event. Stored locally and synced via your iCloud private database.
+
+## Adding a note
+
+On any detail screen — an event, talk, or custom event — scroll to the bottom. You'll see a collapsed section labeled **My Notes**:
+
+```
+📝  My Notes                                              Show ›
+```
+
+Tap the row to expand. The accent dot appears when there's already a note saved; absent dot = empty.
+
+If empty:
+- An **Add a note** button appears.
+- Tap it to open the editor.
+
+If a note exists:
+- Markdown render of your note is shown read-only.
+- Tap anywhere on the rendered text to open the editor.
+
+## The editor
+
+The editor sheet has two tabs:
+
+- **Write** — a monospace `TextEditor` for entering Markdown.
+- **Preview** — same editor body rendered as Markdown.
+
+Supports the standard Markdown syntax: headings, bold/italic, lists, links, code blocks, etc. (Same `MarkdownUI` library used for the conference's content descriptions.)
+
+Toolbar:
+- **Cancel** — discard the in-progress edit.
+- **🗑 (trash, destructive)** — only visible when editing an existing note. Confirms before deleting; deletion propagates to your iCloud-synced devices.
+- **Save** — persist the note.
+
+## Where notes live
+
+Notes are stored as Core Data rows keyed by `(targetID, targetKind)`. The kind is one of `event`, `content`, or `customEvent`. They're synced to your **iCloud private database** via `NSPersistentCloudKitContainer`.
+
+We never see them. There's no server-side storage of note content.
+
+If you uninstall the app and reinstall without signing into iCloud, the notes are gone. With iCloud signed in, they come back.
+
+## Cross-kind notes
+
+You can author a note from either the **Schedule** detail screen (kind = `event`) or the **All Content** detail screen (kind = `content`). The app cross-references both:
+
+- A note authored from a talk's detail lights up the **pencil badge** on both the Schedule row for any session of that talk AND the All Content row for the talk itself.
+- The **Has Notes** filter on either list catches the same set of events.
+
+You're never forced to remember "where did I add that note" — it just shows up.
+
+## Find rows with notes
+
+Each list row shows a **pencil icon** to the left of the bookmark when the row's target has a saved note. The filter sheet's **Has Notes** chip narrows the list to just those rows.
+
+## Limits
+
+- **One note per item.** Editing replaces the previous body.
+- **No images or attachments.** Markdown text only.
+- **Empty notes are auto-deleted.** Saving a blank or whitespace-only body removes the row. The CTA reverts to "Add a note."
+
+## See also
+
+- [Bookmarking events](bookmarks.md)
+- [Custom events](custom-events.md)
+- [Search and filter](search-and-filter.md)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,75 @@
+# Privacy and tracking
+
+Plain English version of what HackerTracker collects, doesn't collect, and how it handles your data. The in-app copy of this lives at **Settings → Privacy & Tracking** and stays in sync with this page.
+
+## TL;DR
+
+- We don't sell or rent any data.
+- We don't show ads.
+- We don't use IDFA. The IDFA-capable Firebase SDK is not in the binary.
+- There is no ATT (App Tracking Transparency) prompt because there's nothing to track.
+- Your private notes, custom events, and bookmarks live in your iCloud private database. We don't have the key.
+
+## What we collect
+
+**Conference data** — talks, events, speakers, maps, merch, news. Read from Firebase Firestore. We never write anything to your account; data flows one direction, server → your phone.
+
+**Your bookmarks, custom events, and private notes** — stored in local Core Data on your device, optionally synced via *your* iCloud private database. We don't have the key. We never see them.
+
+**Crash reports** — stack traces and the OS / app version when the app crashes. Sent to Firebase Crashlytics on the next launch after a crash. No message bodies, no user input, no IDFA. Sent only when the app crashes; nothing is sent during normal use.
+
+**Push notification token** — the opaque APNs identifier Apple gives the app for delivering pushes. Stored in Firebase Cloud Messaging so we can send conference-wide announcements you opted into via iOS Settings. Deleting the app or revoking notification permission cuts this off immediately.
+
+**Anonymous usage events** — which screens you visit, how long the session was, the app version, the device model and OS version. Stored in Firebase Analytics (the **no-IDFA** variant — we link the build of the SDK that literally cannot read the advertising identifier). No name, no email, no IDFA, no cross-app tracking. Used to tell us which parts of the app are actually used so we can prioritize fixes and features.
+
+## What we don't collect
+
+- Your name, email, account, or phone number. We don't have user accounts.
+- Your contact list, photos, microphone, camera, or precise location.
+- Browsing history, ad identifiers (IDFA), or device fingerprints. We link the no-AdId build of Firebase Analytics; the IDFA-capable variant is **not present in the app bundle**.
+- The contents of your bookmarks, custom events, or private notes — those live in your iCloud private database, encrypted; we have no access to them.
+- Tracking across other apps or websites. There is no ATT prompt because there is no IDFA to collect.
+
+## Your choices
+
+**Disable notifications.** *Settings → Notifications → HackerTracker → off.* We can no longer push you anything.
+
+**Delete your local data.** Swipe-delete bookmarks, long-press to delete custom events / notes from inside the app. Or sign out of iCloud, or uninstall the app — your local store goes with it.
+
+## What we never do
+
+- Sell or rent any data to anyone, ever.
+- Show ads.
+- Share identifiers with ad networks, marketing platforms, or data brokers.
+- Read your private notes, custom events, or bookmark contents. CloudKit puts those in your private database, encrypted; we don't have the key.
+
+## What CloudKit does for you
+
+Your bookmarks, custom events, and private notes are stored in **Core Data** locally and replicated to **your Apple ID's iCloud private database** via `NSPersistentCloudKitContainer`.
+
+Properties of this storage:
+- **End-to-end encrypted** when iCloud Advanced Data Protection is enabled on your Apple ID.
+- **Sandboxed per Apple ID** — only your devices have access.
+- **Off-limits to us** — the app's developers have no read access. We can't make this point strongly enough.
+
+## App Store privacy disclosures
+
+The corresponding **App Store Connect → Privacy** disclosures for this app:
+
+| Data type | Linked to user? | Used for tracking? | Purposes |
+|---|---|---|---|
+| Crash Data | No | No | App Functionality |
+| Performance Data | No | No | Analytics, App Functionality |
+| Other Diagnostic Data | No | No | Analytics, App Functionality |
+| Product Interaction | No | No | Analytics, App Functionality |
+| Push Notification Token | No | No | App Functionality |
+
+(No **Device ID (IDFA)** disclosure because we don't collect it.)
+
+## Contact
+
+Questions? Bugs? Privacy concerns? Email **hackertracker@defcon.org** or [open an issue](https://github.com/junctor/hackertracker-ios/issues/new). We respond.
+
+## Source of truth
+
+The in-app version of this disclosure lives at [`hackertracker/Views/PrivacyDoc.swift`](../hackertracker/Views/PrivacyDoc.swift) and is rendered under **Settings → Privacy & Tracking**. When this page changes, that file changes — or the other way around. The two must agree.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,47 @@
+# Quick Start
+
+Five minutes from install to bookmarked schedule.
+
+## 1. Install
+
+HackerTracker is available on the App Store: search **HackerTracker** or follow the link from [defcon.org](https://defcon.org).
+
+Requirements: iOS 17 or later. iPad supported with a custom split-view layout.
+
+## 2. First launch
+
+The app opens to the **Info** tab (the house icon, far left of the tab bar). It picks a default conference automatically — usually the next upcoming or currently-active one.
+
+If the wrong conference is loaded, tap **Settings → Select Conference** to pick a different one. The app saves your choice across launches.
+
+## 3. Browse the schedule
+
+Tap the **calendar** icon in the tab bar to open the Schedule. You'll see every event grouped by day. Scroll or use the floating **Top / Bottom** circles at the bottom-right of the screen to jump.
+
+- Tap any event row to see its full description, speakers, location, and tags.
+- Tap the **bookmark** outline on the right of a row to save it. The icon fills in to confirm.
+- Tap the **filter** circle in the bottom-left to narrow the schedule by tags, your bookmarks, or other chips.
+
+## 4. Search
+
+Tap the **magnifying glass** in the top-right of any list screen to start typing. Search is debounced — the list refreshes after you pause typing.
+
+## 5. Find a room
+
+Tap the **map** icon in the tab bar. Swipe between maps; pinch to zoom; or use the floating zoom controls on the bottom-left. If the conference publishes a searchable SVG version, a magnifying-glass search field appears on the trailing side of the toolbar.
+
+## 6. Make it yours
+
+Things that only you can see, all stored locally and synced to your other devices via iCloud:
+
+- **Bookmarks** (above) — saved events.
+- **Custom events** — your own schedule entries. Tap the **+** in the Schedule toolbar. See [Custom events](custom-events.md).
+- **Private notes** — Markdown-formatted notes attached to any event, talk, or custom event. Open any detail screen, scroll to the bottom, tap **My Notes → Show → Add a note**. See [Notes](notes.md).
+
+## Next reading
+
+- [Tabs and navigation](navigation.md)
+- [Schedule view](schedule.md)
+- [Bookmarking events](bookmarks.md)
+- [Custom events](custom-events.md)
+- [Private notes](notes.md)

--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -1,0 +1,71 @@
+# Schedule view
+
+The day-by-day agenda. Available from the calendar icon in the tab bar.
+
+## Layout
+
+Events are grouped by day. Inside each day, rows are sorted chronologically.
+
+Each row shows:
+- **Time block** (start and end) on the left.
+- A **colored stripe** indicating the event's primary tag color.
+- **Title**, **speakers**, **location**, and **tag chips** in the middle.
+- Status icons on the right:
+  - **Pencil** (gray) — this event has a [saved private note](notes.md).
+  - **Bookmark** — outline or filled. Filled = bookmarked. **Red** = bookmarked AND conflicting with another bookmark.
+  - **Sparkle ✨ + summary line** — appears under the speaker line when [AI summaries](ai-summaries.md) are enabled and the model has generated one.
+
+## Row actions
+
+| Action | Effect |
+|---|---|
+| Tap row | Open the talk's detail view |
+| Tap bookmark | Toggle bookmarked state |
+| Swipe row left | Same as tapping bookmark |
+| Long-press a row with an AI summary | Peek at the original (uncompressed) description |
+| Tap pencil-or-bookmark icon | Same as the row tap for navigation; bookmark icon also toggles |
+
+## Toolbar controls
+
+The Schedule's toolbar (top of the screen) carries:
+
+**Trailing side**
+- **+** — Add a new [custom event](custom-events.md).
+- **Magnifying glass** — Open the search field.
+
+**Leading side**
+- **Menu** (three dots) — Toggle local time, 24-hour time, hide past events, share schedule QR.
+- **Conflict indicator** — Red warning triangle when bookmarked events overlap each other.
+
+## Floating controls
+
+**Bottom-left circle** — Filter sheet. See [Search and filter](search-and-filter.md).
+
+**Bottom-right circle** — Top / Bottom / Current / Next jump menu.
+
+## Custom events in the schedule
+
+Custom events you've created appear inline with the official ones, sorted by time. They carry:
+- Your chosen accent color in the row's left stripe.
+- A small **"Custom Event"** chip in the tag area.
+- The standard pencil / bookmark icons on the right.
+
+Tap a custom event to open its detail view, which adds **Edit**, **Share via QR**, and **Delete** affordances. See [Custom events](custom-events.md).
+
+## Hiding past events
+
+**Settings → Show Past Events** off — past events disappear from the schedule entirely.
+
+## Conference timezone vs your local time
+
+By default, the schedule renders in the **conference's local timezone** (the venue's wall clock). Toggle **Settings → Show Local Timezone** to show times in your device's current timezone instead. Useful if you're remote or traveling.
+
+The current active timezone shows under the toggle in Settings.
+
+## See also
+
+- [Bookmarking events](bookmarks.md)
+- [Combined Bookmark Schedule](combined-schedule.md)
+- [Custom events](custom-events.md)
+- [Private notes](notes.md)
+- [Search and filter](search-and-filter.md)

--- a/docs/search-and-filter.md
+++ b/docs/search-and-filter.md
@@ -1,0 +1,86 @@
+# Search and filter
+
+Two complementary tools for narrowing list views.
+
+## Search
+
+The **magnifying glass** icon in the top-right of every list (Schedule, All Content, Speakers, Orgs, Merch) opens an inline search bar.
+
+- Searching is **case-insensitive** and matches against title + description fields (and speaker names on Schedule + Content rows).
+- The list updates after a short **debounce** so you can type quickly without re-filtering on every keystroke.
+- Tap the **X** to clear the field; the **magnifying glass** to close the search bar entirely.
+
+## Filter sheet
+
+The **filter circle** in the bottom-left of list views opens the filter sheet.
+
+Layout:
+```
+[ Match   ( Any | All ) ]
+( 12 events )                ← live tally
+─────────────────────────
+[ Bookmarks ]                ← pseudo-tag chips (top)
+[ Custom Events ]
+[ Has Notes ]
+
+Event Category
+[ Talk ]  [ Demo Lab ]  [ Workshop ] ...
+
+Skill Level
+[ Beginner ]  [ Intermediate ] ...
+
+Organizer
+[ AppSec Village ]  [ Cloud Village ] ...
+```
+
+### Pseudo-tag chips
+
+Three special chips at the top — they don't correspond to real tags in the data, but to filter behaviors:
+
+| Chip | Behavior |
+|---|---|
+| **Bookmarks** | Only show events you've bookmarked |
+| **Custom Events** | Only show user-created events |
+| **Has Notes** | Only show events that have a saved private note (kind `event`, `content`, or `customEvent`) |
+
+### Real tag chips
+
+Tag chips are organized by **tag type** (Event Category, Skill Level, Organizer, etc.). Each chip uses the conference's color for that tag.
+
+Tap to add to the current selection; tap again to remove.
+
+### Match Any / Match All
+
+At the very top of the sheet, a segmented control switches between two composition modes:
+
+- **Any** (default) — A row survives when **any** selected chip matches it. Selecting "Bookmarks + Custom Events" returns the **union** (all bookmarks plus all custom events).
+- **All** — A row must satisfy **every** selected chip. Selecting "Bookmarks + Custom Events" returns the **intersection** (only custom events that are also bookmarked).
+
+Mode persists across launches.
+
+### Live tally
+
+Just below the picker, a small label shows the **count of rows that will be visible** with your current selection — `12 events`, `47 talks`, `3 products`. Updates as you toggle chips.
+
+### Clear and Done
+
+- **Clear** (top-left) wipes all selected chips. Disabled when nothing's selected.
+- **Done** (top-right, bold) closes the sheet.
+
+## Filter parity across list types
+
+The same filter UI appears on the Schedule, All Content, and Merch screens. The pseudo-tag chips that apply vary by context:
+
+| List | Bookmarks | Custom Events | Has Notes | Sizes |
+|---|---|---|---|---|
+| Schedule | ✓ | ✓ | ✓ | — |
+| All Content | ✓ | (no custom events on this list) | ✓ | — |
+| Merch | — | — | — | ✓ (in-stock sizes) |
+
+The Merch filter ("Filter by Size") has the same chrome and the same Match Any / All toggle. Any = at least one selected size is in stock for the product. All = every selected size is in stock (useful when buying bundles).
+
+## See also
+
+- [Schedule view](schedule.md)
+- [Bookmarking events](bookmarks.md)
+- [Private notes](notes.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,90 @@
+# Troubleshooting
+
+Common problems and how to fix them.
+
+## Schedule looks empty
+
+The conference data is fetched from Firebase Firestore on launch and then continuously listened to. If the schedule is blank:
+
+1. Check your **internet connection**.
+2. Pull-to-refresh the schedule (drag down at the top of the list).
+3. **Settings → Select Conference** — make sure the right conference is active.
+4. Force-quit the app (swipe up from the home indicator, swipe up on the HackerTracker card) and relaunch.
+5. If the schedule is still empty for an active conference, the conference data may not have been published yet by the organizers. Check the conference's official channels.
+
+## Maps not loading
+
+Maps are downloaded once per conference and cached at `<documents>/<conference_code>/<filename>`.
+
+1. **Tab icon pulses?** Wait — maps are still downloading in the background.
+2. **Beezle bobbing with "Map downloading…"?** Same — the empty state during download.
+3. **Pull to refresh on the Maps tab** — pulls the conference data again, which re-triggers map downloads.
+4. **Force-quit and relaunch** — sometimes a hung URLSession is the culprit.
+5. If maps stay broken, **Settings → Select Conference → re-select your conference** — this forces a fresh fetch.
+
+## Notes (or bookmarks, or custom events) not syncing across devices
+
+These use **iCloud private database** via Core Data + NSPersistentCloudKitContainer.
+
+1. **Are both devices signed into the same Apple ID?** This is the most common cause.
+2. **Is iCloud Drive enabled** on both devices? **Settings → [your name] → iCloud → iCloud Drive** must be on.
+3. **Are you in low-power mode?** iOS deprioritizes CloudKit sync in low-power mode.
+4. **Wait 30-60 seconds.** CloudKit isn't real-time; it batches changes for efficiency.
+5. **Toggle iCloud sync off and on for HackerTracker:** Settings → iCloud → HackerTracker → off → on.
+
+If it still doesn't sync, file an issue.
+
+## App crashed
+
+Crash reports are sent to **Firebase Crashlytics** automatically on next launch. You don't need to do anything.
+
+If you can reliably reproduce the crash, please [open an issue](https://github.com/junctor/hackertracker-ios/issues) with steps to reproduce — that's far more useful than a bare crash report.
+
+## Notifications not arriving
+
+Per-event notifications (custom events) and conference-wide pushes are different paths:
+
+**Custom event notifications** — uses the global "Before Event" minutes from Settings (default 20). Check:
+1. Did you toggle "Send a notification before this event" on when creating the event? (Off by default.)
+2. **iOS Settings → Notifications → HackerTracker** — Allow Notifications must be on.
+3. The notification fires at `event_start - notifyAt_minutes`. If you set notifyAt to 20 and the event starts at 3:00 PM, the alert fires at 2:40 PM.
+
+**Conference-wide push** — uses APNs/FCM:
+1. Same: Allow Notifications must be on.
+2. Sometimes APNs takes a moment to register a new install; relaunch a few times.
+
+## AI summaries don't appear
+
+If you don't see the sparkle ✨ on talk rows after toggling AI Summaries on:
+
+1. **Check the toggle is actually on** — Settings → AI Summaries.
+2. **iOS 26 or later required.** Older iOS versions hide the toggle entirely; if you don't see the toggle at all, your device or OS doesn't support it.
+3. **Apple Intelligence enabled?** iOS Settings → Apple Intelligence & Siri.
+4. **Wait a few seconds.** The first time you scroll to a row, the model needs ~1-3 seconds to generate the summary. Subsequent visits are instant (cached).
+5. **The talk description is under 100 characters?** Then there's nothing to summarize — short blurbs are skipped intentionally.
+
+## Custom event QR scan doesn't open the form
+
+If scanning a QR code with iOS Camera opens HackerTracker but doesn't show the import form:
+
+1. **Is the URL well-formed?** It should start with `hackertracker://import/customEvent?t=...&b=...&e=...`.
+2. **The encoding might be off.** Try the **Share Link…** option in the share sheet on the sending side; AirDrop the link instead of scanning.
+3. The recipient device's conferences must be loaded enough to render the form. Open the app, let it settle, then re-scan.
+
+## How to file a bug
+
+[GitHub Issues](https://github.com/junctor/hackertracker-ios/issues/new). Include:
+
+- App version (Settings → About).
+- iOS version.
+- Device model.
+- Steps to reproduce.
+- Expected vs actual behavior.
+- Screenshot if relevant.
+
+For privacy concerns specifically, email **hackertracker@defcon.org**.
+
+## See also
+
+- [Privacy and tracking](privacy.md)
+- [Quick Start](quickstart.md)


### PR DESCRIPTION
## Summary

First pass of the user guide as proposed in the wiki plan — Markdown files under `/docs`, rendered directly by GitHub without any GitHub Pages setup.

## Pages

15 in total, each self-contained with cross-links between them and links back to source files where there's a clear implementation anchor:

| File | Section |
|---|---|
| `README.md` | Landing page, TOC, 6.0 highlights |
| `quickstart.md` | 5-minute onboarding |
| `navigation.md` | Tabs + deep-link URL reference |
| `schedule.md` | Schedule view, row anatomy, toolbar |
| `bookmarks.md` | Bookmarking + conflicts + sharing QR |
| `combined-schedule.md` | Cross-conference bookmark timeline |
| `custom-events.md` | Create / edit / delete / multi-conf / QR share |
| `notes.md` | Markdown notes + editor + cross-kind pencil |
| `maps.md` | Swipe + zoom + share + SVG search |
| `search-and-filter.md` | Filter sheet + Match Any/All + live tally |
| `ai-summaries.md` | Apple Intelligence summaries |
| `privacy.md` | What we collect, what we don't (mirrors `PrivacyDoc.body`) |
| `ipad.md` | Split view + two-column Settings |
| `easter-eggs.md` | Beezle watermark + 7-tap chord |
| `troubleshooting.md` | Common problems → fixes |

## Source of truth

`docs/privacy.md` mirrors [`hackertracker/Views/PrivacyDoc.swift`](../../hackertracker/Views/PrivacyDoc.swift) verbatim. When one changes, both change.

## What's NOT included (yet)

- Screenshots — text only for now. Phase 2 should capture iPhone + iPad screenshots from a clean simulator for each documented screen.
- A developer-reference section. CLAUDE.md serves that role for now.
- A dedicated changelog page. The "What's new in 6.0" section in `README.md` covers the current release.

## Future iteration

The proposed Phase 2/3 wiki structure (deeper troubleshooting, per-tab walk-throughs, animated GIFs) can layer on top of this without restructuring — each existing page has natural extension points.

🧙 Built with [WOZCODE](https://wozcode.com)