### PR TITLE
Fix iPad schedule scroll/tap (Button-in-Button)

### DIFF
--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -781,27 +781,31 @@ struct EventData: View {
             if let custSel = iPadCustomEventSelection,
                let contentSel = iPadContentSelection {
               if let cid = event.customEventID {
-                Button {
-                  contentSel.wrappedValue = nil
-                  custSel.wrappedValue = cid
-                } label: {
-                  EventCell(event: event, showDay: false)
-                    .id(event.id)
-                    .foregroundColor(.primary)
-                    .padding(1)
-                }
-                .buttonStyle(.plain)
+                // iPad: a plain tappable cell, NOT a Button. EventCell
+                // contains its own bookmark Button, and nesting a Button
+                // inside a Button breaks gesture arbitration on iPadOS 17
+                // (scroll + row tap die while the inner bookmark still
+                // fires). A contentShape + onTapGesture composes with the
+                // inner button and leaves scrolling intact.
+                EventCell(event: event, showDay: false)
+                  .id(event.id)
+                  .foregroundColor(.primary)
+                  .padding(1)
+                  .contentShape(Rectangle())
+                  .onTapGesture {
+                    contentSel.wrappedValue = nil
+                    custSel.wrappedValue = cid
+                  }
               } else {
-                Button {
-                  custSel.wrappedValue = nil
-                  contentSel.wrappedValue = event.contentId
-                } label: {
-                  EventCell(event: event, showDay: false)
-                    .id(event.id)
-                    .foregroundColor(.primary)
-                    .padding(1)
-                }
-                .buttonStyle(.plain)
+                EventCell(event: event, showDay: false)
+                  .id(event.id)
+                  .foregroundColor(.primary)
+                  .padding(1)
+                  .contentShape(Rectangle())
+                  .onTapGesture {
+                    custSel.wrappedValue = nil
+                    contentSel.wrappedValue = event.contentId
+                  }
               }
             } else if let cid = event.customEventID {
               NavigationLink(destination: CustomEventDetailView(eventID: cid)) {
@@ -811,15 +815,14 @@ struct EventData: View {
                   .padding(1)
               }
             } else if let sel = iPadContentSelection {
-              Button {
-                sel.wrappedValue = event.contentId
-              } label: {
-                EventCell(event: event, showDay: false)
-                  .id(event.id)
-                  .foregroundColor(.primary)
-                  .padding(1)
-              }
-              .buttonStyle(.plain)
+              EventCell(event: event, showDay: false)
+                .id(event.id)
+                .foregroundColor(.primary)
+                .padding(1)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                  sel.wrappedValue = event.contentId
+                }
             } else {
               NavigationLink(destination: ContentDetailView(contentId:event.contentId)) {
                 EventCell(event: event, showDay: false)


### PR DESCRIPTION
## Problem
iPad users (reported on iPadOS 17.7.11) can't scroll the Schedule list or tap a row to open an event's detail — but **can** still tap the bookmark toggle on visible rows.

## Root cause
On the iPad split-view path, each row is a `Button { setSelection } label: { EventCell(...) }`, and `EventCell` contains its own bookmark `Button` (`EventCellView.swift:129`). That's a **`Button` nested inside a `Button`** inside a `ScrollView`/`LazyVStack` — undefined in SwiftUI. On iPadOS 17.7 the gesture arbitration between the two buttons and the scroll view collapses: scroll drags and outer-row taps are consumed and never resolve, while the inner bookmark button (a distinct nested control) still activates. iPhone is unaffected because its rows are `NavigationLink`s, not `Button`s.

## Fix
Replace the three iPad row `Button`s in `EventData` with `EventCell(...).contentShape(Rectangle()).onTapGesture { … }` that sets the same `iPadContentSelection` / `iPadCustomEventSelection`. A tap gesture composes correctly with the inner bookmark `Button` and does not consume scroll drags — the same reason the iPhone `NavigationLink` path always worked. No visual change (the buttons used `.plain`).

## Test plan
- [ ] **iPadOS 17.7.11 device** (the reported OS): Schedule scrolls; tapping a row opens the detail pane; bookmark still toggles — needs on-device confirmation, can't repro in this environment.
- [ ] iPad 18.x: same three behaviors.
- [ ] iPhone: unchanged (NavigationLink push still works, scroll + bookmark intact).
- [ ] Custom events: tapping a custom-event row opens CustomEventDetailView in the pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)