### PR TITLE
Efficiency & design review fixes (+ conference media)

### DIFF
--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -967,7 +967,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26062801;
+				CURRENT_PROJECT_VERSION = 26062901;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;
@@ -985,7 +985,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1;
+				MARKETING_VERSION = 6.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = org.beezle.hackertracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1007,7 +1007,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26062801;
+				CURRENT_PROJECT_VERSION = 26062901;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;
@@ -1025,7 +1025,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1;
+				MARKETING_VERSION = 6.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = org.beezle.hackertracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -49,7 +49,7 @@
 		5D642D4F2A5DDB8D0064492D /* AddEventController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D4E2A5DDB8D0064492D /* AddEventController.swift */; };
 		5D642D512A5DDBD20064492D /* AddEventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D642D502A5DDBD20064492D /* AddEventView.swift */; };
 		5D9681162C5946E000D246B0 /* FeedbackUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9681152C5946E000D246B0 /* FeedbackUtility.swift */; };
-		5D9681182C5C380000D246B0 /* FirebaseInAppMessagingSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 5D9681172C5C380000D246B0 /* FirebaseInAppMessagingSwift-Beta */; };
+		5D9681182C5C380000D246B0 /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 5D9681172C5C380000D246B0 /* FirebaseInAppMessaging-Beta */; };
 		5D96811A2C5D948100D246B0 /* NewsUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9681192C5D948100D246B0 /* NewsUtility.swift */; };
 		5D96811C2C5D976C00D246B0 /* NotificationDotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D96811B2C5D976C00D246B0 /* NotificationDotView.swift */; };
 		5D9B8EC92C534207009AAA61 /* FeedbackForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9B8EC82C534207009AAA61 /* FeedbackForm.swift */; };
@@ -76,10 +76,8 @@
 		5DAE04CA2820948F00930A2D /* hackertrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAE04C92820948F00930A2D /* hackertrackerTests.swift */; };
 		5DAE04D42820948F00930A2D /* hackertrackerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAE04D32820948F00930A2D /* hackertrackerUITests.swift */; };
 		5DAE04D62820948F00930A2D /* hackertrackerUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAE04D52820948F00930A2D /* hackertrackerUITestsLaunchTests.swift */; };
-		5DAE3E982836A76000F9F845 /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 5DAE3E972836A76000F9F845 /* FirebaseAnalyticsSwift */; };
 		5DAE3E9A2836A76000F9F845 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 5DAE3E992836A76000F9F845 /* FirebaseAnalyticsWithoutAdIdSupport */; };
-		5DAE3E9C2836A76000F9F845 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 5DAE3E9B2836A76000F9F845 /* FirebaseDatabaseSwift */; };
-		5DAE3E9E2836A76000F9F845 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 5DAE3E9D2836A76000F9F845 /* FirebaseFirestoreSwift */; };
+		5DAE3E9E2836A76000F9F845 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 5DAE3E9D2836A76000F9F845 /* FirebaseFirestore */; };
 		5DB4E0AB284E86900012F6F4 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E0AA284E86900012F6F4 /* ScheduleView.swift */; };
 		5DB4E0AD284E86AD0012F6F4 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E0AC284E86AD0012F6F4 /* MapView.swift */; };
 		5DB4E0AF284E86CC0012F6F4 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E0AE284E86CC0012F6F4 /* InfoView.swift */; };
@@ -273,15 +271,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D642D312A4F9F0E0064492D /* FirebaseMessaging in Frameworks */,
-				5DAE3E9C2836A76000F9F845 /* FirebaseDatabaseSwift in Frameworks */,
-				5D9681182C5C380000D246B0 /* FirebaseInAppMessagingSwift-Beta in Frameworks */,
+				5D9681182C5C380000D246B0 /* FirebaseInAppMessaging-Beta in Frameworks */,
 				5D0A5A662A35293000BD5ECE /* MarkdownUI in Frameworks */,
 				5D642D3E2A5725D80064492D /* Kingfisher in Frameworks */,
 				5D1C77232FC901970042DABC /* FirebaseCrashlytics in Frameworks */,
-				5DAE3E982836A76000F9F845 /* FirebaseAnalyticsSwift in Frameworks */,
 				5D2FAD992BC095C90043A84C /* FirebaseStorage in Frameworks */,
 				5DAE3E9A2836A76000F9F845 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
-				5DAE3E9E2836A76000F9F845 /* FirebaseFirestoreSwift in Frameworks */,
+				5DAE3E9E2836A76000F9F845 /* FirebaseFirestore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -547,15 +543,13 @@
 			);
 			name = hackertracker;
 			packageProductDependencies = (
-				5DAE3E972836A76000F9F845 /* FirebaseAnalyticsSwift */,
 				5DAE3E992836A76000F9F845 /* FirebaseAnalyticsWithoutAdIdSupport */,
-				5DAE3E9B2836A76000F9F845 /* FirebaseDatabaseSwift */,
-				5DAE3E9D2836A76000F9F845 /* FirebaseFirestoreSwift */,
+				5DAE3E9D2836A76000F9F845 /* FirebaseFirestore */,
 				5D0A5A652A35293000BD5ECE /* MarkdownUI */,
 				5D642D302A4F9F0E0064492D /* FirebaseMessaging */,
 				5D642D3D2A5725D80064492D /* Kingfisher */,
 				5D2FAD982BC095C90043A84C /* FirebaseStorage */,
-				5D9681172C5C380000D246B0 /* FirebaseInAppMessagingSwift-Beta */,
+				5D9681172C5C380000D246B0 /* FirebaseInAppMessaging-Beta */,
 				5D1C77222FC901970042DABC /* FirebaseCrashlytics */,
 			);
 			productName = hackertracker;
@@ -1178,7 +1172,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.0.0;
+				minimumVersion = 11.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1208,30 +1202,20 @@
 			package = 5D642D3C2A5725D80064492D /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
 		};
-		5D9681172C5C380000D246B0 /* FirebaseInAppMessagingSwift-Beta */ = {
+		5D9681172C5C380000D246B0 /* FirebaseInAppMessaging-Beta */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5DAE3E962836A76000F9F845 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseInAppMessagingSwift-Beta";
-		};
-		5DAE3E972836A76000F9F845 /* FirebaseAnalyticsSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5DAE3E962836A76000F9F845 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalyticsSwift;
+			productName = "FirebaseInAppMessaging-Beta";
 		};
 		5DAE3E992836A76000F9F845 /* FirebaseAnalyticsWithoutAdIdSupport */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5DAE3E962836A76000F9F845 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalyticsWithoutAdIdSupport;
 		};
-		5DAE3E9B2836A76000F9F845 /* FirebaseDatabaseSwift */ = {
+		5DAE3E9D2836A76000F9F845 /* FirebaseFirestore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5DAE3E962836A76000F9F845 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseDatabaseSwift;
-		};
-		5DAE3E9D2836A76000F9F845 /* FirebaseFirestoreSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5DAE3E962836A76000F9F845 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseFirestoreSwift;
+			productName = FirebaseFirestore;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3C04BD9E2A5FDFD900D01402 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C04BD9D2A5FDFD900D01402 /* Filters.swift */; };
 		3C04BDA02A5FE91500D01402 /* FiltersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C04BD9F2A5FE91500D01402 /* FiltersView.swift */; };
 		3C07C209285C6F7600CC9469 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C07C208285C6F7600CC9469 /* Theme.swift */; };
+		F35BEAD60BF24C4BB0AED8CF /* AppStorageKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */; };
 		3C0E05CB2A53E5F500E7154F /* EventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0E05CA2A53E5F500E7154F /* EventDetailView.swift */; };
 		3C0E05CD2A53E6AD00E7154F /* GlobalSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0E05CC2A53E6AD00E7154F /* GlobalSearchView.swift */; };
 		3C0E05CF2A53E70200E7154F /* Searchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0E05CE2A53E70200E7154F /* Searchable.swift */; };
@@ -151,6 +152,7 @@
 		3C04BD9D2A5FDFD900D01402 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
 		3C04BD9F2A5FE91500D01402 /* FiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersView.swift; sourceTree = "<group>"; };
 		3C07C208285C6F7600CC9469 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageKeys.swift; sourceTree = "<group>"; };
 		3C0E05CA2A53E5F500E7154F /* EventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailView.swift; sourceTree = "<group>"; };
 		3C0E05CC2A53E6AD00E7154F /* GlobalSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchView.swift; sourceTree = "<group>"; };
 		3C0E05CE2A53E70200E7154F /* Searchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Searchable.swift; sourceTree = "<group>"; };
@@ -491,6 +493,7 @@
 				5DC0DE000000000000080001 /* NotesUtility.swift */,
 				3C0E05CE2A53E70200E7154F /* Searchable.swift */,
 				3C07C208285C6F7600CC9469 /* Theme.swift */,
+				B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -768,6 +771,7 @@
 				5D642D292A44A1960064492D /* ProductsView.swift in Sources */,
 				5DAE04B62820948B00930A2D /* ContentView.swift in Sources */,
 				3C07C209285C6F7600CC9469 /* Theme.swift in Sources */,
+				F35BEAD60BF24C4BB0AED8CF /* AppStorageKeys.swift in Sources */,
 				5DC0DE0000000000000000A1 /* Logger+HT.swift in Sources */,
 				5DC0DE0000000000000000B1 /* KFImage+HT.swift in Sources */,
 				5DC0DE0000000000000000C1 /* ClockService.swift in Sources */,

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -62,7 +62,6 @@
 		5D9E57492859037C001374D4 /* BookmarkUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E57482859037C001374D4 /* BookmarkUtility.swift */; };
 		5D9E5753285A3C25001374D4 /* SpeakersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E5752285A3C25001374D4 /* SpeakersView.swift */; };
 		5D9E5755285A3C86001374D4 /* SpeakerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E5754285A3C86001374D4 /* SpeakerRow.swift */; };
-		61AE145FB3CF4CEF9CD898DC /* ListChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C3F9C2929744A6948A2200 /* ListChrome.swift */; };
 		5D9E5759285A4710001374D4 /* SpeakerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E5758285A4710001374D4 /* SpeakerDetailView.swift */; };
 		5D9E575F285CFDF0001374D4 /* EventViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E575E285CFDF0001374D4 /* EventViewModel.swift */; };
 		5DA0F6962A741EA400A093B5 /* ConferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA0F6952A741EA400A093B5 /* ConferencesViewModel.swift */; };
@@ -127,6 +126,7 @@
 		5DF51AD8285155BC007BCB83 /* FAQ.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF51AD7285155BC007BCB83 /* FAQ.swift */; };
 		5DF51AE028526C0C007BCB83 /* UserEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF51ADF28526C0C007BCB83 /* UserEvent.swift */; };
 		5DF82B262A5F3B29001395C7 /* NotificationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF82B252A5F3B29001395C7 /* NotificationUtility.swift */; };
+		61AE145FB3CF4CEF9CD898DC /* ListChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C3F9C2929744A6948A2200 /* ListChrome.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -147,6 +147,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		39C3F9C2929744A6948A2200 /* ListChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListChrome.swift; sourceTree = "<group>"; };
 		3C04BD9D2A5FDFD900D01402 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
 		3C04BD9F2A5FE91500D01402 /* FiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersView.swift; sourceTree = "<group>"; };
 		3C07C208285C6F7600CC9469 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -199,7 +200,6 @@
 		5D9E57482859037C001374D4 /* BookmarkUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkUtility.swift; sourceTree = "<group>"; };
 		5D9E5752285A3C25001374D4 /* SpeakersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakersView.swift; sourceTree = "<group>"; };
 		5D9E5754285A3C86001374D4 /* SpeakerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerRow.swift; sourceTree = "<group>"; };
-		39C3F9C2929744A6948A2200 /* ListChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListChrome.swift; sourceTree = "<group>"; };
 		5D9E5758285A4710001374D4 /* SpeakerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerDetailView.swift; sourceTree = "<group>"; };
 		5D9E575E285CFDF0001374D4 /* EventViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventViewModel.swift; sourceTree = "<group>"; };
 		5DA0F6952A741EA400A093B5 /* ConferencesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferencesViewModel.swift; sourceTree = "<group>"; };
@@ -971,7 +971,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26062901;
+				CURRENT_PROJECT_VERSION = 26070501;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;
@@ -1011,7 +1011,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26062901;
+				CURRENT_PROJECT_VERSION = 26070501;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		5D9E57492859037C001374D4 /* BookmarkUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E57482859037C001374D4 /* BookmarkUtility.swift */; };
 		5D9E5753285A3C25001374D4 /* SpeakersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E5752285A3C25001374D4 /* SpeakersView.swift */; };
 		5D9E5755285A3C86001374D4 /* SpeakerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E5754285A3C86001374D4 /* SpeakerRow.swift */; };
+		61AE145FB3CF4CEF9CD898DC /* ListChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C3F9C2929744A6948A2200 /* ListChrome.swift */; };
 		5D9E5759285A4710001374D4 /* SpeakerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E5758285A4710001374D4 /* SpeakerDetailView.swift */; };
 		5D9E575F285CFDF0001374D4 /* EventViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9E575E285CFDF0001374D4 /* EventViewModel.swift */; };
 		5DA0F6962A741EA400A093B5 /* ConferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA0F6952A741EA400A093B5 /* ConferencesViewModel.swift */; };
@@ -198,6 +199,7 @@
 		5D9E57482859037C001374D4 /* BookmarkUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkUtility.swift; sourceTree = "<group>"; };
 		5D9E5752285A3C25001374D4 /* SpeakersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakersView.swift; sourceTree = "<group>"; };
 		5D9E5754285A3C86001374D4 /* SpeakerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerRow.swift; sourceTree = "<group>"; };
+		39C3F9C2929744A6948A2200 /* ListChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListChrome.swift; sourceTree = "<group>"; };
 		5D9E5758285A4710001374D4 /* SpeakerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerDetailView.swift; sourceTree = "<group>"; };
 		5D9E575E285CFDF0001374D4 /* EventViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventViewModel.swift; sourceTree = "<group>"; };
 		5DA0F6952A741EA400A093B5 /* ConferencesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferencesViewModel.swift; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 				3CD532DE2A29AC33009D17F3 /* ShareView.swift */,
 				5D9E5758285A4710001374D4 /* SpeakerDetailView.swift */,
 				5D9E5754285A3C86001374D4 /* SpeakerRow.swift */,
+				39C3F9C2929744A6948A2200 /* ListChrome.swift */,
 				5D9E5752285A3C25001374D4 /* SpeakersView.swift */,
 				3CE59E3A285B3ACD00B453C9 /* ViewModifiers.swift */,
 			);
@@ -724,6 +727,7 @@
 				3C04BD9E2A5FDFD900D01402 /* Filters.swift in Sources */,
 				5D9E5759285A4710001374D4 /* SpeakerDetailView.swift in Sources */,
 				5D9E5755285A3C86001374D4 /* SpeakerRow.swift in Sources */,
+				61AE145FB3CF4CEF9CD898DC /* ListChrome.swift in Sources */,
 				5D9E57492859037C001374D4 /* BookmarkUtility.swift in Sources */,
 				5DF51AC928514F33007BCB83 /* Article.swift in Sources */,
 				5DF51AD8285155BC007BCB83 /* FAQ.swift in Sources */,

--- a/hackertracker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/hackertracker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
-        "version" : "1.2024011602.0"
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
-        "version" : "10.19.2"
+        "revision" : "bb4002485ff867768dec13bf904a2ddb050bd1b1",
+        "version" : "11.3.0"
       }
     },
     {
@@ -24,8 +24,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
-        "version" : "10.29.0"
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
       }
     },
     {
@@ -33,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
-        "version" : "10.28.0"
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
       }
     },
     {
@@ -42,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
-        "version" : "9.4.0"
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
       }
     },
     {
@@ -51,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
-        "version" : "7.13.3"
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
       }
     },
     {
@@ -60,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
-        "version" : "1.62.2"
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
       }
     },
     {
@@ -78,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
       "state" : {
-        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
-        "version" : "100.0.0"
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
       }
     },
     {

--- a/hackertracker/Models/Conference.swift
+++ b/hackertracker/Models/Conference.swift
@@ -7,6 +7,7 @@
 
 import FirebaseFirestore
 import Foundation
+import SwiftUI
 
 struct Conference: Codable, Identifiable, Equatable {
     static func == (lhs: Conference, rhs: Conference) -> Bool {
@@ -36,6 +37,10 @@ struct Conference: Codable, Identifiable, Equatable {
     var merchMandatoryAck: String?
     var merchTaxStatement: String?
     var emergencyDocId: Int?
+    /// Optional per-conference branding assets. Each entry carries
+    /// `dark` and/or `light` variants — the picker resolves which to
+    /// show based on the active color scheme.
+    var media: [ConferenceMediaEntry]?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -60,5 +65,49 @@ struct Conference: Codable, Identifiable, Equatable {
         case merchMandatoryAck = "merch_mandatory_acknowledgement"
         case merchTaxStatement = "merch_tax_statement"
         case emergencyDocId = "emergency_document_id"
+        case media
+    }
+
+    /// First square-logo URL string available for the requested
+    /// appearance, falling back to the opposite variant if the
+    /// requested one isn't published. Returns nil when no media is
+    /// configured at all.
+    func squareLogo(for colorScheme: ColorScheme) -> String? {
+        guard let media, !media.isEmpty else { return nil }
+        let preferred: (ConferenceMediaEntry) -> String? = {
+            colorScheme == .dark
+                ? { $0.dark?.squareLogo }
+                : { $0.light?.squareLogo }
+        }()
+        let fallback: (ConferenceMediaEntry) -> String? = {
+            colorScheme == .dark
+                ? { $0.light?.squareLogo }
+                : { $0.dark?.squareLogo }
+        }()
+        if let hit = media.compactMap(preferred).first(where: { !$0.isEmpty }) {
+            return hit
+        }
+        return media.compactMap(fallback).first(where: { !$0.isEmpty })
+    }
+}
+
+/// One entry in `Conference.media`. Either side may be missing — a
+/// conference may publish only a dark logo, only a light one, or
+/// both. Field names match the Firestore document
+/// (banner_background, banner_logo, square_logo).
+struct ConferenceMediaEntry: Codable, Equatable {
+    var dark: ConferenceMediaImages?
+    var light: ConferenceMediaImages?
+}
+
+struct ConferenceMediaImages: Codable, Equatable {
+    var bannerBackground: String?
+    var bannerLogo: String?
+    var squareLogo: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case bannerBackground = "banner_background"
+        case bannerLogo = "banner_logo"
+        case squareLogo = "square_logo"
     }
 }

--- a/hackertracker/Models/Conference.swift
+++ b/hackertracker/Models/Conference.swift
@@ -37,10 +37,10 @@ struct Conference: Codable, Identifiable, Equatable {
     var merchMandatoryAck: String?
     var merchTaxStatement: String?
     var emergencyDocId: Int?
-    /// Optional per-conference branding assets. Each entry carries
-    /// `dark` and/or `light` variants — the picker resolves which to
-    /// show based on the active color scheme.
-    var media: [ConferenceMediaEntry]?
+    /// Optional per-conference branding assets. Carries `dark` and/or
+    /// `light` variants — the picker resolves which to show based on
+    /// the active color scheme.
+    var media: ConferenceMediaEntry?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -73,26 +73,17 @@ struct Conference: Codable, Identifiable, Equatable {
     /// requested one isn't published. Returns nil when no media is
     /// configured at all.
     func squareLogo(for colorScheme: ColorScheme) -> String? {
-        guard let media, !media.isEmpty else { return nil }
-        let preferred: (ConferenceMediaEntry) -> String? = {
-            colorScheme == .dark
-                ? { $0.dark?.squareLogo }
-                : { $0.light?.squareLogo }
-        }()
-        let fallback: (ConferenceMediaEntry) -> String? = {
-            colorScheme == .dark
-                ? { $0.light?.squareLogo }
-                : { $0.dark?.squareLogo }
-        }()
-        if let hit = media.compactMap(preferred).first(where: { !$0.isEmpty }) {
-            return hit
-        }
-        return media.compactMap(fallback).first(where: { !$0.isEmpty })
+        guard let media else { return nil }
+        let preferred = colorScheme == .dark ? media.dark?.squareLogo : media.light?.squareLogo
+        if let preferred, !preferred.isEmpty { return preferred }
+        let fallback = colorScheme == .dark ? media.light?.squareLogo : media.dark?.squareLogo
+        if let fallback, !fallback.isEmpty { return fallback }
+        return nil
     }
 }
 
-/// One entry in `Conference.media`. Either side may be missing — a
-/// conference may publish only a dark logo, only a light one, or
+/// Per-conference branding assets. Either side may be missing — a
+/// conference may publish only a dark variant, only a light one, or
 /// both. Field names match the Firestore document
 /// (banner_background, banner_logo, square_logo).
 struct ConferenceMediaEntry: Codable, Equatable {

--- a/hackertracker/Utils/AppStorageKeys.swift
+++ b/hackertracker/Utils/AppStorageKeys.swift
@@ -1,0 +1,42 @@
+//
+//  AppStorageKeys.swift
+//  hackertracker
+//
+
+import Foundation
+
+/// Central registry of `@AppStorage` / `UserDefaults` key strings used throughout the app.
+///
+/// All persisted preference keys should be referenced via these constants instead of
+/// raw string literals. This gives compile-time checking (a typo becomes a build error
+/// rather than silently creating a brand-new, disconnected setting) and makes it possible
+/// to find every read/write site for a given key with a single "Find Usages".
+///
+/// The string VALUE of each constant must remain byte-identical to the original literal —
+/// these are persisted `UserDefaults` keys, and changing a value would orphan users'
+/// previously saved settings.
+enum AppStorageKeys {
+    static let colorMode = "colorMode"
+    static let notifyAt = "notifyAt"
+    static let showLocaltime = "showLocaltime"
+    static let show24hourtime = "show24hourtime"
+    static let filterMatchMode = "filterMatchMode"
+    static let easterEgg = "easterEgg"
+    static let aiSummaries = "aiSummaries"
+    static let showNews = "showNews"
+    static let showMerchInfo = "showMerchInfo"
+    static let lightMode = "lightMode"
+    static let conferenceCode = "conferenceCode"
+    static let speakerAISummaries = "speakerAISummaries"
+    static let showPastEvents = "showPastEvents"
+    static let showHidden = "showHidden"
+    static let showCustomEvents = "showCustomEvents"
+    static let showConflictAlert = "showConflictAlert"
+    static let launchScreen = "launchScreen"
+    static let filterMatchModeSpeakers = "filterMatchModeSpeakers"
+    static let filterMatchModeMerch = "filterMatchModeMerch"
+    static let easterEggPeriod = "easterEggPeriod"
+    static let easterEggMaxOpacity = "easterEggMaxOpacity"
+    static let lastMapIndex = "lastMapIndex"
+    static let infoLogoCollapsedCodes = "infoLogoCollapsedCodes"
+}

--- a/hackertracker/Utils/CustomEventUtility.swift
+++ b/hackertracker/Utils/CustomEventUtility.swift
@@ -19,13 +19,13 @@ enum CustomEventUtility {
     /// Schedule or refresh a notification for the supplied event.
     /// No-op when notificationsEnabled is false or when the event
     /// is missing required fields. Uses the global "Before Event"
-    /// minutes setting (@AppStorage("notifyAt")), defaulting to 20
+    /// minutes setting (@AppStorage(AppStorageKeys.notifyAt)), defaulting to 20
     /// to match the rest of the app.
     private static func scheduleNotificationIfNeeded(_ event: CustomEvent) {
         guard event.notificationsEnabled,
               let begin = event.beginTimestamp,
               let title = event.title else { return }
-        let notifyAt = UserDefaults.standard.object(forKey: "notifyAt") as? Int ?? 20
+        let notifyAt = UserDefaults.standard.object(forKey: AppStorageKeys.notifyAt) as? Int ?? 20
         let date = begin.addingTimeInterval(Double(-notifyAt) * 60)
         let id = notificationID(for: event)
         let location = event.location ?? ""

--- a/hackertracker/Utils/DateFormatterUtility.swift
+++ b/hackertracker/Utils/DateFormatterUtility.swift
@@ -73,7 +73,7 @@ class DateFormatterUtility {
     }
 
     func preferLocalTime() -> Bool {
-        UserDefaults.standard.bool(forKey: "showLocaltime")
+        UserDefaults.standard.bool(forKey: AppStorageKeys.showLocaltime)
     }
 
     // time format

--- a/hackertracker/Utils/ModelExt.swift
+++ b/hackertracker/Utils/ModelExt.swift
@@ -84,7 +84,7 @@ enum PseudoTagID {
     static let all: Set<Int> = [bookmarks, customEvents, hasNotes]
 }
 
-/// Filter-chip composition mode. Read from @AppStorage("filterMatchMode")
+/// Filter-chip composition mode. Read from @AppStorage(AppStorageKeys.filterMatchMode)
 /// by FiltersView (writes) and the predicate consumers (reads). Storing
 /// the raw string lets us swap it cleanly via @AppStorage on multiple
 /// independent views without an envelope object.

--- a/hackertracker/Utils/ModelExt.swift
+++ b/hackertracker/Utils/ModelExt.swift
@@ -168,12 +168,17 @@ extension [Event] {
         // Phase 4: single source of truth in ClockService; no more hardcoded LA fallback.
         formatter.timeZone = ClockService.resolveTimeZone(conference: conference, showLocaltime: showLocaltime)
         
+        // Perf D: sort each day's events once here so consumers
+        // (EventData's ForEach, the scroll-command handlers) can
+        // iterate directly instead of re-sorting per render.
         let eventDict = Dictionary(
             grouping: self,
             by: {
                 formatter.string(from: $0.beginTimestamp)
             }
-        )
+        ).mapValues { day in
+            day.sorted { $0.beginTimestamp < $1.beginTimestamp }
+        }
         return eventDict.sorted {
             ($0.value.first?.beginTimestamp ?? Date()) < ($1.value.first?.beginTimestamp ?? Date())
         }

--- a/hackertracker/Utils/NotificationUtility.swift
+++ b/hackertracker/Utils/NotificationUtility.swift
@@ -82,9 +82,20 @@ enum NotificationUtility {
     } */
     
     static func scheduleNotification(date: Date, id: Int, title: String, location: String) {
+        // Bugfix: without .year, UNCalendarNotificationTrigger matches the next
+        // occurrence of month/day/hour/minute — if `date` is already in the past
+        // (bookmarking an in-progress event, or browsing a past conference) the
+        // trigger silently fires ~12 months later instead of not firing at all.
+        // Guard against scheduling anything that's already elapsed, and include
+        // .year so a future date actually fires on the intended year.
+        guard date > Date.now else {
+            Log.notifications.debug("skipping notification for id \(id, privacy: .public): date already in the past")
+            return
+        }
+
         let calendar = Calendar(identifier: .gregorian)
         let components = calendar.dateComponents(in: .current, from: date)
-        let newComponents = DateComponents(calendar: calendar, timeZone: .current, month: components.month, day: components.day, hour: components.hour, minute: components.minute)
+        let newComponents = DateComponents(calendar: calendar, timeZone: .current, year: components.year, month: components.month, day: components.day, hour: components.hour, minute: components.minute)
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: newComponents, repeats: false)
 

--- a/hackertracker/Utils/PDFView.swift
+++ b/hackertracker/Utils/PDFView.swift
@@ -161,18 +161,55 @@ struct PDFView: UIViewRepresentable {
     }
 }
 
-/// Process-lifetime cache for parsed `PDFDocument`s, keyed by absolute path.
-/// Maps don't change at runtime, so once parsed they stay in memory until
-/// the app is killed. Conferences ship with only a handful of maps, so the
-/// memory cost is negligible compared to re-parsing on every swipe.
+/// Process-lifetime LRU cache for parsed `PDFDocument`s, keyed by absolute path.
+/// Maps don't change at runtime, so once parsed they're reused to avoid re-parsing.
+/// An LRU eviction policy prevents unbounded memory growth when the user visits
+/// multiple conferences with many maps (each conference's maps and prewarmed neighbors
+/// are retained; old conferences' maps are evicted as new ones are accessed).
+///
+/// Capacity is 12 documents: typically a conference has 1-4 maps, and prewarming
+/// loads the current page plus adjacent pages in the TabView (3 simultaneous). With
+/// 12 slots, a user can visit 3+ conferences and maintain responsive map access
+/// for the current + 2 neighbor pages without unbounded growth.
 @MainActor
 final class PDFDocumentCache {
     static let shared = PDFDocumentCache()
-    private var storage: [URL: PDFDocument] = [:]
+
+    /// Maximum number of PDFDocuments to retain. When the cache fills beyond
+    /// this, the least-recently-used document is evicted on the next insertion.
+    private static let capacityLimit = 12
+
+    /// Ordered list of (URL, document) pairs; index 0 is LRU, end is MRU.
+    /// Using a small array keeps append/remove O(n) but n is small (≤12).
+    private var lruOrder: [(URL, PDFDocument)] = []
 
     subscript(url: URL) -> PDFDocument? {
-        get { storage[url] }
-        set { storage[url] = newValue }
+        get {
+            // Find and move to MRU (end of array)
+            if let index = lruOrder.firstIndex(where: { $0.0 == url }) {
+                let item = lruOrder.remove(at: index)
+                lruOrder.append(item)
+                return item.1
+            }
+            return nil
+        }
+        set {
+            if let newValue {
+                // Remove existing entry with this URL if present
+                lruOrder.removeAll { $0.0 == url }
+
+                // Evict LRU (first element) if at capacity
+                if lruOrder.count >= Self.capacityLimit {
+                    lruOrder.removeFirst()
+                }
+
+                // Insert at MRU (end)
+                lruOrder.append((url, newValue))
+            } else {
+                // Explicit nil assignment removes the entry
+                lruOrder.removeAll { $0.0 == url }
+            }
+        }
     }
 
     /// Synchronously parse and cache `url` if not already cached. Safe to

--- a/hackertracker/Utils/Searchable.swift
+++ b/hackertracker/Utils/Searchable.swift
@@ -30,16 +30,16 @@ extension [Event] {
     /// Build a per-call id->name index and match against it.
     func search(text: String, speakers: [Speaker]) -> Self {
         guard !text.isEmpty else { return self }
-        let needle = text.lowercased()
+        let needle = text
         // Index speaker names once per call instead of O(events * speakers).
         let speakerNameById: [Int: String] = Dictionary(
-            uniqueKeysWithValues: speakers.map { ($0.id, $0.name.lowercased()) }
+            uniqueKeysWithValues: speakers.map { ($0.id, $0.name) }
         )
         return self.filter { event in
-            if event.title.lowercased().contains(needle) { return true }
-            if event.description.lowercased().contains(needle) { return true }
+            if _searchMatches(event.title, needle: needle) { return true }
+            if _searchMatches(event.description, needle: needle) { return true }
             for person in event.people {
-                if let name = speakerNameById[person.id], name.contains(needle) {
+                if let name = speakerNameById[person.id], _searchMatches(name, needle: needle) {
                     return true
                 }
             }

--- a/hackertracker/Utils/TalkSummaryCache.swift
+++ b/hackertracker/Utils/TalkSummaryCache.swift
@@ -91,28 +91,35 @@ final class TalkSummaryCache {
     /// the queue isn't tied to either model type's lifecycle.
     @ObservationIgnored private var pending: [(key: String, description: String, kind: SummaryKind)] = []
 
+    /// Cap on the pending queue. Scroll-driven pre-warms can enqueue
+    /// far more items than we'll ever get to; without a bound this
+    /// retains full description strings indefinitely and keeps
+    /// scheduling stale work long after the user has scrolled away.
+    /// When full, the oldest (least likely to still be on-screen)
+    /// entry is dropped to make room for the newest.
+    private let maxPending = 64
+
+    @ObservationIgnored private var persistTask: Task<Void, Never>?
+    @ObservationIgnored private var dirty = false
+
     private init() {
         load()
     }
 
     // MARK: - Public API
 
-    /// Returns the cached summary for `content` if we have one whose
-    /// description hash matches the current description. Returns nil
-    /// when there's no summary yet OR when the description has
-    /// changed since we last summarized (the stale entry is dropped
-    /// to force a re-warm).
+    /// Returns the cached summary for `content`, or nil if we don't
+    /// have one yet. This is a plain dictionary lookup by
+    /// `summaryCacheKey` — it deliberately does NOT hash the
+    /// description, since it's on the hot render path (called from
+    /// cell bodies on every scroll/redraw). Staleness detection
+    /// (hashing the description to notice server-side edits) happens
+    /// only in `warm(_:)`, which runs far less often, so a stale
+    /// summary can be returned here for at most one warm cycle before
+    /// `warm` drops and regenerates it.
     func summary(for item: any SummarizableTalk) -> String? {
         let key = item.summaryCacheKey
-        guard let entry = memory[key] else { return nil }
-        let currentHash = Self.stableHash(item.description)
-        if entry.descriptionHash == currentHash {
-            return entry.summary
-        }
-        // Description changed -> stale. Drop and let the next warm refill.
-        memory.removeValue(forKey: key)
-        persist()
-        return nil
+        return memory[key]?.summary
     }
 
     /// Minimum description length that warrants summarization.
@@ -131,12 +138,25 @@ final class TalkSummaryCache {
         guard AISummaryAvailability.isSupported else { return }
         let trimmed = item.description.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.count >= minDescriptionChars else { return }
-        guard summary(for: item) == nil else { return }
         let key = item.summaryCacheKey
+        if let entry = memory[key] {
+            // Only hash here, on the warm/write path, not on every
+            // render-time read — description hashing is comparatively
+            // expensive and reads happen far more often than warms.
+            if entry.descriptionHash == Self.stableHash(item.description) {
+                return
+            }
+            // Description changed -> stale. Drop and fall through to re-warm.
+            memory.removeValue(forKey: key)
+            markDirty()
+        }
         guard inflight[key] == nil else { return }
 
         if inflight.count >= maxConcurrent {
             if !pending.contains(where: { $0.key == key }) {
+                if pending.count >= maxPending {
+                    pending.removeFirst()
+                }
                 pending.append((key, item.description, item.summaryKind))
             }
             return
@@ -182,7 +202,7 @@ final class TalkSummaryCache {
                 )
                 self?.memory[key] = entry
                 self?.prune()
-                self?.persist()
+                self?.markDirty()
                 Log.app.debug("AI summary OK for \(key, privacy: .public): \(summary, privacy: .public)")
             } catch {
                 Log.app.debug("AI summary failed for \(key, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -280,6 +300,34 @@ final class TalkSummaryCache {
         }
         // Corrupt payload — drop it.
         UserDefaults.standard.removeObject(forKey: Self.defaultsKey)
+    }
+
+    /// Marks the cache dirty and schedules a coalesced flush a short
+    /// while later. Re-entering this while a flush is already pending
+    /// just extends the debounce — a warm sweep that touches dozens of
+    /// entries in quick succession ends up doing one encode instead of
+    /// one per entry. `flush()` is still available for callers that
+    /// need the write to happen immediately (e.g. going to background).
+    private func markDirty() {
+        dirty = true
+        persistTask?.cancel()
+        persistTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            guard !Task.isCancelled else { return }
+            self?.flush()
+        }
+    }
+
+    /// Immediately writes the cache to UserDefaults if there are
+    /// unsaved changes, bypassing the debounce. Safe to call at any
+    /// time (e.g. scenePhase -> .background) as a belt-and-suspenders
+    /// flush so a debounced write in flight is never lost.
+    func flush() {
+        persistTask?.cancel()
+        persistTask = nil
+        guard dirty else { return }
+        dirty = false
+        persist()
     }
 
     private func persist() {

--- a/hackertracker/Utils/Theme.swift
+++ b/hackertracker/Utils/Theme.swift
@@ -7,39 +7,11 @@
 
 import SwiftUI
 
-class Theme: ObservableObject {
-    @AppStorage("lightMode") var lightMode: Bool = false
-    @Published var colorScheme: ColorScheme = .dark
-
-    let colors = ["#326295", "#71cc98", "#c16784", "#4b9560", "#c04c36"]
-    let font = ThemeFont()
-    var index = 0
-    
-    init() {
-        if lightMode {
-            self.colorScheme = .light
-        } else {
-            self.colorScheme = .dark
-        }
-    }
-
-    func carousel() -> Color {
-        if index >= colors.count {
-            index = 0
-        }
-
-        let color = colors[index]
-        index += 1
-
-        return Color(UIColor(hex: color) ?? .purple)
-    }
-}
-
-struct ThemeFont {
-    let bold = "Futura Bold"
-    let regular = "Futura Medium"
-    let italic = "Futura Medium Italic"
-}
+// The legacy `Theme` ObservableObject (colorScheme flag + impure
+// carousel() color cycler + unused Futura ThemeFont) is gone — its
+// responsibilities folded into ThemeManager below: lightMode /
+// preferredColorScheme for the app-wide scheme, carouselColor(index:)
+// for the colorful-mode card palette.
 
 enum ThemeColors {
     static let pink = hexSwiftUIColor(hex: "#c16784")
@@ -522,14 +494,58 @@ enum ThemeMetrics {
 @MainActor
 final class ThemeManager {
     private static let userDefaultsKey = "themeID"
+    private static let lightModeKey = "lightMode"
 
     /// Backing storage. @Observable tracks reads + writes of this.
     private var storedID: String
 
+    /// Light/dark selection, folded in from the legacy `Theme` class.
+    /// Same hand-rolled persistence pattern as `storedID` (see the
+    /// header comment): plain stored property for observation, synced
+    /// to UserDefaults under the SAME "lightMode" key the old system
+    /// used so existing user settings carry over.
+    private var storedLightMode: Bool
+
     init() {
         self.storedID = UserDefaults.standard.string(forKey: ThemeManager.userDefaultsKey)
             ?? AppTheme.default.id
+        self.storedLightMode = UserDefaults.standard.bool(forKey: ThemeManager.lightModeKey)
         applyNavBarAppearance()
+    }
+
+    /// App-wide color scheme. The app intentionally never returns nil
+    /// (system-follow) — dark unless the user opted into light mode,
+    /// matching the legacy Theme behavior.
+    var preferredColorScheme: ColorScheme {
+        storedLightMode ? .light : .dark
+    }
+
+    /// Flip light mode. The SettingsView Toggle binds its own
+    /// @AppStorage("lightMode") for UI state and calls this in
+    /// onChange so observation fires app-wide.
+    func setLightMode(_ on: Bool) {
+        storedLightMode = on
+        UserDefaults.standard.set(on, forKey: ThemeManager.lightModeKey)
+    }
+
+    /// Colorful-mode card palette, folded in from the legacy
+    /// `Theme.carousel()`. That version mutated a shared index per
+    /// call, so card colors depended on render order; this is pure —
+    /// pass the card's stable position and it always gets the same
+    /// color.
+    private static let carouselColors = ["#326295", "#71cc98", "#c16784", "#4b9560", "#c04c36"]
+    func carouselColor(index: Int) -> Color {
+        let colors = ThemeManager.carouselColors
+        let hex = colors[((index % colors.count) + colors.count) % colors.count]
+        return Color(UIColor(hex: hex) ?? .purple)
+    }
+
+    /// Carousel color for a String-keyed model (e.g. Organization,
+    /// whose `id` is a Firestore `@DocumentID String?`). Derives a
+    /// stable, launch-independent index from the key's scalars so the
+    /// same org always gets the same tint.
+    func carouselColor(forKey key: String) -> Color {
+        carouselColor(index: key.unicodeScalars.reduce(0) { $0 + Int($1.value) })
     }
 
     /// The currently active theme. Falls back to the default if the

--- a/hackertracker/Utils/Theme.swift
+++ b/hackertracker/Utils/Theme.swift
@@ -113,6 +113,7 @@ struct ThemePalette: Hashable {
     let background: DualColor    // base screen background — shows below cards
     let cardSurface: DualColor   // standout-button and detail-card fill
     let accent: DualColor         // primary tinted action color
+    let success: DualColor        // active, selected, positive affordances
     let danger: DualColor         // warnings, conflicts, destructive
     let textPrimary: DualColor    // headings + body text
     let textSecondary: DualColor  // metadata + captions
@@ -163,6 +164,10 @@ extension AppTheme {
             accent: DualColor(
                 light: Color(.systemBlue),
                 dark:  Color(.systemBlue)
+            ),
+            success: DualColor(
+                light: Color(.systemGreen),
+                dark:  Color(.systemGreen)
             ),
             danger: DualColor(
                 light: ThemeColors.red,
@@ -216,6 +221,10 @@ extension AppTheme {
             accent: DualColor(
                 light: Color(red: 0/255,   green: 140/255, blue: 50/255),  // #008C32 (readable on white)
                 dark:  Color(red: 0/255,   green: 255/255, blue: 65/255)   // #00FF41 (matrix green)
+            ),
+            success: DualColor(
+                light: Color(red: 0/255,   green: 140/255, blue: 50/255),  // #008C32
+                dark:  Color(red: 0/255,   green: 255/255, blue: 65/255)   // #00FF41
             ),
             danger: DualColor(
                 light: ThemeColors.red,
@@ -274,6 +283,10 @@ extension AppTheme {
                 light: Color(red: 200/255, green: 0/255,   blue: 150/255), // deep magenta
                 dark:  Color(red: 255/255, green: 64/255,  blue: 200/255)  // neon magenta
             ),
+            success: DualColor(
+                light: Color(red: 200/255, green: 0/255,   blue: 150/255), // deep magenta
+                dark:  Color(red: 255/255, green: 64/255,  blue: 200/255)  // neon magenta
+            ),
             danger: DualColor(
                 light: ThemeColors.red,
                 dark:  ThemeColors.red
@@ -329,6 +342,10 @@ extension AppTheme {
                 light: Color(red: 192/255, green: 0/255,   blue: 0/255),   // #C00000
                 dark:  Color(red: 255/255, green: 45/255,  blue: 45/255)   // #FF2D2D
             ),
+            success: DualColor(
+                light: Color(red: 192/255, green: 0/255,   blue: 0/255),   // #C00000
+                dark:  Color(red: 255/255, green: 45/255,  blue: 45/255)   // #FF2D2D
+            ),
             danger: DualColor(
                 light: Color(red: 178/255, green: 34/255,  blue: 34/255),  // #B22222
                 dark:  Color(red: 255/255, green: 69/255,  blue: 0/255)    // #FF4500
@@ -378,6 +395,10 @@ extension AppTheme {
                 dark:  Color(red: 14/255,  green: 20/255,  blue: 40/255)   // #0E1428
             ),
             accent: DualColor(
+                light: Color(red: 0/255,   green: 139/255, blue: 139/255), // #008B8B
+                dark:  Color(red: 0/255,   green: 255/255, blue: 255/255)  // #00FFFF
+            ),
+            success: DualColor(
                 light: Color(red: 0/255,   green: 139/255, blue: 139/255), // #008B8B
                 dark:  Color(red: 0/255,   green: 255/255, blue: 255/255)  // #00FFFF
             ),
@@ -433,6 +454,10 @@ extension AppTheme {
                 light: Color(red: 199/255, green: 21/255,  blue: 133/255), // #C71585
                 dark:  Color(red: 255/255, green: 20/255,  blue: 147/255)  // #FF1493
             ),
+            success: DualColor(
+                light: Color(red: 199/255, green: 21/255,  blue: 133/255), // #C71585
+                dark:  Color(red: 255/255, green: 20/255,  blue: 147/255)  // #FF1493
+            ),
             danger: DualColor(
                 light: Color(red: 178/255, green: 34/255,  blue: 34/255),  // #B22222
                 dark:  Color(red: 255/255, green: 69/255,  blue: 0/255)    // #FF4500
@@ -473,6 +498,14 @@ extension AppTheme {
 enum ThemeRegistry {
     static let all: [AppTheme] = [.default, .hackerGreen, .synthwave, .defconRed, .cyberpunk, .vegas]
     static let fallback: AppTheme = .default
+}
+
+/// Spacing and sizing tokens for consistent layout across themes.
+enum ThemeMetrics {
+    /// Standard corner radius for card surfaces and semantic containers.
+    /// Note: InfoView cards use 15 and small buttons use 5 — those are
+    /// intentional design choices and left unchanged.
+    static let cardRadius: CGFloat = 10
 }
 
 /// Observable holder for the active theme. Read by views via
@@ -579,6 +612,7 @@ final class ThemeManager {
     var background: Color     { current.palette.background.auto }
     var cardSurface: Color    { current.palette.cardSurface.auto }
     var accent: Color         { current.palette.accent.auto }
+    var success: Color        { current.palette.success.auto }
     var danger: Color         { current.palette.danger.auto }
     var textPrimary: Color    { current.palette.textPrimary.auto }
     var textSecondary: Color  { current.palette.textSecondary.auto }
@@ -603,6 +637,8 @@ final class ThemeManager {
     var headingFont: Font     { current.typography.heading }
     var subheadlineFont: Font { current.typography.subheadline }
     var bodyFont: Font        { current.typography.body }
+    var calloutFont: Font     { .system(.callout, design: fontDesign == .monospaced ? .monospaced : fontDesign == .rounded ? .rounded : .default) }
+    var footnoteFont: Font    { current.typography.caption }
     var captionFont: Font     { current.typography.caption }
     var monospaceFont: Font   { current.typography.monospace }
 }

--- a/hackertracker/Utils/Theme.swift
+++ b/hackertracker/Utils/Theme.swift
@@ -494,7 +494,7 @@ enum ThemeMetrics {
 @MainActor
 final class ThemeManager {
     private static let userDefaultsKey = "themeID"
-    private static let lightModeKey = "lightMode"
+    private static let lightModeKey = AppStorageKeys.lightMode
 
     /// Backing storage. @Observable tracks reads + writes of this.
     private var storedID: String
@@ -521,7 +521,7 @@ final class ThemeManager {
     }
 
     /// Flip light mode. The SettingsView Toggle binds its own
-    /// @AppStorage("lightMode") for UI state and calls this in
+    /// @AppStorage(AppStorageKeys.lightMode) for UI state and calls this in
     /// onChange so observation fires app-wide.
     func setLightMode(_ on: Bool) {
         storedLightMode = on

--- a/hackertracker/Utils/iPadAdaptive.swift
+++ b/hackertracker/Utils/iPadAdaptive.swift
@@ -228,3 +228,54 @@ extension EnvironmentValues {
         set { self[NoteContentIDsKey.self] = newValue }
     }
 }
+
+// MARK: - Bookmark plumbing
+//
+// Perf C: EventCell used to own a per-row @FetchRequest on Bookmarks
+// and rebuild id sets/arrays on every render. Same parent-publishes-
+// into-env pattern as the Notes badge above: the list-level view that
+// already holds a Bookmarks FetchRequest (EventsView, GlobalSearchView,
+// InfoView's shared-schedule pane) computes one snapshot and publishes
+// it; cells read the value directly.
+
+/// Immutable snapshot of the user's bookmarks, precomputed once per
+/// parent render for the shapes cells actually need.
+struct BookmarkSnapshot: Equatable {
+    /// Bookmarked event ids for O(1) membership checks.
+    let ids: Set<Int32>
+    /// The same ids as Int, in fetch order, for the conflict checker.
+    let conflictIds: [Int]
+    /// Precomputed identity of `conflictIds` (same hash the old code
+    /// derived per call) so InfoViewModel.bookmarkConflicts doesn't
+    /// re-hash the array on every invocation.
+    let conflictKey: Int
+
+    init(bookmarkIds: [Int32]) {
+        var idSet: Set<Int32> = []
+        idSet.reserveCapacity(bookmarkIds.count)
+        var ints: [Int] = []
+        ints.reserveCapacity(bookmarkIds.count)
+        var hasher = Hasher()
+        for id in bookmarkIds {
+            idSet.insert(id)
+            ints.append(Int(id))
+            hasher.combine(Int(id))
+        }
+        ids = idSet
+        conflictIds = ints
+        conflictKey = hasher.finalize()
+    }
+
+    static let empty = BookmarkSnapshot(bookmarkIds: [])
+}
+
+private struct BookmarkSnapshotKey: EnvironmentKey {
+    static let defaultValue: BookmarkSnapshot = .empty
+}
+
+extension EnvironmentValues {
+    var bookmarkSnapshot: BookmarkSnapshot {
+        get { self[BookmarkSnapshotKey.self] }
+        set { self[BookmarkSnapshotKey.self] = newValue }
+    }
+}

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -20,20 +20,6 @@ import SwiftUI
 // `Task { @MainActor in ... }` for the actual array assignment. This closes
 // the SwiftUI "Publishing changes from background threads" warning surface
 // and is a prerequisite for Swift 6 strict concurrency.
-/// Firestore's `QueryDocumentSnapshot` (and the `[QueryDocumentSnapshot]` arrays
-/// handed to snapshot listener closures) are not declared `Sendable` in the
-/// firebase-ios-sdk version this project pins (10.29.0), even though the
-/// underlying ObjC snapshot objects are immutable, thread-safe-to-read value
-/// snapshots — decoding one on a background thread is exactly what Firebase's
-/// own `data(as:)` does under the hood and is safe regardless of which thread
-/// calls it. This box exists solely to carry such an array across the
-/// `Task.detached` boundary for the off-main decode in fetchContent/fetchSpeakers
-/// without asserting a blanket, unverifiable Sendable conformance on Firebase's
-/// own types.
-private struct UncheckedSendableBox<Value>: @unchecked Sendable {
-    let value: Value
-}
-
 @Observable
 @MainActor
 final class InfoViewModel {
@@ -586,17 +572,16 @@ final class InfoViewModel {
                 // Phase perf: DEF CON has 1000+ content docs, so the Codable
                 // decode + event rebuild below is expensive enough to cause a
                 // visible main-thread stall if done inline in this listener
-                // closure (which Firestore invokes on the main queue). Box the
-                // [QueryDocumentSnapshot] (not Sendable in this SDK version, but
-                // safe to read off-main — see UncheckedSendableBox) and hop to a
+                // closure (which Firestore invokes on the main queue). Hop to a
                 // detached task to do the heavy lifting off-main; only the
                 // final array assignment comes back to the MainActor.
                 self.contentGeneration += 1
                 let generation = self.contentGeneration
-                let boxedDocs = UncheckedSendableBox(value: docs)
 
+                // firebase-ios-sdk 11.3+ declares QueryDocumentSnapshot
+                // Sendable, so the docs array crosses the Task.detached
+                // boundary directly — no @unchecked box needed.
                 Task.detached(priority: .userInitiated) { [weak self] in
-                    let docs = boxedDocs.value
                     var cache = 0
                     var firestore = 0
                     // Phase 1 fix: previously `self.events = []` lived inside the per-document
@@ -666,10 +651,8 @@ final class InfoViewModel {
                 // in full on every snapshot tick.
                 self.speakerGeneration += 1
                 let generation = self.speakerGeneration
-                let boxedDocs = UncheckedSendableBox(value: docs)
 
                 Task.detached(priority: .userInitiated) { [weak self] in
-                    let docs = boxedDocs.value
                     var cache = 0
                     var firestore = 0
                     var decodedSpeakers: [Speaker] = docs.compactMap { queryDocumentSnapshot -> Speaker? in

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -140,10 +140,17 @@ final class InfoViewModel {
     @ObservationIgnored private var db = Firestore.firestore()
     
     func bookmarkConflicts(eventId: Int, bookmarks: [Int]) -> Bool {
-        // Phase 2: O(1) dict lookup + per-event memoization keyed on bookmark identity.
+        // Convenience overload: derives the bookmark identity key here.
+        // Callers that render many rows against the same bookmark set
+        // (EventCell) should precompute the key once (BookmarkSnapshot)
+        // and use the overload below so the array isn't re-hashed per call.
         var hasher = Hasher()
         for b in bookmarks { hasher.combine(b) }
-        let bookmarkKey = hasher.finalize()
+        return bookmarkConflicts(eventId: eventId, bookmarks: bookmarks, bookmarkKey: hasher.finalize())
+    }
+
+    func bookmarkConflicts(eventId: Int, bookmarks: [Int], bookmarkKey: Int) -> Bool {
+        // Phase 2: O(1) dict lookup + per-event memoization keyed on bookmark identity.
         if bookmarkKey != conflictCacheBookmarkKey {
             conflictCache.removeAll(keepingCapacity: true)
             conflictCacheBookmarkKey = bookmarkKey

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -198,39 +198,14 @@ final class InfoViewModel {
     func removeListeners() {
         // print("Removing listeners")
         // print("DB Cache Settings: \(db.settings.isPersistenceEnabled)")
-        if let cl = conferenceListener {
-            cl.remove()
-        }
-        if let dl = documentListener {
-            dl.remove()
-        }
-        if let tl = tagListener {
-            tl.remove()
-        }
-        if let ll = locationListener {
-            ll.remove()
-        }
-        if let pl = productListener {
-            pl.remove()
-        }
-        if let cl = contentListener {
-            cl.remove()
-        }
-        if let sl = speakerListener {
-            sl.remove()
-        }
-        if let ll = listListener {
-            ll.remove()
-        }
-        if let al = articleListener {
-            al.remove()
-        }
-        if let ml = menuListener {
-            ml.remove()
-        }
-        if let fl = feedbackFormsListener {
-            fl.remove()
-        }
+        // Bugfix: this used to hand-roll its own list of `if let ... .remove()`
+        // and had drifted out of sync with removeListenersImmediate() /
+        // deinit — it was missing orgListener, so fetchData() -> removeListeners()
+        // followed by fetchOrgs() orphaned the previous conference's org
+        // listener (leaked live Firestore listener + possible stale-data
+        // clobber). Delegate to removeListenersImmediate() so there's a
+        // single source of truth for "which listeners exist."
+        removeListenersImmediate()
     }
 
     /// deinit-safe variant that doesn't touch @Published state.
@@ -418,10 +393,25 @@ final class InfoViewModel {
                                 completion(nil, error)
                             }
                         } else {
-                            completion(nil, error)
+                            // Bugfix: statusCode == 200 but no temp file — treat as a
+                            // failure so `completion` still fires exactly once instead
+                            // of silently dropping the callback.
+                            Log.network.error("download reported success but no temp file")
+                            completion(nil, URLError(.badServerResponse))
                         }
-
+                    } else {
+                        // Bugfix: non-200 responses (404/500/etc) previously fell through
+                        // without calling `completion` at all, which left
+                        // pendingMapDownloads permanently incremented and the Maps tab
+                        // spinner stuck on for the rest of the session.
+                        Log.network.error("download failed with status \(response.statusCode, privacy: .public)")
+                        completion(nil, URLError(.badServerResponse))
                     }
+                } else {
+                    // Bugfix: cast to HTTPURLResponse failed (non-HTTP response, or nil) —
+                    // same "never call completion" hole as the non-200 branch above.
+                    Log.network.error("download response was not an HTTPURLResponse")
+                    completion(nil, URLError(.badServerResponse))
                 }
 
             }

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -20,6 +20,20 @@ import SwiftUI
 // `Task { @MainActor in ... }` for the actual array assignment. This closes
 // the SwiftUI "Publishing changes from background threads" warning surface
 // and is a prerequisite for Swift 6 strict concurrency.
+/// Firestore's `QueryDocumentSnapshot` (and the `[QueryDocumentSnapshot]` arrays
+/// handed to snapshot listener closures) are not declared `Sendable` in the
+/// firebase-ios-sdk version this project pins (10.29.0), even though the
+/// underlying ObjC snapshot objects are immutable, thread-safe-to-read value
+/// snapshots — decoding one on a background thread is exactly what Firebase's
+/// own `data(as:)` does under the hood and is safe regardless of which thread
+/// calls it. This box exists solely to carry such an array across the
+/// `Task.detached` boundary for the off-main decode in fetchContent/fetchSpeakers
+/// without asserting a blanket, unverifiable Sendable conformance on Firebase's
+/// own types.
+private struct UncheckedSendableBox<Value>: @unchecked Sendable {
+    let value: Value
+}
+
 @Observable
 @MainActor
 final class InfoViewModel {
@@ -138,7 +152,18 @@ final class InfoViewModel {
     }
 
     @ObservationIgnored private var db = Firestore.firestore()
-    
+
+    // Phase perf: generation counters guard the off-main decode path in
+    // fetchContent/fetchSpeakers against out-of-order snapshot delivery.
+    // Firestore can fire a cache tick immediately followed by a server tick;
+    // if the cache-tick decode (dispatched first) happens to finish after the
+    // server-tick decode, applying it would clobber fresher data with stale
+    // data. Each fetcher captures the pre-increment generation before
+    // detaching its decode Task, and the result is discarded unless its
+    // generation is still the newest one issued for that fetcher.
+    @ObservationIgnored private var contentGeneration = 0
+    @ObservationIgnored private var speakerGeneration = 0
+
     func bookmarkConflicts(eventId: Int, bookmarks: [Int]) -> Bool {
         // Convenience overload: derives the bookmark identity key here.
         // Callers that render many rows against the same bookmark set
@@ -234,7 +259,8 @@ final class InfoViewModel {
     func fetchConference(code: String) {
         conferenceListener = db.collection("conferences")
             .document(code)
-            .addSnapshotListener { documentSnapshot, error in
+            .addSnapshotListener { [weak self] documentSnapshot, error in
+                guard let self else { return }
                 guard let doc = documentSnapshot else {
                     Log.firestore.error("conference fetch failed: \(String(describing: error), privacy: .public)")
                     if let e = error { CrashReport.record(e, context: ["op": "fetchConference"]) }
@@ -429,7 +455,8 @@ final class InfoViewModel {
         documentListener = db.collection("conferences")
             .document(code)
             .collection("documents")
-            .order(by: "id", descending: false).addSnapshotListener { querySnapshot, error in
+            .order(by: "id", descending: false).addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("documents: empty snapshot")
                     return
@@ -458,7 +485,8 @@ final class InfoViewModel {
         tagListener = db.collection("conferences")
             .document(code)
             .collection("tagtypes")
-            .order(by: "sort_order", descending: false).addSnapshotListener { querySnapshot, error in
+            .order(by: "sort_order", descending: false).addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("tags: empty snapshot")
                     return
@@ -488,7 +516,8 @@ final class InfoViewModel {
             .document(code)
             .collection("locations")
             .order(by: "peer_sort_order", descending: false)
-            .addSnapshotListener { querySnapshot, error in
+            .addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("locations: empty snapshot")
                     return
@@ -517,7 +546,8 @@ final class InfoViewModel {
         productListener = db.collection("conferences")
             .document(code)
             .collection("products")
-            .order(by: "sort_order", descending: false).addSnapshotListener { querySnapshot, error in
+            .order(by: "sort_order", descending: false).addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("products: empty snapshot")
                     return
@@ -546,57 +576,77 @@ final class InfoViewModel {
         contentListener = db.collection("conferences")
             .document(code)
             .collection("content")
-            .order(by: "title", descending: false).addSnapshotListener { querySnapshot, error in
+            .order(by: "title", descending: false).addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("content: empty snapshot")
                     return
                 }
 
-                var cache = 0
-                var firestore = 0
-                // Phase 1 fix: previously `self.events = []` lived inside the per-document
-                // compactMap, so each decoded doc reset events and a concurrent snapshot
-                // mid-decode could duplicate or drop entries. Build a local buffer first,
-                // then assign atomically once decoding completes.
-                let decodedContent: [Content] = docs.compactMap { queryDocumentSnapshot -> Content? in
-                    do {
-                        if queryDocumentSnapshot.metadata.isFromCache {
-                            cache = cache + 1
-                        } else {
-                            firestore = firestore + 1
-                        }
-                        return try queryDocumentSnapshot.data(as: Content.self)
-                    } catch {
-                        Log.firestore.error("content decode failed: \(error, privacy: .public)")
-                        CrashReport.record(error, context: ["op": "decodeContent"])
-                        return nil
-                    }
-                }
-                var rebuiltEvents: [Event] = []
-                var seenEventIds: Set<Int> = []
-                for c in decodedContent {
-                    if !c.sessions.isEmpty {
-                        for s in c.sessions {
-                            if seenEventIds.contains(s.id) {
-                                continue
-                            }
-                            seenEventIds.insert(s.id)
-                            let e = Event(id: s.id, contentId: c.id, description: c.description, beginTimestamp: s.beginTimestamp, endTimestamp: s.endTimestamp, title: c.title, locationId: s.locationId, people: c.people, tagIds: c.tagIds, relatedIds: c.relatedIds)
-                            rebuiltEvents.append(e)
-                            /* Task {
-                                if await NotificationUtility.notificationExists(id: e.id) {
-                                    NotificationUtility.removeNotification(id: e.id)
-                                    let notDate = e.beginTimestamp.addingTimeInterval(Double((-self.notifyAt)) * 60)
-                                    NotificationUtility.scheduleNotification(date: notDate, id: e.id, title: e.title, location: self.locations.first(where: {$0.id == e.locationId})?.name ?? "unknown")
-                                }
-                            } */
-                        }
-                    }
-                }
-                self.content = decodedContent
-                self.events = rebuiltEvents
+                // Phase perf: DEF CON has 1000+ content docs, so the Codable
+                // decode + event rebuild below is expensive enough to cause a
+                // visible main-thread stall if done inline in this listener
+                // closure (which Firestore invokes on the main queue). Box the
+                // [QueryDocumentSnapshot] (not Sendable in this SDK version, but
+                // safe to read off-main — see UncheckedSendableBox) and hop to a
+                // detached task to do the heavy lifting off-main; only the
+                // final array assignment comes back to the MainActor.
+                self.contentGeneration += 1
+                let generation = self.contentGeneration
+                let boxedDocs = UncheckedSendableBox(value: docs)
 
-                NSLog("InfoViewModel: \(self.content.count) content (cache hits \(cache), firestore hits \(firestore))")
+                Task.detached(priority: .userInitiated) { [weak self] in
+                    let docs = boxedDocs.value
+                    var cache = 0
+                    var firestore = 0
+                    // Phase 1 fix: previously `self.events = []` lived inside the per-document
+                    // compactMap, so each decoded doc reset events and a concurrent snapshot
+                    // mid-decode could duplicate or drop entries. Build a local buffer first,
+                    // then assign atomically once decoding completes.
+                    let decodedContent: [Content] = docs.compactMap { queryDocumentSnapshot -> Content? in
+                        do {
+                            if queryDocumentSnapshot.metadata.isFromCache {
+                                cache = cache + 1
+                            } else {
+                                firestore = firestore + 1
+                            }
+                            return try queryDocumentSnapshot.data(as: Content.self)
+                        } catch {
+                            Log.firestore.error("content decode failed: \(error, privacy: .public)")
+                            CrashReport.record(error, context: ["op": "decodeContent"])
+                            return nil
+                        }
+                    }
+                    var rebuiltEvents: [Event] = []
+                    var seenEventIds: Set<Int> = []
+                    for c in decodedContent {
+                        if !c.sessions.isEmpty {
+                            for s in c.sessions {
+                                if seenEventIds.contains(s.id) {
+                                    continue
+                                }
+                                seenEventIds.insert(s.id)
+                                let e = Event(id: s.id, contentId: c.id, description: c.description, beginTimestamp: s.beginTimestamp, endTimestamp: s.endTimestamp, title: c.title, locationId: s.locationId, people: c.people, tagIds: c.tagIds, relatedIds: c.relatedIds)
+                                rebuiltEvents.append(e)
+                                /* Task {
+                                    if await NotificationUtility.notificationExists(id: e.id) {
+                                        NotificationUtility.removeNotification(id: e.id)
+                                        let notDate = e.beginTimestamp.addingTimeInterval(Double((-self.notifyAt)) * 60)
+                                        NotificationUtility.scheduleNotification(date: notDate, id: e.id, title: e.title, location: self.locations.first(where: {$0.id == e.locationId})?.name ?? "unknown")
+                                    }
+                                } */
+                            }
+                        }
+                    }
+
+                    await MainActor.run {
+                        // Discard this result if a newer snapshot's decode already landed.
+                        guard let self, generation == self.contentGeneration else { return }
+                        self.content = decodedContent
+                        self.events = rebuiltEvents
+                        NSLog("InfoViewModel: \(self.content.count) content (cache hits \(cache), firestore hits \(firestore))")
+                    }
+                }
             }
     }
 
@@ -604,30 +654,48 @@ final class InfoViewModel {
         speakerListener = db.collection("conferences")
             .document(code)
             .collection("speakers")
-            .order(by: "name", descending: false).addSnapshotListener { querySnapshot, error in
+            .order(by: "name", descending: false).addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("speakers: empty snapshot")
                     return
                 }
 
-                var cache = 0
-                var firestore = 0
-                self.speakers = docs.compactMap { queryDocumentSnapshot -> Speaker? in
-                    do {
-                        if queryDocumentSnapshot.metadata.isFromCache {
-                            cache = cache + 1
-                        } else {
-                            firestore = firestore + 1
+                // Phase perf: same off-main decode treatment as fetchContent —
+                // speakers is one of the larger collections and is re-decoded
+                // in full on every snapshot tick.
+                self.speakerGeneration += 1
+                let generation = self.speakerGeneration
+                let boxedDocs = UncheckedSendableBox(value: docs)
+
+                Task.detached(priority: .userInitiated) { [weak self] in
+                    let docs = boxedDocs.value
+                    var cache = 0
+                    var firestore = 0
+                    var decodedSpeakers: [Speaker] = docs.compactMap { queryDocumentSnapshot -> Speaker? in
+                        do {
+                            if queryDocumentSnapshot.metadata.isFromCache {
+                                cache = cache + 1
+                            } else {
+                                firestore = firestore + 1
+                            }
+                            return try queryDocumentSnapshot.data(as: Speaker.self)
+                        } catch {
+                            Log.firestore.error("speaker decode failed: \(error, privacy: .public)")
+                            CrashReport.record(error, context: ["op": "decodeSpeaker"])
+                            return nil
                         }
-                        return try queryDocumentSnapshot.data(as: Speaker.self)
-                    } catch {
-                        Log.firestore.error("speaker decode failed: \(error, privacy: .public)")
-                        CrashReport.record(error, context: ["op": "decodeSpeaker"])
-                        return nil
+                    }
+                    // Finding B: sort before assigning so there's exactly one
+                    // didSet/observation invalidation per snapshot tick instead of two.
+                    decodedSpeakers.sort(using: KeyPathComparator(\.self.name, comparator: .localizedStandard))
+
+                    await MainActor.run {
+                        guard let self, generation == self.speakerGeneration else { return }
+                        self.speakers = decodedSpeakers
+                        NSLog("InfoViewModel: \(self.speakers.count) speakers (cache hits \(cache), firestore hits \(firestore))")
                     }
                 }
-                self.speakers.sort(using: KeyPathComparator(\.self.name, comparator: .localizedStandard))
-                NSLog("InfoViewModel: \(self.speakers.count) speakers (cache hits \(cache), firestore hits \(firestore))")
             }
     }
 
@@ -635,7 +703,8 @@ final class InfoViewModel {
         orgListener = db.collection("conferences")
             .document(code)
             .collection("organizations")
-            .order(by: "name", descending: false).addSnapshotListener { querySnapshot, error in
+            .order(by: "name", descending: false).addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("orgs: empty snapshot")
                     return
@@ -643,7 +712,7 @@ final class InfoViewModel {
 
                 var cache = 0
                 var firestore = 0
-                self.orgs = docs.compactMap { queryDocumentSnapshot -> Organization? in
+                var decodedOrgs: [Organization] = docs.compactMap { queryDocumentSnapshot -> Organization? in
                     do {
                         if queryDocumentSnapshot.metadata.isFromCache {
                             cache = cache + 1
@@ -657,7 +726,10 @@ final class InfoViewModel {
                         return nil
                     }
                 }
-                self.orgs.sort(using: KeyPathComparator(\.self.name, comparator: .localizedStandard))
+                // Finding B: sort the local array before assigning to `orgs`
+                // so there's exactly one didSet/observation invalidation per tick.
+                decodedOrgs.sort(using: KeyPathComparator(\.self.name, comparator: .localizedStandard))
+                self.orgs = decodedOrgs
                 NSLog("InfoViewModel: \(self.orgs.count) organizations (cache hits \(cache), firestore hits \(firestore))")
             }
     }
@@ -666,7 +738,8 @@ final class InfoViewModel {
         listListener = db.collection("conferences")
             .document(code)
             .collection("faqs")
-            .order(by: "id", descending: false).addSnapshotListener { querySnapshot, error in
+            .order(by: "id", descending: false).addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("faqs: empty snapshot")
                     return
@@ -696,7 +769,8 @@ final class InfoViewModel {
             .order(by: "updated_at", descending: true)
             // Phase 2: cap news feed; older articles can be loaded on demand later.
             .limit(to: 100)
-            .addSnapshotListener { querySnapshot, error in
+            .addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("articles: empty snapshot")
                     return
@@ -726,7 +800,8 @@ final class InfoViewModel {
         menuListener = db.collection("conferences")
             .document(code)
             .collection("menus")
-            .order(by: "id", descending: false).addSnapshotListener { querySnapshot, error in
+            .order(by: "id", descending: false).addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("menus: empty snapshot")
                     return
@@ -758,7 +833,8 @@ final class InfoViewModel {
         feedbackFormsListener = db.collection("conferences")
             .document(code)
             .collection("feedbackforms")
-            .addSnapshotListener { querySnapshot, error in
+            .addSnapshotListener { [weak self] querySnapshot, error in
+                guard let self else { return }
                 guard let docs = querySnapshot?.documents else {
                     Log.firestore.info("feedbackForms: empty snapshot")
                     return

--- a/hackertracker/Views/404View.swift
+++ b/hackertracker/Views/404View.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct _04View: View {
     var message: String
     var show404: Bool = true
-    @AppStorage("conferenceCode") var conferenceCode: String = "INIT"
+    @AppStorage(AppStorageKeys.conferenceCode) var conferenceCode: String = "INIT"
     @StateObject var selected = SelectedConference()
     @State private var viewModel = InfoViewModel()
     @Environment(\.colorScheme) private var beezleColorScheme

--- a/hackertracker/Views/ConferenceRow.swift
+++ b/hackertracker/Views/ConferenceRow.swift
@@ -5,6 +5,7 @@
 //  Created by Seth W Law on 6/7/22.
 //
 
+import Kingfisher
 import SwiftUI
 
 struct ConferenceRow: View {
@@ -12,10 +13,19 @@ struct ConferenceRow: View {
     var code: String
 
     @Environment(ThemeManager.self) private var themeManager
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         let isActive = conference.code == code
         HStack(spacing: 12) {
+            if let logo = conference.squareLogo(for: colorScheme),
+               let url = URL(string: logo) {
+                KFImage(url)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 44, height: 44)
+                    .cornerRadius(6)
+            }
             VStack(alignment: .leading, spacing: 4) {
                 Text(conference.name)
                     .font(themeManager.title3Font)

--- a/hackertracker/Views/ConferenceRow.swift
+++ b/hackertracker/Views/ConferenceRow.swift
@@ -29,14 +29,6 @@ struct ConferenceRow: View {
                 }
             }
             HStack(alignment: .center, spacing: 12) {
-                if let logo = conference.squareLogo(for: colorScheme),
-                   let url = URL(string: logo) {
-                    KFImage(url)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 56, height: 56)
-                        .cornerRadius(6)
-                }
                 VStack(alignment: .leading, spacing: 4) {
                     if conference.startDate == conference.endDate {
                         Text(conference.endDate)
@@ -61,6 +53,15 @@ struct ConferenceRow: View {
                         .padding(.top, 2)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+
+                if let logo = conference.squareLogo(for: colorScheme),
+                   let url = URL(string: logo) {
+                    KFImage(url)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 56, height: 56)
+                        .cornerRadius(6)
+                }
             }
         }
         // Card-style row matching ThemePickerView: cardSurface

--- a/hackertracker/Views/ConferenceRow.swift
+++ b/hackertracker/Views/ConferenceRow.swift
@@ -24,7 +24,7 @@ struct ConferenceRow: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 if isActive {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
+                        .foregroundStyle(themeManager.success)
                         .font(themeManager.title3Font)
                 }
             }
@@ -66,16 +66,16 @@ struct ConferenceRow: View {
             }
         }
         // Card-style row matching ThemePickerView: cardSurface
-        // background, 2pt green border + checkmark when active, soft
+        // background, success border + checkmark when active, soft
         // hairline border otherwise.
         .padding()
         .background(themeManager.cardSurface)
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(isActive ? Color.green : Color.primary.opacity(0.08),
+            RoundedRectangle(cornerRadius: ThemeMetrics.cardRadius)
+                .stroke(isActive ? themeManager.success : Color.primary.opacity(0.08),
                         lineWidth: isActive ? 2 : 0.5)
         )
-        .cornerRadius(10)
+        .cornerRadius(ThemeMetrics.cardRadius)
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
     }

--- a/hackertracker/Views/ConferenceRow.swift
+++ b/hackertracker/Views/ConferenceRow.swift
@@ -57,6 +57,7 @@ struct ConferenceRow: View {
                 if let logo = conference.squareLogo(for: colorScheme),
                    let url = URL(string: logo) {
                     KFImage(url)
+                        .htDownsampled(side: 56)
                         .resizable()
                         .scaledToFit()
                         .frame(width: 56, height: 56)

--- a/hackertracker/Views/ConferenceRow.swift
+++ b/hackertracker/Views/ConferenceRow.swift
@@ -17,46 +17,50 @@ struct ConferenceRow: View {
 
     var body: some View {
         let isActive = conference.code == code
-        HStack(spacing: 12) {
-            if let logo = conference.squareLogo(for: colorScheme),
-               let url = URL(string: logo) {
-                KFImage(url)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 44, height: 44)
-                    .cornerRadius(6)
-            }
-            VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
                 Text(conference.name)
                     .font(themeManager.title3Font)
-                if conference.startDate == conference.endDate {
-                    Text(conference.endDate)
-                        .font(themeManager.bodyFont)
-                } else {
-                    Text("\(conference.startDate) - \(conference.endDate)")
-                        .font(themeManager.bodyFont)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if isActive {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(themeManager.title3Font)
                 }
-                // Polish: surface the conference timezone so users can see at
-                // a glance which timezone the schedule renders in.
-                if let tz = conference.timezone, !tz.isEmpty {
-                    HStack(spacing: 4) {
-                        Image(systemName: "clock")
-                        Text(tz)
-                    }
-                    .font(themeManager.captionFont)
-                    .foregroundStyle(.secondary)
-                }
-                Text(isActive ? "Active" : "Tap to switch")
-                    .font(themeManager.captionFont)
-                    .foregroundStyle(.secondary)
-                    .padding(.top, 2)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            if isActive {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-                    .font(themeManager.title3Font)
+            HStack(alignment: .center, spacing: 12) {
+                if let logo = conference.squareLogo(for: colorScheme),
+                   let url = URL(string: logo) {
+                    KFImage(url)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 56, height: 56)
+                        .cornerRadius(6)
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    if conference.startDate == conference.endDate {
+                        Text(conference.endDate)
+                            .font(themeManager.bodyFont)
+                    } else {
+                        Text("\(conference.startDate) - \(conference.endDate)")
+                            .font(themeManager.bodyFont)
+                    }
+                    // Polish: surface the conference timezone so users can see at
+                    // a glance which timezone the schedule renders in.
+                    if let tz = conference.timezone, !tz.isEmpty {
+                        HStack(spacing: 4) {
+                            Image(systemName: "clock")
+                            Text(tz)
+                        }
+                        .font(themeManager.captionFont)
+                        .foregroundStyle(.secondary)
+                    }
+                    Text(isActive ? "Active" : "Tap to switch")
+                        .font(themeManager.captionFont)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         // Card-style row matching ThemePickerView: cardSurface

--- a/hackertracker/Views/ConferencesView.swift
+++ b/hackertracker/Views/ConferencesView.swift
@@ -18,9 +18,9 @@ struct ConferencesView: View {
     @Environment(\.presentationMode) var presentationMode
     @Environment(ThemeManager.self) private var themeManager
     @Environment(\.managedObjectContext) private var viewContext
-    @AppStorage("conferenceCode") var conferenceCode: String = "INIT"
-    @AppStorage("showHidden") var showHidden: Bool = false
-    @AppStorage("showLocaltime") var showLocaltime: Bool = false
+    @AppStorage(AppStorageKeys.conferenceCode) var conferenceCode: String = "INIT"
+    @AppStorage(AppStorageKeys.showHidden) var showHidden: Bool = false
+    @AppStorage(AppStorageKeys.showLocaltime) var showLocaltime: Bool = false
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
 
     // Polish parity with the other top-level lists.

--- a/hackertracker/Views/ConferencesView.swift
+++ b/hackertracker/Views/ConferencesView.swift
@@ -13,7 +13,6 @@ struct ConferencesView: View {
     // var conferences: [Conference]
     @EnvironmentObject var selected: SelectedConference
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
     @Environment(ConferencesViewModel.self) private var consViewModel
     @EnvironmentObject var filters: Filters
     @Environment(\.presentationMode) var presentationMode

--- a/hackertracker/Views/ConferencesView.swift
+++ b/hackertracker/Views/ConferencesView.swift
@@ -38,65 +38,10 @@ struct ConferencesView: View {
         }
     }
 
-    @ViewBuilder private var inlineSearchBar: some View {
-        if isSearching {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-                TextField("Search conferences", text: $searchText)
-                    .focused($searchFocused)
-                    .submitLabel(.search)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                    }
-                    .accessibilityLabel("Clear search text")
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.thinMaterial)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    @ViewBuilder private var searchToggleButton: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isSearching.toggle()
-            }
-            if isSearching {
-                searchFocused = true
-            } else {
-                searchText = ""
-            }
-        } label: {
-            Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
-        }
-        .accessibilityLabel(isSearching ? "Close search" : "Search conferences")
-    }
-
-    @ViewBuilder private var jumpMenu: some View {
-        Menu {
-            Button {
-                jumpTarget = "__top"
-            } label: { Label("Top", systemImage: "arrow.up") }
-            Button {
-                jumpTarget = "__bottom"
-            } label: { Label("Bottom", systemImage: "arrow.down") }
-        } label: {
-            Image(systemName: "arrow.up.arrow.down")
-        }
-        .menuOrder(.fixed)
-    }
-
     var body: some View {
         if consViewModel.conferences.count > 0 {
             VStack(spacing: 0) {
-                inlineSearchBar
+                InlineSearchBar(placeholder: "Search conferences", text: $searchText, isFocused: $searchFocused, visible: isSearching)
                 ScrollView {
                     if filteredConferences.isEmpty {
                         ContentUnavailableView.search(text: searchText)
@@ -139,12 +84,7 @@ struct ConferencesView: View {
             .overlay(alignment: .bottom) {
                 HStack {
                     Spacer()
-                    jumpMenu
-                        .font(themeManager.title2Font)
-                        .foregroundStyle(.primary)
-                        .frame(width: 48, height: 48)
-                        .background(.regularMaterial, in: Circle())
-                        .accessibilityLabel("Jump")
+                    JumpMenuOverlay(target: $jumpTarget)
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 12)
@@ -156,7 +96,7 @@ struct ConferencesView: View {
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    searchToggleButton
+                    SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search conferences")
                 }
             }
             .analyticsScreen(name: "ConferencesView")

--- a/hackertracker/Views/ContentCellView.swift
+++ b/hackertracker/Views/ContentCellView.swift
@@ -15,12 +15,12 @@ struct ContentCell: View {
     @Environment(\.noteContentIDs) private var noteContentIDs
     @Environment(ThemeManager.self) private var themeManager
     let dfu = DateFormatterUtility.shared
-    @AppStorage("notifyAt") var notifyAt: Int = 20
+    @AppStorage(AppStorageKeys.notifyAt) var notifyAt: Int = 20
     /// Step 3 of the AI summary spike: warm the on-device LLM
     /// cache when this cell materializes IF the user has opted in.
     /// TalkSummaryCache.warm is a no-op when the device can't run
     /// FoundationModels, so this stays safe on iOS < 26.
-    @AppStorage("aiSummaries") private var aiSummaries: Bool = false
+    @AppStorage(AppStorageKeys.aiSummaries) private var aiSummaries: Bool = false
     /// Whether to present the original description sheet in response
     /// to a long-press. Only used when an AI summary is shown — long-
     /// pressing a cell with no summary is a no-op so we don't compete

--- a/hackertracker/Views/ContentCellView.swift
+++ b/hackertracker/Views/ContentCellView.swift
@@ -132,12 +132,6 @@ struct ContentCell: View {
         .cornerRadius(10)
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
-        .swipeActions {
-            Button(isBookmarked ? "Remove Bookmark" : "Bookmark") {
-                bookmarkAction()
-            }.buttonStyle(DefaultButtonStyle())
-                .tint(isBookmarked ? .red : .yellow)
-        }
         // LazyVStack inside ContentListView materializes cells as they
         // scroll into view; this .task runs once per materialization.
         // Cheap no-op when aiSummaries is off or the device can't run

--- a/hackertracker/Views/ContentCellView.swift
+++ b/hackertracker/Views/ContentCellView.swift
@@ -129,7 +129,7 @@ struct ContentCell: View {
             }
         }
         .background(themeManager.cardSurface)
-        .cornerRadius(10)
+        .cornerRadius(ThemeMetrics.cardRadius)
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
         // LazyVStack inside ContentListView materializes cells as they

--- a/hackertracker/Views/ContentDetailView.swift
+++ b/hackertracker/Views/ContentDetailView.swift
@@ -146,7 +146,6 @@ struct ContentDetailView: View {
 struct showFeedbackButton: View {
     @Binding var showFeedback: Bool
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
     @AppStorage("colorMode") var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
@@ -161,7 +160,7 @@ struct showFeedbackButton: View {
             .foregroundColor(colorMode ? .white : .primary)
             .frame(maxWidth: .infinity)
             .padding(15)
-            .background(colorMode ? theme.carousel() : themeManager.cardSurface)
+            .background(colorMode ? themeManager.carouselColor(index: 0) : themeManager.cardSurface)
             .cornerRadius(15)
         }
     }
@@ -417,7 +416,6 @@ struct showRelated: View {
 struct showPeople: View {
     var content: Content
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
     @State private var collapsed = false
     @AppStorage("colorMode") var colorMode: Bool = false
     let columns = [GridItem(.flexible()), GridItem(.flexible())]
@@ -469,7 +467,7 @@ struct showPeople: View {
                                 .foregroundColor(.primary)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                                 .padding(15)
-                                .background(colorMode ? theme.carousel(): themeManager.cardSurface)
+                                .background(colorMode ? themeManager.carouselColor(index: person.id) : themeManager.cardSurface)
                                 .cornerRadius(15)
                             }
                         }
@@ -488,7 +486,7 @@ struct showPeople: View {
                     .foregroundColor(.primary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(15)
-                    .background(colorMode ? theme.carousel(): themeManager.cardSurface)
+                    .background(colorMode ? themeManager.carouselColor(index: speaker.id) : themeManager.cardSurface)
                     .cornerRadius(15)
                 }
             }

--- a/hackertracker/Views/ContentDetailView.swift
+++ b/hackertracker/Views/ContentDetailView.swift
@@ -146,7 +146,7 @@ struct ContentDetailView: View {
 struct showFeedbackButton: View {
     @Binding var showFeedback: Bool
     @Environment(InfoViewModel.self) private var viewModel
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
 
@@ -244,8 +244,8 @@ struct showSessionRow: View {
     let dfu = DateFormatterUtility.shared
     
     @State var notExists: Bool = false
-    @AppStorage("notifyAt") var notifyAt: Int = 20
-    @AppStorage("show24hourtime") var show24hourtime: Bool = true
+    @AppStorage(AppStorageKeys.notifyAt) var notifyAt: Int = 20
+    @AppStorage(AppStorageKeys.show24hourtime) var show24hourtime: Bool = true
     @Environment(InfoViewModel.self) private var viewModel
     
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
@@ -417,7 +417,7 @@ struct showPeople: View {
     var content: Content
     @Environment(InfoViewModel.self) private var viewModel
     @State private var collapsed = false
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     let columns = [GridItem(.flexible()), GridItem(.flexible())]
 
     @Environment(ThemeManager.self) private var themeManager

--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -128,49 +128,6 @@ struct ContentListView: View {
         groupedContent.sorted { $0.key < $1.key }
     }
 
-    /// Inline search bar shown only when `isSearching` is true.
-    @ViewBuilder private var inlineSearchBar: some View {
-        if isSearching {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-                TextField("Search content title or description", text: $searchText)
-                    .focused($searchFocused)
-                    .submitLabel(.search)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                    }
-                    .accessibilityLabel("Clear search text")
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.thinMaterial)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    /// Toolbar button that toggles the inline search field.
-    @ViewBuilder private var searchToggleButton: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isSearching.toggle()
-            }
-            if isSearching {
-                searchFocused = true
-            } else {
-                searchText = ""
-            }
-        } label: {
-            Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
-        }
-        .accessibilityLabel(isSearching ? "Close search" : "Search content")
-    }
-
     /// Floating bottom-right menu: jump to a letter group, plus
     /// Top / Next Group / Bottom shortcuts.
     @ViewBuilder private var jumpToGroupMenu: some View {
@@ -227,7 +184,7 @@ struct ContentListView: View {
     @ViewBuilder
     private var contentSidebar: some View {
         VStack(spacing: 0) {
-            inlineSearchBar
+            InlineSearchBar(placeholder: "Search content title or description", text: $searchText, isFocused: $searchFocused, visible: isSearching)
             ScrollView {
                 if grouped.isEmpty {
                     if searchText.isEmpty && filters.filters.isEmpty {
@@ -316,7 +273,7 @@ struct ContentListView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                searchToggleButton
+                SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search content")
             }
         }
         .task(id: searchText) {

--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -78,13 +78,9 @@ struct ContentListView: View {
     /// iPad-only: identifies the content currently shown in the detail column.
     @State private var ipadSelectedContentId: Int?
 
-    /// Number of Content rows surviving the current filter +
-    /// search pipeline. Same shape as scheduleFilteredCount.
-    private var contentFilteredCount: Int {
-        contentGroup().values.reduce(0) { $0 + $1.count }
-    }
-
-    func contentGroup() -> [String.Element: [Content]] {
+    /// Grouped content computed once per body evaluation, shared by
+    /// contentFilteredCount and grouped to avoid duplicate filtering.
+    private var groupedContent: [String.Element: [Content]] {
         let bookmarkIds = Set(bookmarks.map(\.id))
         // Predicate composes search text + filter chips. The chips OR
         // with each other (matches any one keeps the row). Real tags
@@ -122,8 +118,14 @@ struct ContentListView: View {
         )
     }
 
+    /// Number of Content rows surviving the current filter +
+    /// search pipeline. Same shape as scheduleFilteredCount.
+    private var contentFilteredCount: Int {
+        groupedContent.values.reduce(0) { $0 + $1.count }
+    }
+
     private var grouped: [(key: String.Element, value: [Content])] {
-        contentGroup().sorted { $0.key < $1.key }
+        groupedContent.sorted { $0.key < $1.key }
     }
 
     /// Inline search bar shown only when `isSearching` is true.

--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -18,7 +18,7 @@ struct ContentListView: View {
     @State private var debouncedSearch = ""
     /// Filter-chip composition mode. Mirrors EventsView so both
     /// lists honor the same user choice from the Filters sheet.
-    @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    @AppStorage(AppStorageKeys.filterMatchMode) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
     private var filterMatchMode: FilterMatchMode {
         FilterMatchMode(rawOrDefault: filterMatchModeRaw)
     }

--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -321,7 +321,6 @@ struct ContentListView: View {
 struct ContentData: View {
     let char: String.Element
     let content: [Content]
-    @EnvironmentObject var theme: Theme
     @Environment(ThemeManager.self) private var themeManager
     @Environment(\.managedObjectContext) private var viewContext
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>

--- a/hackertracker/Views/ContentView.swift
+++ b/hackertracker/Views/ContentView.swift
@@ -36,14 +36,14 @@ final class ScrollCommandBus: ObservableObject {
 }
 
 struct ContentView: View {
-    @AppStorage("conferenceCode") var conferenceCode: String = "INIT"
-    @AppStorage("launchScreen") var launchScreen: String = "Main"
-    @AppStorage("showHidden") var showHidden: Bool = false
-    @AppStorage("showLocaltime") var showLocaltime: Bool = false
-    @AppStorage("showNews") var showNews: Bool = true
-    @AppStorage("lightMode") var lightMode: Bool = false
-    @AppStorage("colorMode") var colorMode: Bool = false
-    @AppStorage("easterEgg") var easterEgg: Bool = false
+    @AppStorage(AppStorageKeys.conferenceCode) var conferenceCode: String = "INIT"
+    @AppStorage(AppStorageKeys.launchScreen) var launchScreen: String = "Main"
+    @AppStorage(AppStorageKeys.showHidden) var showHidden: Bool = false
+    @AppStorage(AppStorageKeys.showLocaltime) var showLocaltime: Bool = false
+    @AppStorage(AppStorageKeys.showNews) var showNews: Bool = true
+    @AppStorage(AppStorageKeys.lightMode) var lightMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.easterEgg) var easterEgg: Bool = false
 
     @StateObject var selected = SelectedConference()
     @State private var viewModel = InfoViewModel()
@@ -237,16 +237,16 @@ struct ContentView_Previews: PreviewProvider {
 /// through the full hue spectrum once every 12s; with just easterEgg
 /// it tints to the system primary so it adapts to light/dark mode.
 private struct BeezleEasterEggOverlay: View {
-    @AppStorage("easterEgg") var easterEgg: Bool = false
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.easterEgg) var easterEgg: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     /// User-tunable peak opacity of the breathing watermark. Floor at
     /// 0.05 so we never persist a fully-invisible setting that looks
     /// like the feature is broken; ceiling at 1.0 if the user wants
     /// the ghost solid-on at peak.
-    @AppStorage("easterEggMaxOpacity") var easterEggMaxOpacity: Double = 0.20
+    @AppStorage(AppStorageKeys.easterEggMaxOpacity) var easterEggMaxOpacity: Double = 0.20
     /// Period of the sine-wave pulse, in seconds. 0 turns the pulse
     /// off entirely — the watermark stays held at peak opacity.
-    @AppStorage("easterEggPeriod") var easterEggPeriod: Double = 12.0
+    @AppStorage(AppStorageKeys.easterEggPeriod) var easterEggPeriod: Double = 12.0
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {

--- a/hackertracker/Views/ContentView.swift
+++ b/hackertracker/Views/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by Seth W Law on 5/2/22.
 //
 
+import Combine
 import CoreData
 import FirebaseFirestore
 import FirebaseAnalytics
@@ -14,17 +15,25 @@ class SelectedConference: ObservableObject {
     @Published var code = "INIT"
 }
 
-class GoToButton: ObservableObject, Equatable {
-    static func == (lhs: GoToButton, rhs: GoToButton) -> Bool {
-        lhs.val == rhs.val
-    }
-    @Published var val: Bool = false
+/// Scroll commands the schedule (and any other scrollable list) can
+/// respond to. Sent through ScrollCommandBus below.
+enum ScrollCommand {
+    case top, bottom, current, next
 }
 
-class ToTop: GoToButton {}
-class ToBottom: GoToButton {}
-class ToCurrent: GoToButton {}
-class ToNext: GoToButton {}
+/// Fire-and-forget command bus for scroll-to actions. Intentionally an
+/// ObservableObject with NO @Published properties: `objectWillChange`
+/// never fires, so sending a command doesn't invalidate every view
+/// holding the bus via @EnvironmentObject — consumers subscribe with
+/// `.onReceive(bus.subject)` and scroll their own proxy. This replaces
+/// the old ToTop/ToBottom/ToCurrent/ToNext published-Bool handshake,
+/// which re-evaluated the whole schedule body twice per command.
+final class ScrollCommandBus: ObservableObject {
+    let subject = PassthroughSubject<ScrollCommand, Never>()
+    func send(_ command: ScrollCommand) {
+        subject.send(command)
+    }
+}
 
 struct ContentView: View {
     @AppStorage("conferenceCode") var conferenceCode: String = "INIT"
@@ -45,10 +54,7 @@ struct ContentView: View {
     /// Injected here so it has a single source of truth at the
     /// ContentView level, same as the other long-lived stores.
     @State private var themeManager = ThemeManager()
-    @StateObject private var toTop = ToTop()
-    @StateObject private var toBottom = ToBottom()
-    @StateObject private var toCurrent = ToCurrent()
-    @StateObject private var toNext = ToNext()
+    @StateObject private var scrollBus = ScrollCommandBus()
     @StateObject var filters = Filters(filters:[])
     /// Independent filter set for the Speakers list — selections here
     /// don't bleed into Schedule / All Content.
@@ -58,12 +64,7 @@ struct ContentView: View {
     /// selection survives tab switches (and now cold launches too).
     @StateObject var merchFilters = MerchFiltersStore()
     @State private var tabSelection = 1
-    // @State private var tappedMainTwice = false
-    // @State private var tappedScheduleTwice = false
-    @State private var info = UUID()
-    @State private var schedule = UUID()
     @State private var isInit: Bool = false
-    @State private var scheduleView = ScheduleView(tagIds: [])
     @State private var showingEmergencySheet = false
 
     var body: some View {
@@ -85,15 +86,13 @@ struct ContentView: View {
                         // Text("Info")
                     }
                     .tag(1)
-                    .id(info)
                     .preferredColorScheme(theme.colorScheme)
-                scheduleView
+                ScheduleView(tagIds: [])
                     .tabItem {
                         Image(systemName: "calendar")
                         // Text("Main")
                     }
                     .tag(2)
-                    .id(schedule)
                     .preferredColorScheme(theme.colorScheme)
                 MapView()
                     .tabItem {
@@ -159,10 +158,7 @@ struct ContentView: View {
             .environmentObject(theme)
             .environment(themeManager)
             .environment(consViewModel)
-            .environmentObject(toTop)
-            .environmentObject(toBottom)
-            .environmentObject(toCurrent)
-            .environmentObject(toNext)
+            .environmentObject(scrollBus)
             .environmentObject(filters)
             .environmentObject(speakerFilters)
             .environmentObject(merchFilters)

--- a/hackertracker/Views/ContentView.swift
+++ b/hackertracker/Views/ContentView.swift
@@ -48,11 +48,11 @@ struct ContentView: View {
     @StateObject var selected = SelectedConference()
     @State private var viewModel = InfoViewModel()
     @State private var consViewModel = ConferencesViewModel()
-    @StateObject var theme = Theme()
-    /// Themes-PR1 plumbing: app-wide theme manager. Read by call
-    /// sites in subsequent PRs via `@Environment(ThemeManager.self)`.
-    /// Injected here so it has a single source of truth at the
-    /// ContentView level, same as the other long-lived stores.
+    /// App-wide theme manager: palettes, typography, light/dark
+    /// preference, and the colorful-mode card palette. The single
+    /// theming source of truth (the legacy `Theme` ObservableObject
+    /// is gone). Injected here at the ContentView level, same as the
+    /// other long-lived stores.
     @State private var themeManager = ThemeManager()
     @StateObject private var scrollBus = ScrollCommandBus()
     @StateObject var filters = Filters(filters:[])
@@ -86,14 +86,14 @@ struct ContentView: View {
                         // Text("Info")
                     }
                     .tag(1)
-                    .preferredColorScheme(theme.colorScheme)
+                    .preferredColorScheme(themeManager.preferredColorScheme)
                 ScheduleView(tagIds: [])
                     .tabItem {
                         Image(systemName: "calendar")
                         // Text("Main")
                     }
                     .tag(2)
-                    .preferredColorScheme(theme.colorScheme)
+                    .preferredColorScheme(themeManager.preferredColorScheme)
                 MapView()
                     .tabItem {
                         // Animate the SF Symbol while map assets are
@@ -104,14 +104,14 @@ struct ContentView: View {
                         // Text("Maps")
                     }
                     .tag(3)
-                    .preferredColorScheme(theme.colorScheme)
+                    .preferredColorScheme(themeManager.preferredColorScheme)
                 SettingsView()
                     .tabItem {
                         Image(systemName: "gearshape")
                         // Text("Settings")
                     }
                     .tag(4)
-                    .preferredColorScheme(theme.colorScheme)
+                    .preferredColorScheme(themeManager.preferredColorScheme)
             }
             // Easter-egg overlay: faint, fading beezle behind the UI.
             // Only renders when easterEgg is on. With colorMode also on,
@@ -155,7 +155,6 @@ struct ContentView: View {
             }
             .environmentObject(selected)
             .environment(viewModel)
-            .environmentObject(theme)
             .environment(themeManager)
             .environment(consViewModel)
             .environmentObject(scrollBus)
@@ -180,22 +179,20 @@ struct ContentView: View {
                 NavigationStack {
                     ConferencesView()
                 }
-                    .preferredColorScheme(theme.colorScheme)
+                    .preferredColorScheme(themeManager.preferredColorScheme)
                     .environmentObject(selected)
                     .environment(viewModel)
                     .environment(consViewModel)
-                    .environmentObject(theme)
                     .environment(themeManager)
                     .environmentObject(filters)
                     .environmentObject(speakerFilters)
                     .environmentObject(merchFilters)
             } else {
-                _04View(message: "Loading", show404: false).preferredColorScheme(theme.colorScheme)
-                    .preferredColorScheme(theme.colorScheme)
+                _04View(message: "Loading", show404: false).preferredColorScheme(themeManager.preferredColorScheme)
+                    .preferredColorScheme(themeManager.preferredColorScheme)
                     .environmentObject(selected)
                     .environment(viewModel)
                     .environment(consViewModel)
-                    .environmentObject(theme)
                     .environment(themeManager)
                     .environmentObject(filters)
                     .environmentObject(speakerFilters)

--- a/hackertracker/Views/DocumentView.swift
+++ b/hackertracker/Views/DocumentView.swift
@@ -17,7 +17,6 @@ struct DocumentView: View {
     /// bar (not duplicated in the scroll body). Emergency / merch-help docs
     /// still want the prominent in-body banner, so this defaults to true.
     var showInlineTitle: Bool = true
-    @EnvironmentObject var theme: Theme
     @AppStorage("colorMode") var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
@@ -37,7 +36,7 @@ struct DocumentView: View {
                     .foregroundColor(colorMode ? .white : .primary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(15)
-                    .background(color ?? (colorMode ? theme.carousel() : themeManager.cardSurface))
+                    .background(color ?? (colorMode ? themeManager.carouselColor(index: 0) : themeManager.cardSurface))
                     .cornerRadius(15)
                     Divider()
                 }

--- a/hackertracker/Views/DocumentView.swift
+++ b/hackertracker/Views/DocumentView.swift
@@ -17,7 +17,7 @@ struct DocumentView: View {
     /// bar (not duplicated in the scroll body). Emergency / merch-help docs
     /// still want the prominent in-body banner, so this defaults to true.
     var showInlineTitle: Bool = true
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
 

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -148,7 +148,7 @@ struct EventCell: View {
 
         }
         .background(themeManager.cardSurface)
-        .cornerRadius(10)
+        .cornerRadius(ThemeMetrics.cardRadius)
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
         // Opportunistic warm on cell materialization, mirroring

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -149,12 +149,6 @@ struct EventCell: View {
         .cornerRadius(10)
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
-        .swipeActions {
-            Button(bookmarkIds.contains(Int32(event.id)) ? "Remove Bookmark" : "Bookmark") {
-                bookmarkAction()
-            }.buttonStyle(DefaultButtonStyle())
-                .tint(bookmarkIds.contains(Int32(event.id)) ? .red : .yellow)
-        }
         // Opportunistic warm on cell materialization, mirroring
         // ContentCellView. Gated on user toggle + cache's own
         // capability + 100-char checks.

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -20,7 +20,11 @@ struct EventCell: View {
     /// tab rows now opt into on-device summaries the same way.
     @AppStorage("aiSummaries") private var aiSummaries: Bool = false
     @State private var showingOriginalDescription: Bool = false
-    @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
+    /// Perf C: bookmark ids come from the environment instead of a
+    /// per-row @FetchRequest. The list-level view that owns the single
+    /// Bookmarks FetchRequest (EventsView, GlobalSearchView, InfoView's
+    /// shared-schedule pane) publishes one precomputed snapshot.
+    @Environment(\.bookmarkSnapshot) private var bookmarkSnapshot
     /// Set of event ids that have a saved private Note. Published by
     /// EventsView (which holds the single Note FetchRequest); defaults
     /// to empty when this cell renders inside a screen that doesn't
@@ -32,8 +36,7 @@ struct EventCell: View {
     
 
     func bookmarkAction() {
-        let bookmarkIds = Set(bookmarks.map(\.id))
-        if bookmarkIds.contains(Int32(event.id)) {
+        if bookmarkSnapshot.ids.contains(Int32(event.id)) {
             Log.bookmarks.debug("eventCell remove \(event.id)")
             BookmarkUtility.deleteBookmark(context: viewContext, id: event.id)
             NotificationUtility.removeNotification(id: event.id)
@@ -49,8 +52,7 @@ struct EventCell: View {
         // Phase 4 follow-up: observe DateFormatterUtility so SwiftUI
         // re-renders this view when the active timezone changes.
         let _ = dfu.tzGeneration
-        let bookmarkIds = Set(bookmarks.map(\.id))
-        let bookmarkIntsForConflict = bookmarks.map { Int($0.id) }
+        let bookmarkIds = bookmarkSnapshot.ids
         VStack(alignment: .leading) {
             HStack(alignment: .center) {
                 Rectangle().fill(getEventTagColorBackground())
@@ -128,11 +130,11 @@ struct EventCell: View {
                             bookmarkAction()
                         } label: {
                             Image(systemName: bookmarkIds.contains(Int32(event.id)) ? "bookmark.fill" : "bookmark")
-                                .foregroundColor((bookmarkIds.contains(Int32(event.id)) && viewModel.bookmarkConflicts(eventId: event.id, bookmarks: bookmarkIntsForConflict)) ? themeManager.danger : .primary)
+                                .foregroundColor((bookmarkIds.contains(Int32(event.id)) && viewModel.bookmarkConflicts(eventId: event.id, bookmarks: bookmarkSnapshot.conflictIds, bookmarkKey: bookmarkSnapshot.conflictKey)) ? themeManager.danger : .primary)
                         }
                         .accessibilityLabel(
                             bookmarkIds.contains(Int32(event.id))
-                                ? (viewModel.bookmarkConflicts(eventId: event.id, bookmarks: bookmarkIntsForConflict)
+                                ? (viewModel.bookmarkConflicts(eventId: event.id, bookmarks: bookmarkSnapshot.conflictIds, bookmarkKey: bookmarkSnapshot.conflictKey)
                                     ? "Bookmarked, conflicts with another event"
                                     : "Remove bookmark")
                                 : "Add bookmark"

--- a/hackertracker/Views/EventCellView.swift
+++ b/hackertracker/Views/EventCellView.swift
@@ -14,11 +14,11 @@ struct EventCell: View {
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
     let dfu = DateFormatterUtility.shared
-    @AppStorage("notifyAt") var notifyAt: Int = 20
-    @AppStorage("show24hourtime") var show24hourtime: Bool = true
+    @AppStorage(AppStorageKeys.notifyAt) var notifyAt: Int = 20
+    @AppStorage(AppStorageKeys.show24hourtime) var show24hourtime: Bool = true
     /// Mirror of ContentCellView's AI summary plumbing — Schedule
     /// tab rows now opt into on-device summaries the same way.
-    @AppStorage("aiSummaries") private var aiSummaries: Bool = false
+    @AppStorage(AppStorageKeys.aiSummaries) private var aiSummaries: Bool = false
     @State private var showingOriginalDescription: Bool = false
     /// Perf C: bookmark ids come from the environment instead of a
     /// per-row @FetchRequest. The list-level view that owns the single

--- a/hackertracker/Views/EventDetailView.swift
+++ b/hackertracker/Views/EventDetailView.swift
@@ -13,7 +13,6 @@ struct EventDetailView: View {
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
     @EnvironmentObject var selected: SelectedConference
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
     let dfu = DateFormatterUtility.shared
     @State var showingAlert = false
     @State var nExists = false
@@ -145,7 +144,7 @@ struct EventDetailView: View {
 struct showSpeakers: View {
     var event: Event
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
+    @Environment(ThemeManager.self) private var themeManager
     @State private var collapsed = false
     let columns = [GridItem(.flexible()), GridItem(.flexible())]
 
@@ -181,7 +180,7 @@ struct showSpeakers: View {
                                 .foregroundColor(.white)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                                 .padding(15)
-                                .background(theme.carousel().gradient)
+                                .background(themeManager.carouselColor(index: person.id).gradient)
                                 .cornerRadius(15)
                             }
                         }
@@ -200,7 +199,7 @@ struct showSpeakers: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(15)
-                    .background(theme.carousel().gradient)
+                    .background(themeManager.carouselColor(index: people[0].id).gradient)
                     .cornerRadius(15)
                 }
             }

--- a/hackertracker/Views/EventDetailView.swift
+++ b/hackertracker/Views/EventDetailView.swift
@@ -18,7 +18,7 @@ struct EventDetailView: View {
     @State var nExists = false
 
     @Environment(\.managedObjectContext) private var viewContext
-    @AppStorage("notifyAt") var notifyAt: Int = 20
+    @AppStorage(AppStorageKeys.notifyAt) var notifyAt: Int = 20
 
     let columns = [
         GridItem(.flexible()),

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -9,10 +9,10 @@ import SwiftUI
 
 struct EventsView: View {
     @EnvironmentObject var selected: SelectedConference
-    @AppStorage("showLocaltime") var showLocaltime: Bool = false
-    @AppStorage("show24hourtime") var show24hourtime: Bool = true
-    @AppStorage("showPastEvents") var showPastEvents: Bool = true
-    @AppStorage("showConflictAlert") var showConflictAlert: Bool = true
+    @AppStorage(AppStorageKeys.showLocaltime) var showLocaltime: Bool = false
+    @AppStorage(AppStorageKeys.show24hourtime) var show24hourtime: Bool = true
+    @AppStorage(AppStorageKeys.showPastEvents) var showPastEvents: Bool = true
+    @AppStorage(AppStorageKeys.showConflictAlert) var showConflictAlert: Bool = true
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
     @EnvironmentObject var scrollBus: ScrollCommandBus
@@ -81,10 +81,10 @@ struct EventsView: View {
     /// User toggle (defaulting on) for whether custom events appear in
     /// the schedule at all. Lives next to the rest of the schedule
     /// state so its value is read inline with the synthesizer.
-    @AppStorage("showCustomEvents") private var showCustomEventsInSchedule: Bool = true
+    @AppStorage(AppStorageKeys.showCustomEvents) private var showCustomEventsInSchedule: Bool = true
     /// Filter-chip composition mode. Read from the same
     /// AppStorage key the Filters sheet writes to.
-    @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    @AppStorage(AppStorageKeys.filterMatchMode) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
     private var filterMatchMode: FilterMatchMode {
         FilterMatchMode(rawOrDefault: filterMatchModeRaw)
     }

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -210,32 +210,6 @@ struct EventsView: View {
   /// other so the detail pane never shows stale state.
   @State private var ipadSelectedCustomEventId: UUID? = nil
 
-  /// Inline search bar shown only when `isSearching` is true.
-  @ViewBuilder private var inlineSearchBar: some View {
-      if isSearching {
-          HStack(spacing: 8) {
-              Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-              TextField("Search title, speaker, or description", text: $searchText)
-                  .focused($searchFocused)
-                  .submitLabel(.search)
-                  .autocorrectionDisabled()
-                  .textInputAutocapitalization(.never)
-              if !searchText.isEmpty {
-                  Button {
-                      searchText = ""
-                  } label: {
-                      Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                  }
-                  .accessibilityLabel("Clear search text")
-              }
-          }
-          .padding(.horizontal, 12)
-          .padding(.vertical, 8)
-          .background(.thinMaterial)
-          .transition(.move(edge: .top).combined(with: .opacity))
-      }
-  }
-
   /// Polish: "Jump to Day" Menu. Now displayed as a floating button at the
   /// bottom-right of the schedule (see .overlay on the schedule VStack).
   /// The label here is just the icon; the surrounding floating-button chrome
@@ -281,23 +255,6 @@ struct EventsView: View {
       .menuOrder(.fixed)
   }
 
-  /// Toolbar button that toggles the inline search field.
-  @ViewBuilder private var searchToggleButton: some View {
-      Button {
-          withAnimation(.easeInOut(duration: 0.2)) {
-              isSearching.toggle()
-          }
-          if isSearching {
-              searchFocused = true
-          } else {
-              searchText = ""
-          }
-      } label: {
-          Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
-      }
-      .accessibilityLabel(isSearching ? "Close search" : "Search schedule")
-  }
-
   /// Schedule body content used inside both the iPhone NavigationStack
   /// and the iPad NavigationSplitView sidebar. Contains the emergency
   /// banner, inline-search bar, EventScrollView, floating Filter +
@@ -313,7 +270,7 @@ struct EventsView: View {
         }
       }
       VStack(spacing: 0) {
-        inlineSearchBar
+        InlineSearchBar(placeholder: "Search title, speaker, or description", text: $searchText, isFocused: $searchFocused, visible: isSearching)
         EventScrollView(
           events: scheduleGrouped,
           dayTag: eventDay,
@@ -408,7 +365,7 @@ struct EventsView: View {
             Image(systemName: "plus")
           }
           .accessibilityLabel("Add custom event")
-          searchToggleButton
+          SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search schedule")
         }
       }
       .task(id: searchText) {
@@ -542,7 +499,7 @@ struct EventsView: View {
       } */
     } else {
       VStack(spacing: 0) {
-        inlineSearchBar
+        InlineSearchBar(placeholder: "Search title, speaker, or description", text: $searchText, isFocused: $searchFocused, visible: isSearching)
         EventScrollView(
           events: scheduleGrouped,
           dayTag: eventDay,
@@ -603,7 +560,7 @@ struct EventsView: View {
               Image(systemName: "arrow.up.arrow.down")
             }
             .accessibilityLabel("Jump to day")
-            searchToggleButton
+            SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search schedule")
           }
         }
         .task(id: searchText) {

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -15,10 +15,7 @@ struct EventsView: View {
     @AppStorage("showConflictAlert") var showConflictAlert: Bool = true
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
-    @EnvironmentObject var toTop: ToTop
-    @EnvironmentObject var toBottom: ToBottom
-    @EnvironmentObject var toCurrent: ToCurrent
-    @EnvironmentObject var toNext: ToNext
+    @EnvironmentObject var scrollBus: ScrollCommandBus
     @EnvironmentObject var filters: Filters
     let dfu = DateFormatterUtility.shared
     var includeNav: Bool = true
@@ -92,20 +89,91 @@ struct EventsView: View {
         FilterMatchMode(rawOrDefault: filterMatchModeRaw)
     }
 
-    /// Firestore events + synthesized CustomEvents that target the
-    /// currently-selected conference. Three Schedule call sites read
-    /// this in place of viewModel.events so user-created rows flow
-    /// through filters / search / eventDayGroup naturally.
+    // MARK: Perf A: shared filter+search+group cache
+    //
+    // The filter -> search -> eventDayGroup pipeline used to be
+    // recomputed inline at five call sites per body pass (filtered
+    // count, two jump-to-day menus, two EventScrollViews). It's now
+    // computed exactly once per relevant input change via the
+    // `.task(id: schedulePipelineKey)` below (same shape as
+    // SpeakersView's speakerTagIdsMap cache) and shared by every
+    // call site in both the iPhone and iPad branches.
+
+    /// Filtered + searched events grouped (and pre-sorted) by day.
+    /// Feeds both EventScrollView instances.
+    @State private var scheduleGrouped: [(key: String, value: [Event])] = []
+    /// Day keys for the jump-to-day menus. Derived from the filtered
+    /// (but NOT searched) pipeline — the menus have always ignored the
+    /// search text, so preserve that.
+    @State private var scheduleDayKeys: [String] = []
     /// Live count of events that survive the current filter +
     /// search selection. Driven into both the Filters sheet's
     /// tally label and any future toolbar-resident counter.
-    private var scheduleFilteredCount: Int {
-        scheduleEvents
-            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
-            .search(text: debouncedSearch, speakers: viewModel.speakers)
-            .count
+    @State private var scheduleFilteredCount: Int = 0
+
+    /// Identity of every input the pipeline reads. When any of them
+    /// change, `.task(id:)` re-runs `recomputeSchedulePipeline()`.
+    private var schedulePipelineKey: Int {
+        var hasher = Hasher()
+        hasher.combine(selected.code)
+        // Firestore events: id + timestamps + title + tags + location
+        // cover the fields the pipeline and the rendered cells read.
+        hasher.combine(viewModel.events.count)
+        for e in viewModel.events {
+            hasher.combine(e.id)
+            hasher.combine(e.beginTimestamp)
+            hasher.combine(e.endTimestamp)
+            hasher.combine(e.title)
+            hasher.combine(e.tagIds)
+            hasher.combine(e.locationId)
+        }
+        // Custom events (synthesized into the schedule when enabled).
+        hasher.combine(showCustomEventsInSchedule)
+        hasher.combine(customEvents.count)
+        for c in customEvents {
+            hasher.combine(c.id)
+            hasher.combine(c.beginTimestamp)
+            hasher.combine(c.endTimestamp)
+            hasher.combine(c.title)
+            hasher.combine(c.colorHex)
+            hasher.combine(c.eventDescription)
+            hasher.combine(c.conferenceCodes as? [String] ?? [])
+        }
+        // Filter / search selection.
+        hasher.combine(filters.filters)
+        hasher.combine(filterMatchModeRaw)
+        hasher.combine(debouncedSearch)
+        hasher.combine(viewModel.tagtypes.count)
+        hasher.combine(viewModel.speakers.count)
+        // Bookmark identity (bookmark chip + toggles from cells).
+        for b in bookmarks { hasher.combine(b.id) }
+        // Notes ("Has Notes" chip).
+        hasher.combine(noteEventIDsForScope)
+        hasher.combine(noteContentIDsForScope)
+        // Day-grouping timezone inputs.
+        hasher.combine(showLocaltime)
+        hasher.combine(viewModel.conference?.timezone)
+        hasher.combine(dfu.tzGeneration)
+        return hasher.finalize()
     }
 
+    /// Runs the pipeline once and fans the results out to the cached
+    /// @State copies above.
+    private func recomputeSchedulePipeline() {
+        let filtered = scheduleEvents
+            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
+        scheduleDayKeys = filtered
+            .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference)
+            .map { $0.key }
+        let searched = filtered.search(text: debouncedSearch, speakers: viewModel.speakers)
+        scheduleFilteredCount = searched.count
+        scheduleGrouped = searched.eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference)
+    }
+
+    /// Firestore events + synthesized CustomEvents that target the
+    /// currently-selected conference. The pipeline recompute reads
+    /// this in place of viewModel.events so user-created rows flow
+    /// through filters / search / eventDayGroup naturally.
     private var scheduleEvents: [Event] {
         guard showCustomEventsInSchedule else { return viewModel.events }
         let code = selected.code
@@ -177,32 +245,29 @@ struct EventsView: View {
       Menu {
           // Dates first (ascending; eventDayGroup already sorts that way),
           // then Top / Now / Next / Bottom.
-          ForEach(
-              scheduleEvents.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
-                  .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference), id: \.key
-          ) { day, _ in
+          ForEach(scheduleDayKeys, id: \.self) { day in
               Button(day) {
                   eventDay = day
               }
           }
           Divider()
           Button {
-              toTop.val = true
+              scrollBus.send(.top)
           } label: {
               Label("Top", systemImage: "arrow.up")
           }
           Button {
-              toCurrent.val = true
+              scrollBus.send(.current)
           } label: {
               Label("Now", systemImage: "clock")
           }
           Button {
-              toNext.val = true
+              scrollBus.send(.next)
           } label: {
               Label("Next", systemImage: "arrow.turn.right.down")
           }
           Button {
-              toBottom.val = true
+              scrollBus.send(.bottom)
           } label: {
               Label("Bottom", systemImage: "arrow.down")
           }
@@ -250,13 +315,7 @@ struct EventsView: View {
       VStack(spacing: 0) {
         inlineSearchBar
         EventScrollView(
-          events:
-            scheduleEvents
-            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
-            .search(text: debouncedSearch, speakers: viewModel.speakers)
-            .eventDayGroup(
-              showLocaltime: showLocaltime, conference: viewModel.conference
-            ),
+          events: scheduleGrouped,
           dayTag: eventDay,
           showPastEvents: showPastEvents, includeNav: includeNav,
           showLocaltime: $showLocaltime
@@ -324,7 +383,7 @@ struct EventsView: View {
             .onChange(of: showPastEvents) { _, value in
               Log.ui.debug("EventsView showPastEvents=\(value)")
               viewModel.showPastEvents = value
-              toTop.val = true
+              scrollBus.send(.top)
             }
             .toggleStyle(.automatic)
           } label: {
@@ -356,8 +415,15 @@ struct EventsView: View {
         try? await Task.sleep(nanoseconds: 250_000_000)
         if !Task.isCancelled { debouncedSearch = searchText }
       }
+      // Perf A: single recompute of the filter+search+group pipeline,
+      // shared by the EventScrollView, jump-to-day menu, and the
+      // filter sheet's matched count.
+      .task(id: schedulePipelineKey) {
+        recomputeSchedulePipeline()
+      }
       .environment(\.noteEventIDs, noteEventIDsForScope)
       .environment(\.noteContentIDs, noteContentIDsForScope)
+      .environment(\.bookmarkSnapshot, BookmarkSnapshot(bookmarkIds: bookmarks.map(\.id)))
       .onAppear { refreshNoteEventIDs() }
       .onReceive(NotificationCenter.default.publisher(
           for: .NSManagedObjectContextDidSave
@@ -420,6 +486,7 @@ struct EventsView: View {
       .environment(\.iPadCustomEventSelection, $ipadSelectedCustomEventId)
       .environment(\.noteEventIDs, noteEventIDsForScope)
       .environment(\.noteContentIDs, noteContentIDsForScope)
+      .environment(\.bookmarkSnapshot, BookmarkSnapshot(bookmarkIds: bookmarks.map(\.id)))
       .onAppear { refreshNoteEventIDs() }
       .onReceive(NotificationCenter.default.publisher(
           for: .NSManagedObjectContextDidSave
@@ -477,12 +544,7 @@ struct EventsView: View {
       VStack(spacing: 0) {
         inlineSearchBar
         EventScrollView(
-          events:
-            scheduleEvents
-            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
-            .search(text: debouncedSearch, speakers: viewModel.speakers).eventDayGroup(
-                showLocaltime: showLocaltime, conference: viewModel.conference
-            ),
+          events: scheduleGrouped,
           dayTag: eventDay,
           showPastEvents: showPastEvents, includeNav: includeNav,
           // tappedScheduleTwice: $tappedScheduleTwice, schedule: $schedule,
@@ -499,7 +561,7 @@ struct EventsView: View {
           ToolbarItemGroup(placement: .navigationBarTrailing) {
             Menu {
                 Button {
-                    toTop.val = true
+                    scrollBus.send(.top)
                 } label: {
                   HStack {
                     Text("Top")
@@ -507,7 +569,7 @@ struct EventsView: View {
                   }
                 }
                   Button {
-                      toCurrent.val = true
+                      scrollBus.send(.current)
                   } label: {
                     HStack {
                       Text("Now")
@@ -515,7 +577,7 @@ struct EventsView: View {
                     }
                   }
                   Button {
-                      toNext.val = true
+                      scrollBus.send(.next)
                   } label: {
                     HStack {
                       Text("Next")
@@ -523,7 +585,7 @@ struct EventsView: View {
                     }
                   }
                   Button {
-                      toBottom.val = true
+                      scrollBus.send(.bottom)
                   } label: {
                     HStack {
                       Text("Bottom")
@@ -531,10 +593,7 @@ struct EventsView: View {
                     }
                   }
                   Divider()
-              ForEach(
-                scheduleEvents.filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
-                    .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference), id: \.key
-              ) { day, _ in
+              ForEach(scheduleDayKeys, id: \.self) { day in
                 Button(day) {
                   eventDay = day
                 }
@@ -552,7 +611,15 @@ struct EventsView: View {
             try? await Task.sleep(nanoseconds: 250_000_000)
             if !Task.isCancelled { debouncedSearch = searchText }
         }
-      .onChange(of: viewModel.conference) { _, con in 
+        // Perf A: single recompute of the filter+search+group pipeline
+        // for the embedded (no-nav) schedule variant.
+        .task(id: schedulePipelineKey) {
+            recomputeSchedulePipeline()
+        }
+        // Perf C: cells read bookmarks from the environment; publish
+        // the snapshot for the embedded variant too.
+        .environment(\.bookmarkSnapshot, BookmarkSnapshot(bookmarkIds: bookmarks.map(\.id)))
+      .onChange(of: viewModel.conference) { _, con in
         Log.ui.debug("EventsView conference -> \(con?.name ?? "<nil>", privacy: .public)")
       }
     }
@@ -569,10 +636,7 @@ struct EventScrollView: View {
     let dfu = DateFormatterUtility.shared
     // @Binding var tappedScheduleTwice: Bool
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var toTop: ToTop
-    @EnvironmentObject var toCurrent: ToCurrent
-    @EnvironmentObject var toBottom: ToBottom
-    @EnvironmentObject var toNext: ToNext
+    @EnvironmentObject var scrollBus: ScrollCommandBus
     @State var viewShowing = false
     @Binding var showLocaltime: Bool
     @State var eventDayGroup: [(key: String, value: [Event])] = []
@@ -581,9 +645,52 @@ struct EventScrollView: View {
     /// When this is empty we show a ContentUnavailableView instead of a
     /// blank scroll surface.
     private var visibleEvents: [(key: String, value: [Event])] {
-        showPastEvents ? events : events.compactMap { (key, day) in
-            let upcoming = day.filter { Date() < $0.endTimestamp }
+        let now = Date()
+        return showPastEvents ? events : events.compactMap { (key, day) in
+            let upcoming = day.filter { now < $0.endTimestamp }
             return upcoming.isEmpty ? nil : (key, upcoming)
+        }
+    }
+
+    /// ScrollCommandBus consumer. Performs the scroll for each command
+    /// against this instance's proxy. Preserves the old ToTop fallback:
+    /// when past events are hidden, "top" behaves like "current" since
+    /// the true first event may not be rendered.
+    private func handle(_ command: ScrollCommand, proxy: ScrollViewProxy) {
+        // Day groups arrive pre-sorted by begin time (eventDayGroup),
+        // so a flatMap walks events in chronological order.
+        let ordered = events.flatMap { $0.value }
+        switch command {
+        case .top:
+            guard showPastEvents else {
+                handle(.current, proxy: proxy)
+                return
+            }
+            if let e = ordered.first {
+                withAnimation {
+                    proxy.scrollTo(e.id, anchor: .top)
+                }
+            }
+        case .bottom:
+            if let e = ordered.last {
+                withAnimation {
+                    proxy.scrollTo(e.id)
+                }
+            }
+        case .current:
+            let curDate = Date()
+            if let e = ordered.first(where: { curDate < $0.endTimestamp }) {
+                withAnimation {
+                    proxy.scrollTo(e.id, anchor: .top)
+                }
+            }
+        case .next:
+            let curDate = Date()
+            if let e = ordered.first(where: { curDate < $0.beginTimestamp }) {
+                withAnimation {
+                    proxy.scrollTo(e.id, anchor: .top)
+                }
+            }
         }
     }
 
@@ -654,51 +761,8 @@ struct EventScrollView: View {
                           proxy.scrollTo(changedValue, anchor: .top)
                       }
                   }
-                  .onChange(of: toTop.val) { _, tapTop in 
-                      guard tapTop else { return }
-                      if tapTop, showPastEvents {
-                          if let e = events.flatMap({$0.value}).sorted(by: {$0.beginTimestamp < $1.beginTimestamp}).first {
-                              withAnimation {
-                                  proxy.scrollTo(e.id, anchor: .top)
-                              }
-                          }
-                          toTop.val = false
-                      } else {
-                          toTop.val = false
-                          toCurrent.val = true
-                      }
-                      
-                  }
-                  .onChange(of: toBottom.val) { _, tapBottom in 
-                      guard tapBottom else { return }
-                      if tapBottom, let es = events.map({$0.value.sorted{$0.beginTimestamp < $1.beginTimestamp}}).last, let e = es.last {
-                          withAnimation {
-                              proxy.scrollTo(e.id)
-                          }
-                          toBottom.val = false
-                      }
-                  }
-                  .onChange(of: toCurrent.val) { _, tapCurrent in 
-                      guard tapCurrent else { return }
-                      let curDate = Date()
-                      // print("events: \(events.key)")
-                      if tapCurrent, let es = events.flatMap({$0.value}).sorted(by: {$0.beginTimestamp < $1.beginTimestamp}).first(where: {curDate < $0.endTimestamp}) {
-                          withAnimation {
-                              proxy.scrollTo(es.id, anchor: .top)
-                          }
-                          toCurrent.val = false
-                      }
-                  }
-                  .onChange(of: toNext.val) { _, tapNext in 
-                      guard tapNext else { return }
-                      let curDate = Date()
-                      // print("events: \(events.key)")
-                      if tapNext, let es = events.flatMap({$0.value}).sorted(by: {$0.beginTimestamp < $1.beginTimestamp}).first(where: {curDate < $0.beginTimestamp}) {
-                          withAnimation {
-                              proxy.scrollTo(es.id, anchor: .top)
-                          }
-                          toNext.val = false
-                      }
+                  .onReceive(scrollBus.subject) { command in
+                      handle(command, proxy: proxy)
                   }
                   .onAppear {
                       viewShowing = true
@@ -741,12 +805,11 @@ struct EventData: View {
         .background(.ultraThinMaterial)
     ) {
       Section {
-        ForEach(
-          events.sorted {
-            $0.beginTimestamp < $1.beginTimestamp
-          }, id: \.id
-        ) { event in
-          if showPastEvents || event.endTimestamp >= Date() {
+        // Perf D: per-day arrays arrive pre-sorted from eventDayGroup;
+        // capture "now" once instead of calling Date() per row.
+        let now = Date()
+        ForEach(events, id: \.id) { event in
+          if showPastEvents || event.endTimestamp >= now {
             // Three row variants:
             //   1. iPad split + custom event -> set the custom-event
             //      selection (clears the content selection) so the

--- a/hackertracker/Views/FAQListView.swift
+++ b/hackertracker/Views/FAQListView.swift
@@ -23,64 +23,9 @@ struct FAQListView: View {
         viewModel.faqs.search(text: searchText)
     }
 
-    @ViewBuilder private var inlineSearchBar: some View {
-        if isSearching {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-                TextField("Search FAQs", text: $searchText)
-                    .focused($searchFocused)
-                    .submitLabel(.search)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                    }
-                    .accessibilityLabel("Clear search text")
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.thinMaterial)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    @ViewBuilder private var searchToggleButton: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isSearching.toggle()
-            }
-            if isSearching {
-                searchFocused = true
-            } else {
-                searchText = ""
-            }
-        } label: {
-            Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
-        }
-        .accessibilityLabel(isSearching ? "Close search" : "Search FAQs")
-    }
-
-    @ViewBuilder private var jumpMenu: some View {
-        Menu {
-            Button {
-                jumpTarget = "__top"
-            } label: { Label("Top", systemImage: "arrow.up") }
-            Button {
-                jumpTarget = "__bottom"
-            } label: { Label("Bottom", systemImage: "arrow.down") }
-        } label: {
-            Image(systemName: "arrow.up.arrow.down")
-        }
-        .menuOrder(.fixed)
-    }
-
     var body: some View {
         VStack(spacing: 0) {
-            inlineSearchBar
+            InlineSearchBar(placeholder: "Search FAQs", text: $searchText, isFocused: $searchFocused, visible: isSearching)
             ScrollView {
                 if filteredFaqs.isEmpty {
                     if searchText.isEmpty {
@@ -122,12 +67,7 @@ struct FAQListView: View {
         .overlay(alignment: .bottom) {
             HStack {
                 Spacer()
-                jumpMenu
-                    .font(themeManager.title2Font)
-                    .foregroundStyle(.primary)
-                    .frame(width: 48, height: 48)
-                    .background(.regularMaterial, in: Circle())
-                    .accessibilityLabel("Jump")
+                JumpMenuOverlay(target: $jumpTarget)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 12)
@@ -139,7 +79,7 @@ struct FAQListView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                searchToggleButton
+                SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search FAQs")
             }
         }
         .analyticsScreen(name: "FAQListView")

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -11,7 +11,7 @@ struct EventFilters: View {
     let tagtypes: [TagType]
     @Binding var showFilters: Bool
     @EnvironmentObject var filters: Filters
-    @EnvironmentObject var toTop: ToTop
+    @EnvironmentObject var scrollBus: ScrollCommandBus
     @Environment(ThemeManager.self) private var themeManager
     var showBookmarks: Bool = true
     /// Number of items that would survive the current filter selection.
@@ -81,7 +81,7 @@ struct EventFilters: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") {
                         showFilters = false
-                        toTop.val = true
+                        scrollBus.send(.top)
                     }
                     .bold()
                 }

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -22,7 +22,7 @@ struct EventFilters: View {
     /// Singular noun used in the live tally label ("event", "talk",
     /// etc.). Plural is auto-derived with a trailing s.
     var unitLabel: String = "event"
-    @AppStorage("filterMatchMode") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    @AppStorage(AppStorageKeys.filterMatchMode) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
 
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
 

--- a/hackertracker/Views/GlobalSearchView.swift
+++ b/hackertracker/Views/GlobalSearchView.swift
@@ -17,7 +17,11 @@ struct GlobalSearchView: View {
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
     @AppStorage("colorMode") var colorMode: Bool = false
-    
+    /// Perf C: single list-level bookmarks fetch published into the
+    /// environment for the EventCells in the Schedule section (they no
+    /// longer run a per-row @FetchRequest).
+    @FetchRequest(sortDescriptors: []) private var bookmarks: FetchedResults<Bookmarks>
+
     var body: some View {
         ScrollView {
             ScrollViewReader { _ in
@@ -102,6 +106,7 @@ struct GlobalSearchView: View {
                     }
                 }
             }
+            .environment(\.bookmarkSnapshot, BookmarkSnapshot(bookmarkIds: bookmarks.map(\.id)))
             .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
             .navigationTitle("Global Search")
             .themedNavTitle("Global Search", themeManager)

--- a/hackertracker/Views/GlobalSearchView.swift
+++ b/hackertracker/Views/GlobalSearchView.swift
@@ -15,7 +15,7 @@ struct GlobalSearchView: View {
     @State private var debouncedSearch = ""
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     /// Perf C: single list-level bookmarks fetch published into the
     /// environment for the EventCells in the Schedule section (they no
     /// longer run a per-row @FetchRequest).

--- a/hackertracker/Views/GlobalSearchView.swift
+++ b/hackertracker/Views/GlobalSearchView.swift
@@ -9,6 +9,10 @@ import SwiftUI
 
 struct GlobalSearchView: View {
     @State private var searchText = ""
+    /// Perf C: debounced mirror of `searchText`. Updated on a 200ms
+    /// .task(id:) so search results re-filter once per pause rather
+    /// than on every keystroke.
+    @State private var debouncedSearch = ""
     @EnvironmentObject var theme: Theme
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
@@ -17,10 +21,10 @@ struct GlobalSearchView: View {
     var body: some View {
         ScrollView {
             ScrollViewReader { _ in
-                if !searchText.isEmpty {
+                if !debouncedSearch.isEmpty {
                     LazyVStack(alignment: .leading, pinnedViews: [.sectionHeaders]) {
                         Section(header: GlobalSearchHeader(headerText: "Schedule")) {
-                            ForEach(viewModel.events.search(text: searchText, speakers: viewModel.speakers).sorted {$0.beginTimestamp < $1.beginTimestamp}, id: \.id) { event in
+                            ForEach(viewModel.events.search(text: debouncedSearch, speakers: viewModel.speakers).sorted {$0.beginTimestamp < $1.beginTimestamp}, id: \.id) { event in
                                 NavigationLink(destination: ContentDetailView(contentId: event.contentId)) {
                                     EventCell(event: event, showDay: true)
                                         .id(event.id)
@@ -29,10 +33,10 @@ struct GlobalSearchView: View {
                                 }
                             }
                         }
-                        
+
                         VStack(alignment: .leading) {
                             Section(header: GlobalSearchHeader(headerText: "Speakers")) {
-                                ForEach(viewModel.speakers.search(text: searchText).sorted {
+                                ForEach(viewModel.speakers.search(text: debouncedSearch).sorted {
                                     $0.name < $1.name
                                 }, id: \.id) { speaker in
                                     NavigationLink(destination: SpeakerDetailView(id: speaker.id)) {
@@ -45,9 +49,9 @@ struct GlobalSearchView: View {
                                 }
                             }
                         }
-                        
+
                         Section(header: GlobalSearchHeader(headerText: "Documents")) {
-                            ForEach(viewModel.documents.search(text: searchText).sorted {
+                            ForEach(viewModel.documents.search(text: debouncedSearch).sorted {
                                 $0.title < $1.title
                             }, id: \.id) { document in
                                 NavigationLink(destination: DocumentView(title_text: document.title, body_text: document.body)) {
@@ -57,11 +61,11 @@ struct GlobalSearchView: View {
                                 }
                             }
                         }
-                        
+
                         if let ott = self.viewModel.tagtypes.first(where: { $0.category == "orga" }) {
                             ForEach(ott.tags, id: \.id) { tag in
                                 Section(header: GlobalSearchHeader(headerText: tag.label)) {
-                                    ForEach(self.viewModel.orgs.filter { $0.tag_ids.contains(tag.id) }.search(text: searchText).sorted {
+                                    ForEach(self.viewModel.orgs.filter { $0.tag_ids.contains(tag.id) }.search(text: debouncedSearch).sorted {
                                         $0.name < $1.name
                                     }, id: \.id) { org in
                                         NavigationLink(destination: DocumentView(title_text: org.name, body_text: org.description)) {
@@ -73,20 +77,20 @@ struct GlobalSearchView: View {
                                 }
                             }
                         }
-                        
+
                         if viewModel.faqs.count > 0 {
                             Section(header: GlobalSearchHeader(headerText: "FAQ")) {
-                                ForEach(self.viewModel.faqs.search(text: searchText)) { faq in
+                                ForEach(self.viewModel.faqs.search(text: debouncedSearch)) { faq in
                                     faqRow(faq: faq)
                                         .foregroundColor(.primary)
                                         .padding(1)
                                 }
                             }
                         }
-                        
+
                         if viewModel.news.count > 0 {
                             Section(header: GlobalSearchHeader(headerText: "News")) {
-                                ForEach(self.viewModel.news.search(text: searchText).sorted {
+                                ForEach(self.viewModel.news.search(text: debouncedSearch).sorted {
                                     $0.updatedAt < $1.updatedAt
                                 }) { article in
                                     articleRow(article: article)
@@ -101,6 +105,10 @@ struct GlobalSearchView: View {
             .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
             .navigationTitle("Global Search")
             .themedNavTitle("Global Search", themeManager)
+            .task(id: searchText) {
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                if !Task.isCancelled { debouncedSearch = searchText }
+            }
         }
     }
 }

--- a/hackertracker/Views/GlobalSearchView.swift
+++ b/hackertracker/Views/GlobalSearchView.swift
@@ -13,7 +13,6 @@ struct GlobalSearchView: View {
     /// .task(id:) so search results re-filter once per pause rather
     /// than on every keystroke.
     @State private var debouncedSearch = ""
-    @EnvironmentObject var theme: Theme
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
     @AppStorage("colorMode") var colorMode: Bool = false
@@ -44,7 +43,7 @@ struct GlobalSearchView: View {
                                     $0.name < $1.name
                                 }, id: \.id) { speaker in
                                     NavigationLink(destination: SpeakerDetailView(id: speaker.id)) {
-                                        SpeakerRow(speaker: speaker, themeColor: theme.carousel())
+                                        SpeakerRow(speaker: speaker, themeColor: themeManager.carouselColor(index: speaker.id))
                                             .id(speaker.id)
                                             .foregroundColor(.primary)
                                             .padding(1)
@@ -59,7 +58,7 @@ struct GlobalSearchView: View {
                                 $0.title < $1.title
                             }, id: \.id) { document in
                                 NavigationLink(destination: DocumentView(title_text: document.title, body_text: document.body)) {
-                                    docSearchRow(title_text: document.title, themeColor: colorMode ? theme.carousel() : Color(.systemGray2))
+                                    docSearchRow(title_text: document.title, themeColor: colorMode ? themeManager.carouselColor(index: document.id) : Color(.systemGray2))
                                         .foregroundColor(.primary)
                                         .padding(1)
                                 }
@@ -73,7 +72,7 @@ struct GlobalSearchView: View {
                                         $0.name < $1.name
                                     }, id: \.id) { org in
                                         NavigationLink(destination: DocumentView(title_text: org.name, body_text: org.description)) {
-                                            orgSearchRow(org: org, themeColor: theme.carousel())
+                                            orgSearchRow(org: org, themeColor: themeManager.carouselColor(forKey: org.id ?? org.name))
                                                 .foregroundColor(.primary)
                                                 .padding(1)
                                         }

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -15,12 +15,12 @@ struct InfoView: View {
     //@Binding var tappedMainTwice: Bool
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(\.managedObjectContext) private var viewContext
-    @AppStorage("showLocaltime") var showLocaltime: Bool = false
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.showLocaltime) var showLocaltime: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     /// Per-conference collapse state for the square logo on this
     /// screen. Stored as a JSON-encoded Set<String> of conference
     /// codes that the user has collapsed; persists across launches.
-    @AppStorage("infoLogoCollapsedCodes") private var collapsedLogoCodesRaw: String = "[]"
+    @AppStorage(AppStorageKeys.infoLogoCollapsedCodes) private var collapsedLogoCodesRaw: String = "[]"
     @EnvironmentObject var selected: SelectedConference
     @EnvironmentObject var filters: Filters
     @Environment(ConferencesViewModel.self) private var consViewModel
@@ -56,7 +56,7 @@ struct InfoView: View {
     /// flip both AppStorage toggles, show a celebratory overlay for
     /// 3s, then fire the rickroll. State is local so the overlay can
     /// be triggered independently of the global enable flags.
-    @AppStorage("easterEgg") private var easterEgg: Bool = false
+    @AppStorage(AppStorageKeys.easterEgg) private var easterEgg: Bool = false
     @State private var easterEggOverlayVisible: Bool = false
     @Environment(\.colorScheme) private var easterEggOverlayColorScheme
     @State var schedule = UUID()
@@ -687,7 +687,7 @@ struct MenuView: View {
     // @Binding var tappedMainTwice: Bool
     @Environment(InfoViewModel.self) private var viewModel
     @EnvironmentObject var filters: Filters
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
     @State var schedule = UUID()
     @FetchRequest(sortDescriptors: []) var readnews: FetchedResults<News>
@@ -789,7 +789,7 @@ struct CardView: View {
     var foregroundColor: Color?
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
 
     var body: some View {
         if colorMode {

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -532,6 +532,9 @@ struct InfoView: View {
                       showPastEvents: true, includeNav: true,
                       showLocaltime: $showLocaltime)
                     //EventsView(sharedEvents: sharedEvents)
+                    // Perf C: EventCells read bookmarks from the
+                    // environment; publish this view's fetch results.
+                    .environment(\.bookmarkSnapshot, BookmarkSnapshot(bookmarkIds: bookmarks.map(\.id)))
                     .onAppear {
                         Log.app.debug("navigating to \(value, privacy: .public)")
                     }

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -17,6 +17,10 @@ struct InfoView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @AppStorage("showLocaltime") var showLocaltime: Bool = false
     @AppStorage("colorMode") var colorMode: Bool = false
+    /// Per-conference collapse state for the square logo on this
+    /// screen. Stored as a JSON-encoded Set<String> of conference
+    /// codes that the user has collapsed; persists across launches.
+    @AppStorage("infoLogoCollapsedCodes") private var collapsedLogoCodesRaw: String = "[]"
     @EnvironmentObject var selected: SelectedConference
     @EnvironmentObject var theme: Theme
     @EnvironmentObject var filters: Filters
@@ -261,13 +265,36 @@ struct InfoView: View {
                         }
                     }
                     if let logo = viewModel.conference?.squareLogo(for: theme.colorScheme),
-                       let logoUrl = URL(string: logo) {
-                        KFImage(logoUrl)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxWidth: 160, maxHeight: 160)
-                            .frame(maxWidth: .infinity)
-                            .padding(.top, 12)
+                       let logoUrl = URL(string: logo),
+                       let code = viewModel.conference?.code {
+                        let isCollapsed = collapsedLogoCodes.contains(code)
+                        VStack(spacing: 6) {
+                            Button {
+                                toggleLogoCollapsed(for: code)
+                            } label: {
+                                HStack(spacing: 6) {
+                                    Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                                        .font(themeManager.captionFont)
+                                    Text(isCollapsed ? "Show conference logo" : "Hide conference logo")
+                                        .font(themeManager.captionFont)
+                                }
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity)
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(isCollapsed ? "Show conference logo" : "Hide conference logo")
+
+                            if !isCollapsed {
+                                KFImage(logoUrl)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(maxWidth: 160, maxHeight: 160)
+                                    .frame(maxWidth: .infinity)
+                                    .onTapGesture { toggleLogoCollapsed(for: code) }
+                            }
+                        }
+                        .padding(.top, 12)
                     }
                     if let url = URL(string: "mailto:hackertracker@defcon.org?subject=HackerTracker&body=\r\n-----------------------\r\nVersion: \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] ?? "Unknown")  (\(Bundle.main.infoDictionary?["CFBundleVersion"] ?? "Unknown"))\r\niOS: \(ProcessInfo.processInfo.operatingSystemVersionString)\r\nApp: \(Bundle.main.bundleIdentifier ?? "Unknown")\r\n-----------------------\r\n".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
                         Divider()
@@ -573,6 +600,25 @@ struct InfoView: View {
         }
         // print("KidsTags: \(kidsTags)")
         return kidsTags
+    }
+
+    /// Decoded copy of the JSON-encoded collapsed-codes set. Reads
+    /// the `@AppStorage` raw string and falls back to an empty set
+    /// when the value is missing or malformed.
+    private var collapsedLogoCodes: Set<String> {
+        guard let data = collapsedLogoCodesRaw.data(using: .utf8),
+              let set = try? JSONDecoder().decode(Set<String>.self, from: data)
+        else { return [] }
+        return set
+    }
+
+    private func toggleLogoCollapsed(for code: String) {
+        var codes = collapsedLogoCodes
+        if codes.contains(code) { codes.remove(code) } else { codes.insert(code) }
+        if let data = try? JSONEncoder().encode(codes),
+           let raw = String(data: data, encoding: .utf8) {
+            collapsedLogoCodesRaw = raw
+        }
     }
 
     func tapped() {

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -22,7 +22,6 @@ struct InfoView: View {
     /// codes that the user has collapsed; persists across launches.
     @AppStorage("infoLogoCollapsedCodes") private var collapsedLogoCodesRaw: String = "[]"
     @EnvironmentObject var selected: SelectedConference
-    @EnvironmentObject var theme: Theme
     @EnvironmentObject var filters: Filters
     @Environment(ConferencesViewModel.self) private var consViewModel
     @Environment(\.openURL) private var openURL
@@ -122,7 +121,7 @@ struct InfoView: View {
                                 CountdownView(start: con.kickoffTimestamp)
                             }
                         } else {
-                            _04View(message: "Loading", show404: false).preferredColorScheme(theme.colorScheme)
+                            _04View(message: "Loading", show404: false).preferredColorScheme(themeManager.preferredColorScheme)
                                 .task {
                                     Log.app.debug("InfoView fetch data for \(selected.code, privacy: .public)")
                                     viewModel.fetchData(code: selected.code)
@@ -145,7 +144,7 @@ struct InfoView: View {
                             .foregroundColor(colorMode ? .white : .primary)
                             .frame(maxWidth: .infinity)
                             .padding(15)
-                            .background(colorMode ? theme.carousel() : themeManager.cardSurface)
+                            .background(colorMode ? themeManager.carouselColor(index: 0) : themeManager.cardSurface)
                             .cornerRadius(15)
                             Divider()
                         }
@@ -193,41 +192,41 @@ struct InfoView: View {
                                 }
                             }
                             NavigationLink(destination: GlobalSearchView()) {
-                                CardView(systemImage: "magnifyingglass", text: "Search", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                CardView(systemImage: "magnifyingglass", text: "Search", color: colorMode ? themeManager.carouselColor(index: 1) : themeManager.cardSurface)
                             }
                             Button {
                                 tabSelection = 2
                             } label: {
-                                CardView(systemImage: "calendar", text: "Schedule", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                CardView(systemImage: "calendar", text: "Schedule", color: colorMode ? themeManager.carouselColor(index: 2) : themeManager.cardSurface)
                             }
                             Button {
                                 tabSelection = 3
                             } label: {
-                                CardView(systemImage: "map", text: "Maps", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                CardView(systemImage: "map", text: "Maps", color: colorMode ? themeManager.carouselColor(index: 3) : themeManager.cardSurface)
                             }
                             // Combined-schedule entry-point: only when SharedScheduleStore
                             // has resolved >=2 overlapping conferences with bookmarks in each.
                             if sharedSchedule.isAvailable {
                                 NavigationLink(destination: SharedScheduleView()) {
-                                    CardView(systemImage: "calendar.badge.plus", text: "Combined Schedule", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                    CardView(systemImage: "calendar.badge.plus", text: "Combined Schedule", color: colorMode ? themeManager.carouselColor(index: 4) : themeManager.cardSurface)
                                 }
                             }
                             NavigationLink(destination: SpeakersView(speakers: viewModel.speakers)) {
-                                CardView(systemImage: "person.crop.rectangle", text: "Speakers", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                CardView(systemImage: "person.crop.rectangle", text: "Speakers", color: colorMode ? themeManager.carouselColor(index: 5) : themeManager.cardSurface)
                             }
                             if self.viewModel.locations.count > 0 {
                                 NavigationLink(destination: LocationView(locations: self.viewModel.locations)) {
-                                    CardView(systemImage: "mappin.and.ellipse", text: "Locations", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                    CardView(systemImage: "mappin.and.ellipse", text: "Locations", color: colorMode ? themeManager.carouselColor(index: 6) : themeManager.cardSurface)
                                 }
                             }
                             if viewModel.faqs.count > 0 {
                                 NavigationLink(destination: FAQListView()) {
-                                    CardView(systemImage: "questionmark.app", text: "FAQ", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                    CardView(systemImage: "questionmark.app", text: "FAQ", color: colorMode ? themeManager.carouselColor(index: 7) : themeManager.cardSurface)
                                 }
                             }
                             if viewModel.news.count > 0 {
                                 NavigationLink(destination: NewsListView()) {
-                                    CardView(systemImage: "newspaper", text: "News", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                    CardView(systemImage: "newspaper", text: "News", color: colorMode ? themeManager.carouselColor(index: 8) : themeManager.cardSurface)
                                 }
                             }
                             if let ott = self.viewModel.tagtypes.first(where: { $0.category == "orga" }) {
@@ -235,7 +234,7 @@ struct InfoView: View {
                                 ForEach(sortedTags, id: \.id) { tag in
                                     if viewModel.orgs.first(where: {$0.tag_ids.contains(tag.id)}) != nil {
                                         NavigationLink(destination: OrgsView(title: tag.label, tagId: tag.id, tabSelection: $tabSelection)) {
-                                            CardView(systemImage: "bag", text: tag.label, color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                            CardView(systemImage: "bag", text: tag.label, color: colorMode ? themeManager.carouselColor(index: tag.id) : themeManager.cardSurface)
                                         }
                                     }
                                 }
@@ -250,7 +249,7 @@ struct InfoView: View {
                                     tabSelection = 2
                                 } label: {
                                     // NavigationLink(destination: ScheduleView(tagIds: [1337], includeNav: false, navTitle: item.title)) {
-                                    CardView(systemImage: "figure.and.child.holdinghands", text: "Kids Content", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                                    CardView(systemImage: "figure.and.child.holdinghands", text: "Kids Content", color: colorMode ? themeManager.carouselColor(index: 9) : themeManager.cardSurface)
                                     // }
                                 }
                             }
@@ -264,7 +263,7 @@ struct InfoView: View {
                             }
                         }
                     }
-                    if let logo = viewModel.conference?.squareLogo(for: theme.colorScheme),
+                    if let logo = viewModel.conference?.squareLogo(for: themeManager.preferredColorScheme),
                        let logoUrl = URL(string: logo),
                        let code = viewModel.conference?.code {
                         let isCollapsed = collapsedLogoCodes.contains(code)
@@ -352,7 +351,6 @@ struct InfoView: View {
                 /*
                  @Environment(InfoViewModel.self) private var viewModel
                  @EnvironmentObject var selected: SelectedConference
-                 @EnvironmentObject var theme: Theme
                  @EnvironmentObject var filters: Filters
                  
                 if #available(iOS 17.0, *) {
@@ -378,7 +376,6 @@ struct InfoView: View {
                 }
                 .onAppear {
                     Log.app.debug("InfoView selectedCode=\(selected.code, privacy: .public)")
-                    if colorMode { theme.index = 0 }
                     checkAppUpdate()
                 }
                 .themedBackground(themeManager)
@@ -689,7 +686,6 @@ struct MenuView: View {
     @Binding var tabSelection: Int
     // @Binding var tappedMainTwice: Bool
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
     @EnvironmentObject var filters: Filters
     @AppStorage("colorMode") var colorMode: Bool = false
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
@@ -713,13 +709,13 @@ struct MenuView: View {
                 
                 case "locations":
                     NavigationLink(destination: LocationView(locations: self.viewModel.locations)) {
-                        CardView(systemImage: item.symbol ?? "mappin.and.ellipse", text: "Locations", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                        CardView(systemImage: item.symbol ?? "mappin.and.ellipse", text: "Locations", color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                     }
                 case "maps":
                     Button {
                         tabSelection = 3
                     } label: {
-                        CardView(systemImage: item.symbol ?? "map", text: "Maps", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                        CardView(systemImage: item.symbol ?? "map", text: "Maps", color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                     }
                 case "menu":
                     if let menuId = item.menuId, let m = viewModel.menus.first(where: {$0.id == menuId}) {
@@ -728,26 +724,26 @@ struct MenuView: View {
                         }
                             .padding(15)
                         ) {
-                            CardView(systemImage: item.symbol ?? "menucard", text: item.title, color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                            CardView(systemImage: item.symbol ?? "menucard", text: item.title, color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                         }
                     }
                 case "news":
                     NavigationLink(destination: NewsListView()) {
-                        CardView(systemImage: item.symbol ?? "newspaper", text: "News", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                        CardView(systemImage: item.symbol ?? "newspaper", text: "News", color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                     }
                 case "content":
                     NavigationLink(destination: ContentListView(content: viewModel.content)) {
-                        CardView(systemImage: item.symbol ?? "list.dash", text: item.title, color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                        CardView(systemImage: item.symbol ?? "list.dash", text: item.title, color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                     }
                 case "organizations":
                     if viewModel.orgs.first(where: {$0.tag_ids.contains(item.appliedTagIds[0])}) != nil {
                         NavigationLink(destination: OrgsView(title: item.title, tagId: item.appliedTagIds[0], tabSelection: $tabSelection)) {
-                            CardView(systemImage: item.symbol ?? "figure.walk", text: item.title, color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                            CardView(systemImage: item.symbol ?? "figure.walk", text: item.title, color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                         }
                     }
                 case "people":
                     NavigationLink(destination: SpeakersView(speakers: viewModel.speakers)) {
-                        CardView(systemImage: item.symbol ?? "person.3", text: "Speakers", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                        CardView(systemImage: item.symbol ?? "person.3", text: "Speakers", color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                     }
                 case "products":
                     if let c = self.viewModel.conference, c.enableMerch {
@@ -757,24 +753,24 @@ struct MenuView: View {
                     }
                 case "faq":
                     NavigationLink(destination: FAQListView()) {
-                        CardView(systemImage: item.symbol ?? "questionmark.app", text: "FAQ", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                        CardView(systemImage: item.symbol ?? "questionmark.app", text: "FAQ", color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                     }
                 case "schedule":
                         Button {
                             tabSelection = 2
                         } label: {
-                            CardView(systemImage: item.symbol ?? "calendar", text: "Schedule", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                            CardView(systemImage: item.symbol ?? "calendar", text: "Schedule", color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                         }
                 case "schedule_bookmark":
                     Button {
                         filters.filters = [1337]
                         tabSelection = 2
                     } label: {
-                        CardView(systemImage: item.symbol ?? "calendar", text: item.title, color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                        CardView(systemImage: item.symbol ?? "calendar", text: item.title, color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                     }
                 case "search":
                      NavigationLink(destination: GlobalSearchView()) {
-                         CardView(systemImage: item.symbol ?? "magnifyingglass", text: "Search", color: colorMode ? theme.carousel() : themeManager.cardSurface)
+                         CardView(systemImage: item.symbol ?? "magnifyingglass", text: "Search", color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                      }
                 default:
                     EmptyView()

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -287,6 +287,7 @@ struct InfoView: View {
 
                             if !isCollapsed {
                                 KFImage(logoUrl)
+                                    .htDownsampled(side: 160)
                                     .resizable()
                                     .scaledToFit()
                                     .frame(maxWidth: 160, maxHeight: 160)

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -6,6 +6,7 @@
 //
 
 import FirebaseFirestore
+import Kingfisher
 import SwiftUI
 import WebKit
 
@@ -258,6 +259,15 @@ struct InfoView: View {
                                 CardView(systemImage: "dollarsign", text: "Merch", color: colorMode ? ThemeColors.drkGreen : themeManager.cardSurface)
                             }
                         }
+                    }
+                    if let logo = viewModel.conference?.squareLogo(for: theme.colorScheme),
+                       let logoUrl = URL(string: logo) {
+                        KFImage(logoUrl)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxWidth: 160, maxHeight: 160)
+                            .frame(maxWidth: .infinity)
+                            .padding(.top, 12)
                     }
                     if let url = URL(string: "mailto:hackertracker@defcon.org?subject=HackerTracker&body=\r\n-----------------------\r\nVersion: \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] ?? "Unknown")  (\(Bundle.main.infoDictionary?["CFBundleVersion"] ?? "Unknown"))\r\niOS: \(ProcessInfo.processInfo.operatingSystemVersionString)\r\nApp: \(Bundle.main.bundleIdentifier ?? "Unknown")\r\n-----------------------\r\n".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
                         Divider()

--- a/hackertracker/Views/ListChrome.swift
+++ b/hackertracker/Views/ListChrome.swift
@@ -1,0 +1,120 @@
+//
+//  ListChrome.swift
+//  hackertracker
+//
+//  Shared chrome for the "search + jump" pattern repeated across the
+//  top-level list screens (Conferences, Merch, Orgs/Vendors, News, FAQs,
+//  and the Speakers / All Content search field). Extracted to remove
+//  near-identical copies that had begun to drift in small ways
+//  (padding, wording, accessibility labels). Screens with a
+//  structurally different jump menu (EventsView's day + Top/Now/Next/
+//  Bottom via ScrollCommandBus; Speakers' / All Content's alphabet
+//  jump-to-group; MapView's live in-document search with match count)
+//  keep their own copies rather than being force-fit into this shape.
+//
+
+import SwiftUI
+
+/// Inline search field shown below the nav bar, toggled by
+/// `SearchToggleButton`. Reproduces the shared layout: magnifying-glass
+/// icon, text field, conditional clear button, thin-material background,
+/// and a move+opacity transition.
+struct InlineSearchBar: View {
+    let placeholder: String
+    @Binding var text: String
+    var isFocused: FocusState<Bool>.Binding
+    let visible: Bool
+
+    var body: some View {
+        if visible {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass").foregroundColor(.secondary)
+                TextField(placeholder, text: $text)
+                    .focused(isFocused)
+                    .submitLabel(.search)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                if !text.isEmpty {
+                    Button {
+                        text = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
+                    }
+                    .accessibilityLabel("Clear search text")
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.thinMaterial)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+}
+
+/// Toolbar button that toggles `InlineSearchBar`'s visibility, handing
+/// focus to the field on open and clearing the search text on close.
+struct SearchToggleButton: View {
+    @Binding var isSearching: Bool
+    @Binding var searchText: String
+    var isFocused: FocusState<Bool>.Binding
+    /// e.g. "Search merch" / "Search conferences" — used for the
+    /// accessibility label while the field is closed.
+    let searchLabel: String
+
+    var body: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isSearching.toggle()
+            }
+            if isSearching {
+                isFocused.wrappedValue = true
+            } else {
+                searchText = ""
+            }
+        } label: {
+            Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
+        }
+        .accessibilityLabel(isSearching ? "Close search" : searchLabel)
+    }
+}
+
+/// Floating bottom-trailing "Top / Bottom" jump menu shared by the list
+/// screens that only need to jump to the ends of a single scroll region
+/// (as opposed to EventsView's per-day menu or the alphabet jump-to-group
+/// menus). Sets `target` to "__top" / "__bottom", which callers observe
+/// via `.onChange` against matching `Color.clear.frame(height: 1).id(...)`
+/// anchors.
+struct JumpMenu: View {
+    @Binding var target: String?
+
+    var body: some View {
+        Menu {
+            Button {
+                target = "__top"
+            } label: { Label("Top", systemImage: "arrow.up") }
+            Button {
+                target = "__bottom"
+            } label: { Label("Bottom", systemImage: "arrow.down") }
+        } label: {
+            Image(systemName: "arrow.up.arrow.down")
+        }
+        .menuOrder(.fixed)
+    }
+}
+
+/// Applies the standard floating-circle chrome (48x48, title2 font,
+/// regularMaterial circle, "Jump" accessibility label) around a
+/// `JumpMenu`. Matches the styling every copy site applied by hand.
+struct JumpMenuOverlay: View {
+    @Binding var target: String?
+    @Environment(ThemeManager.self) private var themeManager
+
+    var body: some View {
+        JumpMenu(target: $target)
+            .font(themeManager.title2Font)
+            .foregroundStyle(.primary)
+            .frame(width: 48, height: 48)
+            .background(.regularMaterial, in: Circle())
+            .accessibilityLabel("Jump")
+    }
+}

--- a/hackertracker/Views/MapView.swift
+++ b/hackertracker/Views/MapView.swift
@@ -16,7 +16,7 @@ struct MapView: View {
     @Environment(ThemeManager.self) private var themeManager
 
     @State private var currentIndex: Int = 0
-    @AppStorage("lastMapIndex") private var storedIndexBlob: String = ""
+    @AppStorage(AppStorageKeys.lastMapIndex) private var storedIndexBlob: String = ""
 
     /// Command sink for zoom + search. Bound to the focused map page so
     /// swipes hand off control automatically.

--- a/hackertracker/Views/MapView.swift
+++ b/hackertracker/Views/MapView.swift
@@ -13,7 +13,6 @@ import PDFKit
 struct MapView: View {
     @EnvironmentObject var selected: SelectedConference
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
     @Environment(ThemeManager.self) private var themeManager
 
     @State private var currentIndex: Int = 0
@@ -127,7 +126,7 @@ struct MapView: View {
                 }
             } else {
                 _04View(message: "Loading...", show404: false)
-                    .preferredColorScheme(theme.colorScheme)
+                    .preferredColorScheme(themeManager.preferredColorScheme)
             }
         }
     }

--- a/hackertracker/Views/MoreMenu.swift
+++ b/hackertracker/Views/MoreMenu.swift
@@ -40,7 +40,7 @@ struct NotificationButton: View {
     var content: Content
     var session: Session
     @Binding var notExists: Bool
-    @AppStorage("notifyAt") var notifyAt: Int = 20
+    @AppStorage(AppStorageKeys.notifyAt) var notifyAt: Int = 20
     @Environment(InfoViewModel.self) private var viewModel
     
     var body: some View {

--- a/hackertracker/Views/NewsListView.swift
+++ b/hackertracker/Views/NewsListView.swift
@@ -24,64 +24,9 @@ struct NewsListView: View {
         viewModel.news.search(text: searchText).sorted { $0.updatedAt > $1.updatedAt }
     }
 
-    @ViewBuilder private var inlineSearchBar: some View {
-        if isSearching {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-                TextField("Search news", text: $searchText)
-                    .focused($searchFocused)
-                    .submitLabel(.search)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                    }
-                    .accessibilityLabel("Clear search text")
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.thinMaterial)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    @ViewBuilder private var searchToggleButton: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isSearching.toggle()
-            }
-            if isSearching {
-                searchFocused = true
-            } else {
-                searchText = ""
-            }
-        } label: {
-            Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
-        }
-        .accessibilityLabel(isSearching ? "Close search" : "Search news")
-    }
-
-    @ViewBuilder private var jumpMenu: some View {
-        Menu {
-            Button {
-                jumpTarget = "__top"
-            } label: { Label("Top", systemImage: "arrow.up") }
-            Button {
-                jumpTarget = "__bottom"
-            } label: { Label("Bottom", systemImage: "arrow.down") }
-        } label: {
-            Image(systemName: "arrow.up.arrow.down")
-        }
-        .menuOrder(.fixed)
-    }
-
     var body: some View {
         VStack(spacing: 0) {
-            inlineSearchBar
+            InlineSearchBar(placeholder: "Search news", text: $searchText, isFocused: $searchFocused, visible: isSearching)
             ScrollView {
                 if filteredNews.isEmpty {
                     if searchText.isEmpty {
@@ -124,12 +69,7 @@ struct NewsListView: View {
         .overlay(alignment: .bottom) {
             HStack {
                 Spacer()
-                jumpMenu
-                    .font(themeManager.title2Font)
-                    .foregroundStyle(.primary)
-                    .frame(width: 48, height: 48)
-                    .background(.regularMaterial, in: Circle())
-                    .accessibilityLabel("Jump")
+                JumpMenuOverlay(target: $jumpTarget)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 12)
@@ -141,7 +81,7 @@ struct NewsListView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                searchToggleButton
+                SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search news")
             }
         }
         .analyticsScreen(name: "NewsListView")

--- a/hackertracker/Views/OrgView.swift
+++ b/hackertracker/Views/OrgView.swift
@@ -13,7 +13,6 @@ struct OrgView: View {
     var org: Organization
     // @Binding var tappedScheduleTwice: Bool
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
     @EnvironmentObject var filters: Filters
     @AppStorage("colorMode") var colorMode: Bool = false
     @Binding var tabSelection: Int
@@ -61,7 +60,7 @@ struct OrgView: View {
                             .foregroundColor(colorMode ? .white : .primary)
                             .frame(maxWidth: .infinity)
                             .padding(15)
-                            .background(colorMode ? theme.carousel() : themeManager.cardSurface)
+                            .background(colorMode ? themeManager.carouselColor(forKey: org.id ?? org.name) : themeManager.cardSurface)
                             .cornerRadius(15)
                     }
                 }
@@ -81,7 +80,6 @@ struct showLinks: View {
     var links: [Link]
     @Environment(\.openURL) private var openURL
     @State private var collapsed = false
-    @EnvironmentObject var theme: Theme
     @AppStorage("colorMode") var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
@@ -125,7 +123,7 @@ struct showLinks: View {
                             .foregroundColor(.primary)
                             .frame(maxWidth: .infinity)
                             .padding(15)
-                            .background(colorMode ? theme.carousel() : themeManager.cardSurface)
+                            .background(colorMode ? themeManager.carouselColor(forKey: link.url) : themeManager.cardSurface)
                             .cornerRadius(15)
                         }
                     }

--- a/hackertracker/Views/OrgView.swift
+++ b/hackertracker/Views/OrgView.swift
@@ -14,7 +14,7 @@ struct OrgView: View {
     // @Binding var tappedScheduleTwice: Bool
     @Environment(InfoViewModel.self) private var viewModel
     @EnvironmentObject var filters: Filters
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     @Binding var tabSelection: Int
 
     @Environment(ThemeManager.self) private var themeManager
@@ -80,7 +80,7 @@ struct showLinks: View {
     var links: [Link]
     @Environment(\.openURL) private var openURL
     @State private var collapsed = false
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
 

--- a/hackertracker/Views/OrgView.swift
+++ b/hackertracker/Views/OrgView.swift
@@ -38,6 +38,7 @@ struct OrgView: View {
                         ForEach(org.media, id: \.assetId) { m in
                             if let url = URL(string: m.url) {
                                 KFImage(url)
+                                    .htDownsampled(side: 300)
                                     .resizable()
                                     .scaledToFit()
                                     .aspectRatio(contentMode: .fit)

--- a/hackertracker/Views/OrgsView.swift
+++ b/hackertracker/Views/OrgsView.swift
@@ -13,7 +13,6 @@ struct OrgsView: View {
     var title: String
     var tagId: Int
     @Binding var tabSelection: Int
-    @EnvironmentObject var theme: Theme
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
     @EnvironmentObject var selected: SelectedConference
@@ -57,7 +56,7 @@ struct OrgsView: View {
                         Color.clear.frame(height: 1).id("__top")
                         LazyVGrid(columns: gridItemLayout, spacing: 20) {
                             ForEach(filteredOrgs, id: \.id) { org in
-                                OrgCell(org: org, theme: theme, tabSelection: $tabSelection)
+                                OrgCell(org: org, tabSelection: $tabSelection)
                             }
                         }
                         Color.clear.frame(height: 1).id("__bottom")
@@ -125,7 +124,6 @@ struct OrgsView: View {
 
 struct OrgCell: View {
     let org: Organization
-    let theme: Theme
     @Binding var tabSelection: Int
     @Environment(\.iPadOrgSelection) private var iPadOrgSelection
 
@@ -134,12 +132,12 @@ struct OrgCell: View {
             Button {
                 sel.wrappedValue = org.id
             } label: {
-                orgRow(org: org, theme: theme)
+                orgRow(org: org)
             }
             .buttonStyle(.plain)
         } else {
             NavigationLink(destination: OrgView(org: org, tabSelection: $tabSelection)) {
-                orgRow(org: org, theme: theme)
+                orgRow(org: org)
             }
         }
     }
@@ -161,7 +159,6 @@ struct orgSearchRow: View {
 
 struct orgRow: View {
     let org: Organization
-    var theme: Theme
     @AppStorage("colorMode") var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
@@ -181,7 +178,7 @@ struct orgRow: View {
             }
             .padding(5)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(colorMode ? theme.carousel(): themeManager.cardSurface)
+            .background(colorMode ? themeManager.carouselColor(forKey: org.id ?? org.name) : themeManager.cardSurface)
             .cornerRadius(15)
 
         } else {
@@ -189,7 +186,7 @@ struct orgRow: View {
                 .foregroundColor(colorMode ? .white : .primary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding(15)
-                .background(colorMode ? theme.carousel(): themeManager.cardSurface)
+                .background(colorMode ? themeManager.carouselColor(forKey: org.id ?? org.name) : themeManager.cardSurface)
                 .cornerRadius(15)
         }
     }

--- a/hackertracker/Views/OrgsView.swift
+++ b/hackertracker/Views/OrgsView.swift
@@ -159,7 +159,7 @@ struct orgSearchRow: View {
 
 struct orgRow: View {
     let org: Organization
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
 

--- a/hackertracker/Views/OrgsView.swift
+++ b/hackertracker/Views/OrgsView.swift
@@ -35,65 +35,10 @@ struct OrgsView: View {
         viewModel.orgs.filter { $0.tag_ids.contains(tagId) }.search(text: searchText)
     }
 
-    @ViewBuilder private var inlineSearchBar: some View {
-        if isSearching {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-                TextField("Search \(title.lowercased())", text: $searchText)
-                    .focused($searchFocused)
-                    .submitLabel(.search)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                    }
-                    .accessibilityLabel("Clear search text")
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.thinMaterial)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    @ViewBuilder private var searchToggleButton: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isSearching.toggle()
-            }
-            if isSearching {
-                searchFocused = true
-            } else {
-                searchText = ""
-            }
-        } label: {
-            Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
-        }
-        .accessibilityLabel(isSearching ? "Close search" : "Search \(title.lowercased())")
-    }
-
-    @ViewBuilder private var jumpMenu: some View {
-        Menu {
-            Button {
-                jumpTarget = "__top"
-            } label: { Label("Top", systemImage: "arrow.up") }
-            Button {
-                jumpTarget = "__bottom"
-            } label: { Label("Bottom", systemImage: "arrow.down") }
-        } label: {
-            Image(systemName: "arrow.up.arrow.down")
-        }
-        .menuOrder(.fixed)
-    }
-
     @ViewBuilder
     private var orgSidebar: some View {
         VStack(spacing: 0) {
-            inlineSearchBar
+            InlineSearchBar(placeholder: "Search \(title.lowercased())", text: $searchText, isFocused: $searchFocused, visible: isSearching)
             ScrollView {
                 if filteredOrgs.isEmpty {
                     if searchText.isEmpty {
@@ -133,12 +78,7 @@ struct OrgsView: View {
         .overlay(alignment: .bottom) {
             HStack {
                 Spacer()
-                jumpMenu
-                    .font(themeManager.title2Font)
-                    .foregroundStyle(.primary)
-                    .frame(width: 48, height: 48)
-                    .background(.regularMaterial, in: Circle())
-                    .accessibilityLabel("Jump")
+                JumpMenuOverlay(target: $jumpTarget)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 12)
@@ -150,7 +90,7 @@ struct OrgsView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                searchToggleButton
+                SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search \(title.lowercased())")
             }
         }
         .analyticsScreen(name: "OrgsView")

--- a/hackertracker/Views/ProductsView.swift
+++ b/hackertracker/Views/ProductsView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 struct ProductsView: View {
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("showMerchInfo") var showMerchInfo: Bool = true
+    @AppStorage(AppStorageKeys.showMerchInfo) var showMerchInfo: Bool = true
     @State private var searchText = ""
     /// Perf C: debounced mirror of `searchText`. Updated on a 200ms
     /// .task(id:) so visibleProducts re-filters once per pause rather
@@ -23,7 +23,7 @@ struct ProductsView: View {
     /// selection survive tab switches; the store also persists it
     /// across cold launches via UserDefaults.
     @EnvironmentObject private var merchFilters: MerchFiltersStore
-    @AppStorage("filterMatchModeMerch") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    @AppStorage(AppStorageKeys.filterMatchModeMerch) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
     private var filterMatchMode: FilterMatchMode {
         FilterMatchMode(rawOrDefault: filterMatchModeRaw)
     }
@@ -243,7 +243,7 @@ struct ProductsView: View {
 }
 
 struct MerchInfo: View {
-    @AppStorage("showMerchInfo") var showMerchInfo: Bool = true
+    @AppStorage(AppStorageKeys.showMerchInfo) var showMerchInfo: Bool = true
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
     
@@ -345,7 +345,7 @@ struct MerchSizeFilter: View {
     /// the already-filtered list to keep the sheet stateless.
     var matchedCount: Int = 0
 
-    @AppStorage("filterMatchModeMerch") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    @AppStorage(AppStorageKeys.filterMatchModeMerch) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]
 
     var body: some View {

--- a/hackertracker/Views/ProductsView.swift
+++ b/hackertracker/Views/ProductsView.swift
@@ -98,65 +98,10 @@ struct ProductsView: View {
             }
     }
 
-    @ViewBuilder private var inlineSearchBar: some View {
-        if isSearching {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-                TextField("Search merch", text: $searchText)
-                    .focused($searchFocused)
-                    .submitLabel(.search)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                    }
-                    .accessibilityLabel("Clear search text")
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.thinMaterial)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    @ViewBuilder private var searchToggleButton: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isSearching.toggle()
-            }
-            if isSearching {
-                searchFocused = true
-            } else {
-                searchText = ""
-            }
-        } label: {
-            Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
-        }
-        .accessibilityLabel(isSearching ? "Close search" : "Search merch")
-    }
-
-    @ViewBuilder private var jumpMenu: some View {
-        Menu {
-            Button {
-                jumpTarget = "__top"
-            } label: { Label("Top", systemImage: "arrow.up") }
-            Button {
-                jumpTarget = "__bottom"
-            } label: { Label("Bottom", systemImage: "arrow.down") }
-        } label: {
-            Image(systemName: "arrow.up.arrow.down")
-        }
-        .menuOrder(.fixed)
-    }
-
     @ViewBuilder
     private var productsSidebar: some View {
         VStack(spacing: 0) {
-            inlineSearchBar
+            InlineSearchBar(placeholder: "Search merch", text: $searchText, isFocused: $searchFocused, visible: isSearching)
         ScrollView {
             if showMerchInfo {
                 MerchInfo()
@@ -228,12 +173,7 @@ struct ProductsView: View {
 
                 Spacer()
 
-                jumpMenu
-                    .font(themeManager.title2Font)
-                    .foregroundStyle(.primary)
-                    .frame(width: 48, height: 48)
-                    .background(.regularMaterial, in: Circle())
-                    .accessibilityLabel("Jump")
+                JumpMenuOverlay(target: $jumpTarget)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 12)
@@ -251,7 +191,7 @@ struct ProductsView: View {
                     }
                     .accessibilityLabel("Merch info")
                 }
-                searchToggleButton
+                SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search merch")
                 if let c = viewModel.conference, c.enableMerchCart {
                     NavigationLink(destination: CartView()) {
                         Image(systemName: "qrcode")

--- a/hackertracker/Views/ProductsView.swift
+++ b/hackertracker/Views/ProductsView.swift
@@ -266,7 +266,7 @@ struct MerchInfo: View {
                 .foregroundColor(.primary)
                 .frame(maxWidth: .infinity)
                 .padding(10)
-                .background(themeManager.danger)
+                .background(themeManager.cardSurface)
                 .cornerRadius(15)
             }
             Divider()

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -32,7 +32,7 @@ extension View {
             .padding(.vertical, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(themeManager.cardSurface)
-            .cornerRadius(10)
+            .cornerRadius(ThemeMetrics.cardRadius)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
     }
@@ -444,7 +444,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
             Text("Version \(marketingVersion)")
                 .font(themeManager.title3Font).bold()
             Text("Build \(buildVersion)")
-                .font(.callout)
+                .font(themeManager.calloutFont)
                 .foregroundStyle(.secondary)
         }
     }
@@ -458,7 +458,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
             }
 
             Text("What this app does and doesn’t collect. The full disclosure mirrors the docs/privacy.md page in the public repo.")
-                .font(.footnote)
+                .font(themeManager.footnoteFont)
                 .foregroundStyle(.secondary)
 
             NavigationLink(destination: DocumentView(
@@ -471,7 +471,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
                 Label("Read the full disclosure", systemImage: "doc.text")
                     .frame(maxWidth: .infinity)
                     .padding(10)
-                    .background(Color.accentColor.opacity(0.15))
+                    .background(themeManager.accent.opacity(0.15))
                     .cornerRadius(8)
             }
         }
@@ -488,7 +488,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
             }
 
             Text("Stamped at build time. Tap **View on GitHub** to confirm this build came from a specific public commit — if the page 404s, this build was not produced from a public commit on the official repo.")
-                .font(.footnote)
+                .font(themeManager.footnoteFont)
                 .foregroundStyle(.secondary)
 
             VStack(alignment: .leading, spacing: 10) {
@@ -504,7 +504,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
 
             if info.dirty {
                 Label("This build was produced from a working copy with uncommitted changes. It does not correspond to a single public commit.", systemImage: "exclamationmark.triangle.fill")
-                    .font(.footnote)
+                    .font(themeManager.footnoteFont)
                     .foregroundStyle(.orange)
                     .padding()
                     .background(Color.orange.opacity(0.1))
@@ -518,7 +518,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
                     Label("View on GitHub", systemImage: "arrow.up.right.square")
                         .frame(maxWidth: .infinity)
                         .padding(10)
-                        .background(Color.accentColor.opacity(0.15))
+                        .background(themeManager.accent.opacity(0.15))
                         .cornerRadius(8)
                 }
             }
@@ -536,7 +536,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
                 Label("Copy build info", systemImage: "doc.on.doc")
                     .frame(maxWidth: .infinity)
                     .padding(10)
-                    .background(Color(.systemGray5))
+                    .background(themeManager.cardSurface)
                     .cornerRadius(8)
             }
         }
@@ -549,7 +549,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
                 .font(themeManager.captionFont)
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(mono ? .system(.footnote, design: .monospaced) : .body)
+                .font(mono ? .system(.footnote, design: .monospaced) : themeManager.bodyFont)
                 .textSelection(.enabled)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -947,18 +947,18 @@ struct ThemePickerView: View {
             Spacer()
             if isActive {
                 Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
+                    .foregroundStyle(themeManager.success)
                     .font(themeManager.title3Font)
             }
         }
         .padding()
         .background(theme.palette.cardSurface.auto)
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(isActive ? Color.green : Color.primary.opacity(0.08),
+            RoundedRectangle(cornerRadius: ThemeMetrics.cardRadius)
+                .stroke(isActive ? themeManager.success : Color.primary.opacity(0.08),
                         lineWidth: isActive ? 2 : 0.5)
         )
-        .cornerRadius(10)
+        .cornerRadius(ThemeMetrics.cardRadius)
     }
 
     private func swatch(_ color: Color) -> some View {

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -73,7 +73,7 @@ extension View {
 struct SettingsView: View {
     @EnvironmentObject var selected: SelectedConference
     @Environment(InfoViewModel.self) private var viewModel
-    @AppStorage("showNews") var showNews: Bool = true
+    @AppStorage(AppStorageKeys.showNews) var showNews: Bool = true
     @State private var iPadSheet: SettingsIPadSheet?
 
     @Environment(ThemeManager.self) private var themeManager
@@ -215,9 +215,9 @@ struct SettingsView: View {
 struct EasterEggSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
     @Environment(InfoViewModel.self) private var viewModel
-    @AppStorage("easterEgg") var easterEgg: Bool = false
-    @AppStorage("easterEggMaxOpacity") var easterEggMaxOpacity: Double = 0.20
-    @AppStorage("easterEggPeriod") var easterEggPeriod: Double = 12.0
+    @AppStorage(AppStorageKeys.easterEgg) var easterEgg: Bool = false
+    @AppStorage(AppStorageKeys.easterEggMaxOpacity) var easterEggMaxOpacity: Double = 0.20
+    @AppStorage(AppStorageKeys.easterEggPeriod) var easterEggPeriod: Double = 12.0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -275,7 +275,7 @@ struct EasterEggSettingsView: View {
 struct NotificationSettingsView: View {
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("notifyAt") var notifyAt: Int = 20
+    @AppStorage(AppStorageKeys.notifyAt) var notifyAt: Int = 20
     @State private var showingAlert = false
 
     var body: some View {
@@ -559,7 +559,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
 struct ShowNewsSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
     @Environment(InfoViewModel.self) private var viewModel
-    @AppStorage("showNews") var showNews: Bool = true
+    @AppStorage(AppStorageKeys.showNews) var showNews: Bool = true
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -577,7 +577,7 @@ struct ShowNewsSettingsView: View {
 
 struct ShowMerchInfoSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("showMerchInfo") var showMerchInfo: Bool = true
+    @AppStorage(AppStorageKeys.showMerchInfo) var showMerchInfo: Bool = true
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -595,7 +595,7 @@ struct ShowMerchInfoSettingsView: View {
 struct ShowPastEventsSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
     @Environment(InfoViewModel.self) private var viewModel
-    @AppStorage("showPastEvents") var showPastEvents: Bool = true
+    @AppStorage(AppStorageKeys.showPastEvents) var showPastEvents: Bool = true
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -614,7 +614,7 @@ struct ShowPastEventsSettingsView: View {
 struct ShowConflictAlertView: View {
     @Environment(ThemeManager.self) private var themeManager
     @Environment(InfoViewModel.self) private var viewModel
-    @AppStorage("showConflictAlert") var showConflictAlert: Bool = true
+    @AppStorage(AppStorageKeys.showConflictAlert) var showConflictAlert: Bool = true
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -632,8 +632,8 @@ struct ShowConflictAlertView: View {
 struct LightModeSettingsView: View {
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("lightMode") var lightMode: Bool = false
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.lightMode) var lightMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -671,7 +671,7 @@ struct StartScreenSettingsView: View {
 
 struct StartScreenPickerView: View {
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("launchScreen") var launchScreen: String = "Main"
+    @AppStorage(AppStorageKeys.launchScreen) var launchScreen: String = "Main"
     let startScreens = ["Main", "Schedule", "Maps"]
 
     var body: some View {
@@ -691,8 +691,8 @@ struct StartScreenPickerView: View {
 struct ShowLocaltimeSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
     @Environment(InfoViewModel.self) private var viewModel
-    @AppStorage("showLocaltime") var showLocaltime: Bool = false
-    @AppStorage("show24hourtime") var show24hourtime: Bool = true
+    @AppStorage(AppStorageKeys.showLocaltime) var showLocaltime: Bool = false
+    @AppStorage(AppStorageKeys.show24hourtime) var show24hourtime: Bool = true
     let dfu = DateFormatterUtility.shared
 
     /// The IANA identifier of the timezone the schedule currently renders in.
@@ -768,12 +768,12 @@ struct SettingsView_Previews: PreviewProvider {
 ///   - Fully interactive otherwise.
 struct AISummarySettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("aiSummaries") var aiSummaries: Bool = false
+    @AppStorage(AppStorageKeys.aiSummaries) var aiSummaries: Bool = false
     /// Hidden gate for AI-generated speaker bios. Off by default and
     /// the toggle only becomes visible after a 7-tap chord on the
     /// "AI Summaries" row (or stays visible if already on, so users
     /// can switch it back off without re-discovering the chord).
-    @AppStorage("speakerAISummaries") var speakerAISummaries: Bool = false
+    @AppStorage(AppStorageKeys.speakerAISummaries) var speakerAISummaries: Bool = false
     /// Tap-counter chord. Transient — resets on view rebuild, which
     /// is fine because revealing the row is a one-time discovery.
     @State private var aiTapCount: Int = 0
@@ -842,7 +842,7 @@ struct AISummarySettingsView: View {
 /// wanting them visible.
 struct ShowCustomEventsSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("showCustomEvents") var showCustomEvents: Bool = true
+    @AppStorage(AppStorageKeys.showCustomEvents) var showCustomEvents: Bool = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -73,7 +73,6 @@ extension View {
 struct SettingsView: View {
     @EnvironmentObject var selected: SelectedConference
     @Environment(InfoViewModel.self) private var viewModel
-    @EnvironmentObject var theme: Theme
     @AppStorage("showNews") var showNews: Bool = true
     @State private var iPadSheet: SettingsIPadSheet?
 
@@ -635,18 +634,16 @@ struct LightModeSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
     @AppStorage("lightMode") var lightMode: Bool = false
     @AppStorage("colorMode") var colorMode: Bool = false
-    @EnvironmentObject var theme: Theme
 
     var body: some View {
         VStack(alignment: .leading) {
             Toggle("Enable Light Mode", isOn: $lightMode)
                 .onChange(of: lightMode) { _, value in
                     Log.ui.debug("lightMode=\(value)")
-                    if value {
-                        theme.colorScheme = .light
-                    } else {
-                        theme.colorScheme = .dark
-                    }
+                    // The @AppStorage binding drives the Toggle UI; the
+                    // ThemeManager stored property is what the rest of
+                    // the app observes via preferredColorScheme.
+                    themeManager.setLightMode(value)
                 }
         }
         .settingsCard(themeManager)

--- a/hackertracker/Views/ShareBookmarksView.swift
+++ b/hackertracker/Views/ShareBookmarksView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 struct ShareBookmarksView: View {
     @Environment(InfoViewModel.self) private var viewModel
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     @State private var message = "Tap link to copy"
     
     @Environment(ThemeManager.self) private var themeManager

--- a/hackertracker/Views/ShareBookmarksView.swift
+++ b/hackertracker/Views/ShareBookmarksView.swift
@@ -7,7 +7,6 @@
 import SwiftUI
 
 struct ShareBookmarksView: View {
-    @EnvironmentObject var theme: Theme
     @Environment(InfoViewModel.self) private var viewModel
     @FetchRequest(sortDescriptors: []) var bookmarks: FetchedResults<Bookmarks>
     @AppStorage("colorMode") var colorMode: Bool = false
@@ -29,7 +28,7 @@ struct ShareBookmarksView: View {
                 .foregroundColor(colorMode ? .white : .primary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding(15)
-                .background(colorMode ? theme.carousel(): themeManager.cardSurface)
+                .background(colorMode ? themeManager.carouselColor(index: 0): themeManager.cardSurface)
                 .cornerRadius(15)
                 Divider()
                 if let conf = viewModel.conference, bookmarks.filter({viewModel.events.map{Int32($0.id)}.contains($0.id)}).count > 0 {

--- a/hackertracker/Views/SharedScheduleView.swift
+++ b/hackertracker/Views/SharedScheduleView.swift
@@ -40,20 +40,6 @@ struct SharedScheduleView: View {
         return order.map { ($0, bucket[$0] ?? []) }
     }
 
-    @ViewBuilder private var jumpMenu: some View {
-        Menu {
-            Button {
-                jumpTarget = "__top"
-            } label: { Label("Top", systemImage: "arrow.up") }
-            Button {
-                jumpTarget = "__bottom"
-            } label: { Label("Bottom", systemImage: "arrow.down") }
-        } label: {
-            Image(systemName: "arrow.up.arrow.down")
-        }
-        .menuOrder(.fixed)
-    }
-
     var body: some View {
         // Phase 4 follow-up: observe DateFormatterUtility tz changes.
         let _ = dfu.tzGeneration
@@ -98,12 +84,7 @@ struct SharedScheduleView: View {
             if !sharedSchedule.entries.isEmpty {
                 HStack {
                     Spacer()
-                    jumpMenu
-                        .font(themeManager.title2Font)
-                        .foregroundStyle(.primary)
-                        .frame(width: 48, height: 48)
-                        .background(.regularMaterial, in: Circle())
-                        .accessibilityLabel("Jump")
+                    JumpMenuOverlay(target: $jumpTarget)
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 12)

--- a/hackertracker/Views/SharedScheduleView.swift
+++ b/hackertracker/Views/SharedScheduleView.swift
@@ -115,7 +115,7 @@ struct SharedScheduleView: View {
 struct SharedScheduleRow: View {
     let entry: SharedScheduleStore.Entry
     let dfu = DateFormatterUtility.shared
-    @AppStorage("show24hourtime") var show24hourtime: Bool = true
+    @AppStorage(AppStorageKeys.show24hourtime) var show24hourtime: Bool = true
 
     /// Format event start time in the device-current zone so the combined
     /// view stays self-consistent regardless of which conference the row

--- a/hackertracker/Views/SpeakerDetailView.swift
+++ b/hackertracker/Views/SpeakerDetailView.swift
@@ -109,7 +109,7 @@ struct showSpeakerLinks: View {
     var links: [SpeakerLink]
     @Environment(\.openURL) private var openURL
     @State private var collapsed = false
-    @AppStorage("colorMode") var colorMode: Bool = false
+    @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
 
@@ -252,7 +252,7 @@ struct SpeakerEventView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
-    @AppStorage("notifyAt") var notifyAt: Int = 20
+    @AppStorage(AppStorageKeys.notifyAt) var notifyAt: Int = 20
 
     var body: some View {
         // Phase 4 follow-up: observe DateFormatterUtility so SwiftUI

--- a/hackertracker/Views/SpeakerDetailView.swift
+++ b/hackertracker/Views/SpeakerDetailView.swift
@@ -13,7 +13,6 @@ import FirebaseAnalytics
 struct SpeakerDetailView: View {
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(\.openURL) private var openURL
-    @EnvironmentObject var theme: Theme
 
     var id: Int
 
@@ -110,7 +109,6 @@ struct showSpeakerLinks: View {
     var links: [SpeakerLink]
     @Environment(\.openURL) private var openURL
     @State private var collapsed = false
-    @EnvironmentObject var theme: Theme
     @AppStorage("colorMode") var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
@@ -154,7 +152,7 @@ struct showSpeakerLinks: View {
                             .foregroundColor(colorMode ? .white : .primary)
                             .frame(maxWidth: .infinity)
                             .padding(15)
-                            .background(colorMode ? theme.carousel(): themeManager.cardSurface)
+                            .background(colorMode ? themeManager.carouselColor(forKey: link.url) : themeManager.cardSurface)
                             .cornerRadius(15)
                             
                         }

--- a/hackertracker/Views/SpeakerRow.swift
+++ b/hackertracker/Views/SpeakerRow.swift
@@ -17,11 +17,11 @@ struct SpeakerRow: View {
     /// Mirror of the AI summary toggle used by EventCell / ContentCell.
     /// When on AND the speaker lacks a job title, we render a one-line
     /// AI-generated bio summary in the subtitle slot.
-    @AppStorage("aiSummaries") private var aiSummaries: Bool = false
+    @AppStorage(AppStorageKeys.aiSummaries) private var aiSummaries: Bool = false
     /// Hidden secondary gate — speaker bios are only summarized when
     /// the user discovers + flips the chord-revealed toggle in
     /// Settings → AI Summaries (7-tap on the main row).
-    @AppStorage("speakerAISummaries") private var speakerAISummaries: Bool = false
+    @AppStorage(AppStorageKeys.speakerAISummaries) private var speakerAISummaries: Bool = false
 
     /// True when both the main AI Summaries toggle AND the hidden
     /// speaker-specific gate are enabled.

--- a/hackertracker/Views/SpeakerRow.swift
+++ b/hackertracker/Views/SpeakerRow.swift
@@ -168,7 +168,7 @@ struct SpeakerRow: View {
         // on the inner content VStack only so the leading color stripe
         // stretches edge-to-edge of the card.
         .background(themeManager.cardSurface)
-        .cornerRadius(10)
+        .cornerRadius(ThemeMetrics.cardRadius)
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
         // Opportunistic warm on materialization. The cache's own

--- a/hackertracker/Views/SpeakersView.swift
+++ b/hackertracker/Views/SpeakersView.swift
@@ -286,7 +286,6 @@ struct SpeakersView: View {
 struct SpeakerData: View {
     let char: String.Element
     let speakers: [Speaker]
-    @EnvironmentObject var theme: Theme
     @Environment(ThemeManager.self) private var themeManager
     /// iPad split-view: row taps update detail column instead of pushing.
     @Environment(\.iPadSpeakerSelection) private var iPadSpeakerSelection
@@ -304,12 +303,12 @@ struct SpeakerData: View {
                     Button {
                         sel.wrappedValue = speaker.id
                     } label: {
-                        SpeakerRow(speaker: speaker, themeColor: theme.carousel())
+                        SpeakerRow(speaker: speaker, themeColor: themeManager.carouselColor(index: speaker.id))
                     }
                     .buttonStyle(.plain)
                 } else {
                     NavigationLink(destination: SpeakerDetailView(id: speaker.id)) {
-                        SpeakerRow(speaker: speaker, themeColor: theme.carousel())
+                        SpeakerRow(speaker: speaker, themeColor: themeManager.carouselColor(index: speaker.id))
                     }
                     // Without .plain, NavigationLink tints every
                     // child view with the system accent color (system

--- a/hackertracker/Views/SpeakersView.swift
+++ b/hackertracker/Views/SpeakersView.swift
@@ -12,7 +12,7 @@ struct SpeakersView: View {
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
     @EnvironmentObject var speakerFilters: SpeakerFiltersStore
-    @AppStorage("filterMatchModeSpeakers") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    @AppStorage(AppStorageKeys.filterMatchModeSpeakers) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
     @State private var searchText = ""
 
     // Polish parity with schedule / All Content.
@@ -353,7 +353,7 @@ struct SpeakerFiltersSheet: View {
     /// using the same filter pipeline so the displayed tally is the
     /// row count the list will render.
     var matchedCount: Int = 0
-    @AppStorage("filterMatchModeSpeakers") private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    @AppStorage(AppStorageKeys.filterMatchModeSpeakers) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
 
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
 

--- a/hackertracker/Views/SpeakersView.swift
+++ b/hackertracker/Views/SpeakersView.swift
@@ -121,47 +121,6 @@ struct SpeakersView: View {
             .sorted { $0.key < $1.key }
     }
 
-    @ViewBuilder private var inlineSearchBar: some View {
-        if isSearching {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-                TextField("Search speakers", text: $searchText)
-                    .focused($searchFocused)
-                    .submitLabel(.search)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                    }
-                    .accessibilityLabel("Clear search text")
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.thinMaterial)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    @ViewBuilder private var searchToggleButton: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isSearching.toggle()
-            }
-            if isSearching {
-                searchFocused = true
-            } else {
-                searchText = ""
-            }
-        } label: {
-            Image(systemName: isSearching ? "xmark.circle" : "magnifyingglass")
-        }
-        .accessibilityLabel(isSearching ? "Close search" : "Search speakers")
-    }
-
     @ViewBuilder private var jumpToGroupMenu: some View {
         Menu {
             ForEach(grouped, id: \.key) { char, _ in
@@ -204,7 +163,7 @@ struct SpeakersView: View {
     @ViewBuilder
     private var speakerSidebar: some View {
         VStack(spacing: 0) {
-            inlineSearchBar
+            InlineSearchBar(placeholder: "Search speakers", text: $searchText, isFocused: $searchFocused, visible: isSearching)
             ScrollView {
                 if grouped.isEmpty {
                     if searchText.isEmpty {
@@ -292,7 +251,7 @@ struct SpeakersView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                searchToggleButton
+                SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search speakers")
             }
         }
         .analyticsScreen(name: "SpeakersView")


### PR DESCRIPTION
## Summary

Fixes from a full six-lens efficiency/design review of the app (42 review+verify agents; every finding adversarially verified against the code before being acted on). Also carries the `conference-media` feature branch this was cut from: optional `Conference.media` (dark/light banner + square logos), the square logo in the conference picker and Info screen (collapsible, per-conference memory), and the 6.2 version bump.

### Correctness fixes (016cc31)
- **Org listener leak**: `removeListeners()` had drifted from `removeListenersImmediate()` and skipped `orgListener` — every conference switch leaked a live Firestore listener that could clobber the new conference's orgs with stale data. Now delegates to the single source of truth.
- **Stuck Maps spinner**: map download completion never fired on non-200 responses or failed casts, leaving `mapsLoading` on for the rest of the session. All paths now complete exactly once.
- **Year-late notifications**: the notification trigger omitted `.year`, so a past-dated notify time silently scheduled for the same date next year. Year included; elapsed dates skipped.
- **Dead swipe actions** removed from event/content cells (they only work inside `List`, which the app no longer uses).

### Performance
- **Schedule render path (11d1871)**: the filter+search+group pipeline used to run up to ~5× per body pass and the ToTop/ToBottom/ToCurrent/ToNext published-Bool objects re-rendered the entire schedule 2-4× per jump tap. Replaced with a `ScrollCommandBus` (PassthroughSubject, zero invalidation) and a single cached pipeline recompute keyed on exactly the inputs it reads. Per-cell bookmark `@FetchRequest`s hoisted into one `BookmarkSnapshot` environment value; day groups pre-sorted once.
- **Off-main Firestore decode (ea1842c)**: content (1000+ docs at DEF CON) and speakers now decode in a detached task with generation-counter staleness guards, so snapshot ticks no longer stall the main thread — including the double cache+server tick at launch. All 12 listeners now capture `[weak self]`.
- **Mechanical sweep (b866b8d)**: image downsampling on three full-res `KFImage` sites, allocation-free event search, debounced global search, deduplicated content grouping.

### Design / maintainability
- **Shared list chrome (2e12cd5)**: the copy-pasted search bar, search toggle, and jump menu across nine list screens extracted into `Views/ListChrome.swift` (net −442 lines).
- **Theme tokens (c31fd0f)**: new `success` palette slot (ends hardcoded `Color.green` on active states), MerchInfo banner de-danger-ed (fixes light-mode contrast), AboutView on theme typography/color tokens, `ThemeMetrics.cardRadius`.

### Conference media (186ed35…84e7d30)
- `Conference.media` decodes the Firestore dict shape ({dark:{...}, light:{...}}) with `banner_background` / `banner_logo` / `square_logo` per appearance and a fallback resolver.
- Square logo in the conference picker row (right-justified beside dates/timezone) and on the Info screen (collapsible; collapse state remembered per conference across launches).

## Test plan
- [x] Builds clean (iPhone 16 / iOS 18.2 sim) after every commit; swiftlint no new violations
- [ ] Device pass on the Schedule tab: Top/Now/Next/Bottom jumps, day jump, bookmark toggle, filter sheet count
- [ ] Conference switch: orgs list shows the right conference; Maps spinner clears on a failed download
- [ ] Theme sweep: active checkmarks in all six themes (note: DEF CON Red's active state is now theme-accent red, not green — flag if that reads badly)
- [ ] Conference picker + Info screen logo rendering for conferences with/without media

🤖 Generated with [Claude Code](https://claude.com/claude-code)