### PR TITLE
docs: drop developer-reference section from user guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,9 +30,6 @@ If you're looking for the **5-minute version**, start with [Quick Start](quickst
 - [Easter eggs](easter-eggs.md) — there is one. See if you can find it.
 - [Troubleshooting](troubleshooting.md) — common problems and fixes
 
-### For developers
-- See [`CLAUDE.md`](../CLAUDE.md) at the repo root for build commands, architecture, and conventions.
-
 ---
 
 ## What's new in 6.0


### PR DESCRIPTION
Remove the 'For developers' bullet (and the CLAUDE.md link it carried) from `docs/README.md`. The user guide is now functionality-only; developer-oriented info stays in CLAUDE.md at the repo root where contributors expect to find it.

🧙 Built with [WOZCODE](https://wozcode.com)