### PR TITLE
Theme: background on About, Speakers, and filter/note sheets

### DIFF
--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -65,6 +65,7 @@ struct EventFilters: View {
             .navigationTitle("Filters")
             .themedNavTitle("Filters", themeManager)
             .navigationBarTitleDisplayMode(.inline)
+            .themedBackground(themeManager)
             .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {

--- a/hackertracker/Views/NoteBlock.swift
+++ b/hackertracker/Views/NoteBlock.swift
@@ -195,6 +195,7 @@ struct NoteEditorView: View {
             .navigationTitle("Note")
             .themedNavTitle("Note", themeManager)
             .navigationBarTitleDisplayMode(.inline)
+            .themedBackground(themeManager)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -436,6 +436,7 @@ HackerTracker iOS is licensed under the [GNU General Public License v3.0](https:
         .navigationTitle("About")
         .themedNavTitle("About", themeManager)
         .navigationBarTitleDisplayMode(.inline)
+        .themedBackground(themeManager)
     }
 
     private var versionHeader: some View {

--- a/hackertracker/Views/SpeakersView.swift
+++ b/hackertracker/Views/SpeakersView.swift
@@ -247,6 +247,7 @@ struct SpeakersView: View {
         .navigationTitle("Speakers")
         .themedNavTitle("Speakers", themeManager)
         .navigationBarTitleDisplayMode(.inline)
+        .themedBackground(themeManager)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
@@ -385,6 +386,7 @@ struct SpeakerFiltersSheet: View {
             .navigationTitle("Filters")
             .themedNavTitle("Filters", themeManager)
             .navigationBarTitleDisplayMode(.inline)
+            .themedBackground(themeManager)
             .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {


### PR DESCRIPTION
Follow-up to #50 — it missed views nested inside other files (the sweep keyed on top-level screen files). These still rendered on the system background:

- **AboutView** (in SettingsView.swift)
- **SpeakersView** — a primary list screen
- **Speakers filter sheet**, **EventFilters sheet** (schedule/content), **Note editor sheet**

Applied `.themedBackground(themeManager)` to each root. `ContentView` is intentionally left as-is — it's the TabView container; its tabs and the wrapped `ConferencesView` theme themselves.

Re-scanned all of `Views/`: no other view with a nav title lacks `themedBackground` now (except ContentView, by design).

Builds clean (iPad 17.5 sim). Screens reachable only by navigation/sheet couldn't be screenshotted from here — worth an eyeball on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)