### PR TITLE
Theme: consistent backgrounds across all screens + hardcoded color fixes

### DIFF
--- a/hackertracker/Views/404View.swift
+++ b/hackertracker/Views/404View.swift
@@ -41,6 +41,7 @@ struct _04View: View {
                             .padding(25)
                     }
             }
+            .themedBackground(themeManager)
         }
         .analyticsScreen(name: "404View")
     }

--- a/hackertracker/Views/CartView.swift
+++ b/hackertracker/Views/CartView.swift
@@ -93,6 +93,7 @@ struct CartView: View {
         .navigationTitle("Merch")
         .themedNavTitle("Merch", themeManager)
         .padding(15)
+        .themedBackground(themeManager)
     }
     
     func checkOutOfStock() {

--- a/hackertracker/Views/ConferencesView.swift
+++ b/hackertracker/Views/ConferencesView.swift
@@ -93,6 +93,7 @@ struct ConferencesView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
+            .themedBackground(themeManager)
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
                     SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search conferences")

--- a/hackertracker/Views/ContentDetailView.swift
+++ b/hackertracker/Views/ContentDetailView.swift
@@ -116,6 +116,7 @@ struct ContentDetailView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
+            .themedBackground(themeManager)
             .toolbar {
                 // iPad: sidebar's section title owns the parent navbar.
                 // Skip per-item principal here to avoid title flicker.
@@ -340,7 +341,7 @@ struct showSessionRow: View {
         .padding(.trailing, 5)
         .padding(.vertical, 5)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background)
+        .background(themeManager.cardSurface)
         .cornerRadius(10)
         .padding(.bottom, 5)
     }

--- a/hackertracker/Views/CustomEventDetailView.swift
+++ b/hackertracker/Views/CustomEventDetailView.swift
@@ -68,6 +68,7 @@ struct CustomEventDetailView: View {
                 .frame(maxHeight: .infinity)
             }
         }
+        .themedBackground(themeManager)
         .navigationBarTitle(Text(""), displayMode: .inline)
         .toolbar {
             // iPad detail pane is rendered without a NavigationStack
@@ -253,7 +254,7 @@ struct CustomEventDetailView: View {
         .padding(.trailing, 5)
         .padding(.vertical, 5)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background)
+        .background(themeManager.cardSurface)
         .cornerRadius(10)
         .padding(.bottom, 5)
     }
@@ -267,7 +268,7 @@ struct CustomEventDetailView: View {
         .padding(.trailing, 5)
         .padding(.vertical, 5)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background)
+        .background(themeManager.cardSurface)
         .cornerRadius(10)
         .padding(.bottom, 5)
     }

--- a/hackertracker/Views/CustomEventFormView.swift
+++ b/hackertracker/Views/CustomEventFormView.swift
@@ -107,6 +107,7 @@ struct CustomEventFormView: View {
             .navigationTitle(existing == nil ? "New Event" : "Edit Event")
             .themedNavTitle(existing == nil ? "New Event" : "Edit Event", themeManager)
             .navigationBarTitleDisplayMode(.inline)
+            .themedBackground(themeManager)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/hackertracker/Views/CustomEventShareSheet.swift
+++ b/hackertracker/Views/CustomEventShareSheet.swift
@@ -36,6 +36,7 @@ struct CustomEventShareSheet: View {
             .navigationTitle("Share Event")
             .themedNavTitle("Share Event", themeManager)
             .navigationBarTitleDisplayMode(.inline)
+            .themedBackground(themeManager)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }

--- a/hackertracker/Views/DocumentView.swift
+++ b/hackertracker/Views/DocumentView.swift
@@ -50,6 +50,7 @@ struct DocumentView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .themedBackground(themeManager)
         .iPadReadableContent()
         .analyticsScreen(name: "DocumentView")
         .padding(15)

--- a/hackertracker/Views/FAQListView.swift
+++ b/hackertracker/Views/FAQListView.swift
@@ -77,6 +77,7 @@ struct FAQListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .themedBackground(themeManager)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 SearchToggleButton(isSearching: $isSearching, searchText: $searchText, isFocused: $searchFocused, searchLabel: "Search FAQs")

--- a/hackertracker/Views/GlobalSearchView.swift
+++ b/hackertracker/Views/GlobalSearchView.swift
@@ -109,6 +109,7 @@ struct GlobalSearchView: View {
             .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
             .navigationTitle("Global Search")
             .themedNavTitle("Global Search", themeManager)
+            .themedBackground(themeManager)
             .task(id: searchText) {
                 try? await Task.sleep(nanoseconds: 200_000_000)
                 if !Task.isCancelled { debouncedSearch = searchText }

--- a/hackertracker/Views/LocationView.swift
+++ b/hackertracker/Views/LocationView.swift
@@ -28,6 +28,7 @@ struct LocationView: View {
             .accentColor(.primary)
             .navigationTitle("Locations")
             .themedNavTitle("Locations", themeManager)
+            .themedBackground(themeManager)
             .searchable(text: $searchText)
             .analyticsScreen(name: "LocationView")
         }

--- a/hackertracker/Views/MapView.swift
+++ b/hackertracker/Views/MapView.swift
@@ -48,7 +48,7 @@ struct MapView: View {
             content
                 .overlay(alignment: .bottomLeading) { zoomFloatingControls }
                 .padding(10)
-                .background(Color(.systemBackground))
+                .background(themeManager.background)
                 .navigationTitle(currentMapTitle ?? "Maps")
                 .themedNavTitle(currentMapTitle ?? "Maps", themeManager)
                 .navigationBarTitleDisplayMode(.inline)

--- a/hackertracker/Views/NewsListView.swift
+++ b/hackertracker/Views/NewsListView.swift
@@ -76,6 +76,7 @@ struct NewsListView: View {
         }
         .navigationTitle("News")
         .themedNavTitle("News", themeManager)
+        .themedBackground(themeManager)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)

--- a/hackertracker/Views/OrgView.swift
+++ b/hackertracker/Views/OrgView.swift
@@ -72,6 +72,7 @@ struct OrgView: View {
             }
         }
         .padding(5)
+        .themedBackground(themeManager)
         .analyticsScreen(name: "OrgView")
     }
 }

--- a/hackertracker/Views/OrgsView.swift
+++ b/hackertracker/Views/OrgsView.swift
@@ -84,6 +84,7 @@ struct OrgsView: View {
         }
         .navigationTitle(title)
         .themedNavTitle(title, themeManager)
+        .themedBackground(themeManager)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)

--- a/hackertracker/Views/ProductView.swift
+++ b/hackertracker/Views/ProductView.swift
@@ -136,10 +136,11 @@ struct ProductView: View {
                 }
                 
                 Text(message.uppercased())
-                    .foregroundColor(.gray)
+                    .foregroundColor(ThemeColors.muted)
                     .font(themeManager.captionFont)
             }
         }
+        .themedBackground(themeManager)
         .padding(15)
         .task {
             self.selectedVariant = self.product.variants[0].variantId

--- a/hackertracker/Views/ProductsView.swift
+++ b/hackertracker/Views/ProductsView.swift
@@ -183,6 +183,7 @@ struct ProductsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .themedBackground(themeManager)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 if !showMerchInfo, let c = viewModel.conference, let docId = c.merchHelpDocId, let doc = viewModel.documentsById[docId] {
@@ -368,10 +369,10 @@ struct MerchSizeFilter: View {
                                 .padding(8)
                                 .frame(maxWidth: .infinity)
                                 .foregroundColor(isOn ? .white : .primary)
-                                .background(isOn ? Color.accentColor : Color.clear)
+                                .background(isOn ? themeManager.accent : Color.clear)
                                 .overlay(
                                     RoundedRectangle(cornerRadius: 10)
-                                        .stroke(isOn ? Color.clear : Color.accentColor, lineWidth: 2)
+                                        .stroke(isOn ? Color.clear : themeManager.accent, lineWidth: 2)
                                 )
                                 .cornerRadius(10)
                         }

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -919,6 +919,7 @@ struct ThemePickerView: View {
         .navigationTitle("Theme")
         .themedNavTitle("Theme", themeManager)
         .navigationBarTitleDisplayMode(.inline)
+        .themedBackground(themeManager)
     }
 
     /// One row per registered theme. Each row previews the theme's

--- a/hackertracker/Views/ShareBookmarksView.swift
+++ b/hackertracker/Views/ShareBookmarksView.swift
@@ -59,6 +59,7 @@ struct ShareBookmarksView: View {
                 Divider()
             }
         }
+        .themedBackground(themeManager)
         .analyticsScreen(name: "ShareBookmarksView")
         .padding(15)
     }

--- a/hackertracker/Views/SharedScheduleView.swift
+++ b/hackertracker/Views/SharedScheduleView.swift
@@ -95,6 +95,7 @@ struct SharedScheduleView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .themedBackground(themeManager)
         .analyticsScreen(name: "SharedScheduleView")
     }
 

--- a/hackertracker/Views/SpeakerDetailView.swift
+++ b/hackertracker/Views/SpeakerDetailView.swift
@@ -34,7 +34,7 @@ struct SpeakerDetailView: View {
                         if let pronouns = speaker.pronouns {
                             Text("(\(pronouns))")
                                 .font(themeManager.captionFont)
-                                .foregroundColor(.gray)
+                                .foregroundColor(ThemeColors.muted)
                         }
                         if let affiliations = speaker.affiliations, affiliations.count > 0 {
                             showAffiliations(affiliations: affiliations)
@@ -98,6 +98,7 @@ struct SpeakerDetailView: View {
                     }
                 }
             }
+            .themedBackground(themeManager)
             .analyticsScreen(name: "SpeakerDetailView")
         } else {
             _04View(message: "Speaker \(id) not found")


### PR DESCRIPTION
## Problem
Detail/secondary screens didn't apply a themed background, so they rendered on the **system** background instead of the active theme's — most visible on ContentDetailView and SpeakerDetailView (reported), but the same across ~20 screens. Pushed detail views don't inherit a parent's background, so each needs its own.

## Fix
Apply the existing `.themedBackground(themeManager)` helper (`scrollContentBackground(.hidden)` + `background(themeManager.background)`) at the root of every screen-level view missing it: 404, Cart, Conferences, ContentDetail, CustomEvent (detail/form/share), Document, FAQ, GlobalSearch, Location, News, Org, Orgs, Product, Products, ShareBookmarks, SharedSchedule, SpeakerDetail.

Plus conservative hardcoded-color fixes:
- nested `.background(.background)` pill rows (ContentDetail session row, CustomEventDetail when/location rows) → `themeManager.cardSurface`
- `.foregroundColor(.gray)` muted text (SpeakerDetail pronouns, ProductView status) → `ThemeColors.muted`
- `MerchSizeFilter` `Color.accentColor` → `themeManager.accent`

**Left intentionally:** `.primary`/`.secondary` (adapt correctly), white text on colorMode carousel cards, data-driven tag/status colors, the QR card's functional white background.

## Notes
- `EventDetailView.swift` untouched — its primary `EventDetailView` struct is entirely commented-out dead code (the live event detail is `ContentDetailView`). Worth deleting or reviving in a separate pass.
- Cells/components (EventCell, ContentCell, SpeakerRow, NoteBlock, ListChrome) and the root TabView were excluded by design.

## Verification
Builds clean (iPad 17.5 sim). Code-verified coverage (every screen root now carries `themedBackground`). Pushed detail screens couldn't be screenshotted from here (no gesture injection), so a device eyeball of ContentDetail/SpeakerDetail across a couple themes is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)