### PR TITLE
Age verification via Declared Age Range API (iOS 26+)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-age-verification.md
+++ b/docs/superpowers/plans/2026-07-17-age-verification.md
@@ -1,0 +1,619 @@
+# Age Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide age-restricted Content and Organizations from users Apple confirms are under an item's `visible_age_min`, using the Declared Age Range API on iOS 26+.
+
+**Architecture:** A single `AgeGate` service (in `Utils/AgeGate.swift`) owns the Declared Age Range query behind an injectable `AgeRangeProviding` protocol, caches a coarse bracket, and exposes `isVisible(minAge:)`. `InfoViewModel` holds the gate, keeps raw decoded arrays private, and publishes age-filtered `content`/`events`/`orgs` (+ their id maps) so every screen is covered at one chokepoint. Fail-open: hide only on a positive under-age signal.
+
+**Tech Stack:** Swift 6, SwiftUI, `@Observable`, Firebase Firestore (Codable), `DeclaredAgeRange` (iOS 26+), XCTest.
+
+## Global Constraints
+
+- Deployment target stays **iOS 17.0**. All Declared Age Range code is gated by `if #available(iOS 26, *)`; on older OS the feature is a no-op and everything shows.
+- Requested age gates are exactly **[13, 16, 18]** (`AgeGateConfig.requestedGates`).
+- Absent `visible_age_min` → `AgeGateConfig.defaultMinAge`, which is **`nil` (no minimum)** today and must be changeable in one place.
+- **Fail open:** hide an item only when we have a confident under-age signal (`upperBound < minAge`). Declined / error / indeterminate / in-flight / iOS <26 all resolve to visible.
+- Only Content and Organizations are gated. Speakers are not.
+- Firestore documents without `visible_age_min` must continue to decode unchanged.
+- Project is NOT a synchronized folder group (`PBXFileSystemSynchronizedRootGroup` count = 0): every new `.swift` source file requires manual `project.pbxproj` wiring (PBXBuildFile + PBXFileReference + Utils group child + Sources build phase). New tests are appended to the existing `hackertrackerTests/hackertrackerTests.swift` (no pbxproj change).
+- Build/verify command:
+  `xcodebuild -project hackertracker.xcodeproj -scheme hackertracker -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' build`
+- Test command:
+  `xcodebuild -project hackertracker.xcodeproj -scheme hackertracker -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' test`
+
+---
+
+### Task 1: `visible_age_min` on the data models
+
+**Files:**
+- Modify: `hackertracker/Models/Content.swift` (struct fields + CodingKeys)
+- Modify: `hackertracker/Models/Organization.swift` (struct fields + CodingKeys)
+- Modify: `hackertracker/Models/Event.swift` (add non-CodingKey property)
+- Modify: `hackertracker/ViewModels/InfoViewModel.swift` (propagate into synthesized events, in `fetchContent`)
+- Test: `hackertrackerTests/hackertrackerTests.swift` (append decode tests)
+
+**Interfaces:**
+- Produces: `Content.visibleAgeMin: Int?`, `Organization.visibleAgeMin: Int?`, `Event.visibleAgeMin: Int?`.
+
+- [ ] **Step 1: Write failing decode tests** — append to `hackertrackerTests/hackertrackerTests.swift`:
+
+```swift
+func testContentDecodesVisibleAgeMin() throws {
+    let json = """
+    {"id": 1, "description": "d", "links": [], "media": [], "people": [],
+     "sessions": [], "tag_ids": [], "title": "t", "visible_age_min": 18}
+    """.data(using: .utf8)!
+    let content = try JSONDecoder().decode(Content.self, from: json)
+    XCTAssertEqual(content.visibleAgeMin, 18)
+}
+
+func testContentDefaultsVisibleAgeMinToNilWhenAbsent() throws {
+    let json = """
+    {"id": 2, "description": "d", "links": [], "media": [], "people": [],
+     "sessions": [], "tag_ids": [], "title": "t"}
+    """.data(using: .utf8)!
+    let content = try JSONDecoder().decode(Content.self, from: json)
+    XCTAssertNil(content.visibleAgeMin)
+}
+
+func testOrganizationDecodesVisibleAgeMin() throws {
+    let json = """
+    {"name": "n", "description": "d", "links": [], "media": [],
+     "tag_ids": [], "visible_age_min": 21}
+    """.data(using: .utf8)!
+    let org = try JSONDecoder().decode(Organization.self, from: json)
+    XCTAssertEqual(org.visibleAgeMin, 21)
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run the test command (filter if desired: `-only-testing:hackertrackerTests/hackertrackerTests/testContentDecodesVisibleAgeMin`).
+Expected: FAIL — `value of type 'Content' has no member 'visibleAgeMin'` (compile error).
+
+- [ ] **Step 3: Add the field to Content** — in `hackertracker/Models/Content.swift`, add after `var feedbackFormId: Int?` (line ~26):
+
+```swift
+    /// Minimum age required to see this content. Absent → no minimum
+    /// (see AgeGateConfig.defaultMinAge). Enforced only on iOS 26+.
+    var visibleAgeMin: Int?
+```
+
+and add to the `CodingKeys` enum (after `case feedbackFormId = "feedback_form_id"`):
+
+```swift
+        case visibleAgeMin = "visible_age_min"
+```
+
+- [ ] **Step 4: Add the field to Organization** — in `hackertracker/Models/Organization.swift`, add after `var tag_id_as_organizer: Int?` (line ~19):
+
+```swift
+    /// Minimum age required to see this organization. Absent → no minimum.
+    var visibleAgeMin: Int?
+```
+
+and to its `CodingKeys` (after `case tag_id_as_organizer`):
+
+```swift
+        case visibleAgeMin = "visible_age_min"
+```
+
+- [ ] **Step 5: Add the field to Event** — in `hackertracker/Models/Event.swift`, add after `var customColorHex: String? = nil` (before the `CodingKeys` enum). Do NOT add it to `CodingKeys` — events are synthesized in code, not decoded from Firestore, matching the existing `customEventID`/`customColorHex` pattern:
+
+```swift
+    /// Minimum age required to see this event, copied from the parent
+    /// Content by the synthesizer. NOT in CodingKeys (events are built in
+    /// code); nil = no minimum.
+    var visibleAgeMin: Int? = nil
+```
+
+- [ ] **Step 6: Propagate into synthesized events** — in `hackertracker/ViewModels/InfoViewModel.swift`, `fetchContent`, find the `Event(` initializer inside the `Task.detached` decode loop and add `visibleAgeMin: c.visibleAgeMin` to the argument list:
+
+```swift
+    let e = Event(id: s.id, contentId: c.id, description: c.description,
+                  beginTimestamp: s.beginTimestamp, endTimestamp: s.endTimestamp,
+                  title: c.title, locationId: s.locationId, people: c.people,
+                  tagIds: c.tagIds, relatedIds: c.relatedIds,
+                  visibleAgeMin: c.visibleAgeMin)
+```
+
+- [ ] **Step 7: Run tests, verify they pass** — run the test command. Expected: the three new tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add hackertracker/Models/Content.swift hackertracker/Models/Organization.swift hackertracker/Models/Event.swift hackertracker/ViewModels/InfoViewModel.swift hackertrackerTests/hackertrackerTests.swift
+git commit -m "Age gate: add visible_age_min to Content/Organization/Event"
+```
+
+---
+
+### Task 2: `AgeGate` service + visibility logic (TDD core)
+
+**Files:**
+- Create: `hackertracker/Utils/AgeGate.swift`
+- Modify: `hackertracker.xcodeproj/project.pbxproj` (wire the new file)
+- Test: `hackertrackerTests/hackertrackerTests.swift` (append)
+
+**Interfaces:**
+- Produces:
+  - `enum AgeGateConfig { static let defaultMinAge: Int?; static let requestedGates: [Int] }`
+  - `struct AgeRangeResult { let lowerBound: Int?; let upperBound: Int? }`
+  - `protocol AgeRangeProviding { func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult }`
+  - `struct NoopAgeRangeProvider: AgeRangeProviding` (returns `.init(lowerBound: nil, upperBound: nil)`)
+  - `@Observable @MainActor final class AgeGate` with `init(provider:)`, `private(set) var lowerBound: Int?`, `private(set) var upperBound: Int?`, `func refresh(forcePrompt: Bool) async`, `func isVisible(minAge: Int?) -> Bool`.
+
+- [ ] **Step 1: Write the failing tests** — append to `hackertrackerTests/hackertrackerTests.swift`:
+
+```swift
+@MainActor
+final class AgeGateTests: XCTestCase {
+    /// Feeds a fixed range so the decision logic can be tested without the OS.
+    struct FakeProvider: AgeRangeProviding {
+        let result: AgeRangeResult
+        func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult { result }
+    }
+
+    private func gate(lower: Int?, upper: Int?) async -> AgeGate {
+        let g = AgeGate(provider: FakeProvider(result: .init(lowerBound: lower, upperBound: upper)))
+        await g.refresh(forcePrompt: false)
+        return g
+    }
+
+    func testNilMinIsAlwaysVisible() async {
+        let g = await gate(lower: 13, upper: 15)   // confirmed under 18
+        XCTAssertTrue(g.isVisible(minAge: nil))     // no minimum → visible
+    }
+
+    func testConfirmedUnderIsHidden() async {
+        let g = await gate(lower: 13, upper: 15)
+        XCTAssertFalse(g.isVisible(minAge: 18))     // max age 15 < 18 → hidden
+    }
+
+    func testAtOrAboveMinIsVisible() async {
+        let g = await gate(lower: 18, upper: nil)   // 18+
+        XCTAssertTrue(g.isVisible(minAge: 18))
+    }
+
+    func testStraddleFailsOpen() async {
+        let g = await gate(lower: 16, upper: 17)
+        XCTAssertTrue(g.isVisible(minAge: 16))      // 17 >= 16 → visible
+        XCTAssertFalse(g.isVisible(minAge: 18))     // 17 < 18 → hidden
+    }
+
+    func testUnknownRangeFailsOpen() async {
+        let g = await gate(lower: nil, upper: nil)  // declined/error/pre-26
+        XCTAssertTrue(g.isVisible(minAge: 18))      // no signal → visible
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run the test command. Expected: FAIL — `cannot find 'AgeGate' in scope` (compile error).
+
+- [ ] **Step 3: Create the service** — write `hackertracker/Utils/AgeGate.swift`:
+
+```swift
+//
+//  AgeGate.swift
+//  hackertracker
+//
+//  Age-restriction gate backed by Apple's Declared Age Range API (iOS 26+).
+//  On iOS < 26 there is no provider, so nothing is ever hidden.
+//
+
+import Foundation
+import SwiftUI
+
+enum AgeGateConfig {
+    /// Applied when an item has no explicit visible_age_min.
+    /// nil = no minimum. Change here to flip the default policy app-wide.
+    static let defaultMinAge: Int? = nil
+    /// Age gates requested from the Declared Age Range API.
+    static let requestedGates: [Int] = [13, 16, 18]
+}
+
+/// Coarse age bracket. nil bounds = unknown (declined / error / iOS < 26).
+struct AgeRangeResult {
+    let lowerBound: Int?
+    let upperBound: Int?
+    static let unknown = AgeRangeResult(lowerBound: nil, upperBound: nil)
+}
+
+/// Injectable source of the declared age range. The real iOS-26 adapter is
+/// added in Task 3; tests and iOS < 26 use NoopAgeRangeProvider.
+protocol AgeRangeProviding: Sendable {
+    func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult
+}
+
+struct NoopAgeRangeProvider: AgeRangeProviding {
+    func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult { .unknown }
+}
+
+@Observable
+@MainActor
+final class AgeGate {
+    private(set) var lowerBound: Int?
+    private(set) var upperBound: Int?
+    @ObservationIgnored private let provider: AgeRangeProviding
+
+    init(provider: AgeRangeProviding = NoopAgeRangeProvider()) {
+        self.provider = provider
+        // Restore the cached bracket so filtering applies before refresh().
+        let d = UserDefaults.standard
+        self.lowerBound = d.object(forKey: Self.lowerKey) as? Int
+        self.upperBound = d.object(forKey: Self.upperKey) as? Int
+    }
+
+    private static let lowerKey = "ageGate.lowerBound.v1"
+    private static let upperKey = "ageGate.upperBound.v1"
+
+    func refresh(forcePrompt: Bool = false) async {
+        let result = await provider.requestRange(gates: AgeGateConfig.requestedGates,
+                                                  forcePrompt: forcePrompt)
+        lowerBound = result.lowerBound
+        upperBound = result.upperBound
+        let d = UserDefaults.standard
+        d.set(result.lowerBound, forKey: Self.lowerKey)
+        d.set(result.upperBound, forKey: Self.upperKey)
+    }
+
+    /// Fail-open decision: hide ONLY when the user's maximum possible age is
+    /// below the item's minimum. Everything else is visible.
+    func isVisible(minAge rawMin: Int?) -> Bool {
+        let minAge = rawMin ?? AgeGateConfig.defaultMinAge
+        guard let minAge else { return true }        // no minimum
+        guard let upper = upperBound else { return true }  // no signal → fail open
+        return upper >= minAge
+    }
+}
+```
+
+- [ ] **Step 4: Wire the file into the project** — edit `hackertracker.xcodeproj/project.pbxproj`. Mirror the existing `Theme.swift` entries (search for `Theme.swift` to copy the exact patterns), adding four entries with two fresh 24-hex-char UUIDs (call them `<BUILDUUID>` and `<FILEUUID>`, generate with `openssl rand -hex 12 | tr a-z A-Z`):
+  1. PBXBuildFile section: `<BUILDUUID> /* AgeGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = <FILEUUID> /* AgeGate.swift */; };`
+  2. PBXFileReference section: `<FILEUUID> /* AgeGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeGate.swift; sourceTree = "<group>"; };`
+  3. The Utils group's `children = ( … )` list: `<FILEUUID> /* AgeGate.swift */,`
+  4. The app target's Sources `PBXSourcesBuildPhase` `files = ( … )` list: `<BUILDUUID> /* AgeGate.swift in Sources */,`
+
+  Verify: `plutil -lint hackertracker.xcodeproj/project.pbxproj` → `OK`.
+
+- [ ] **Step 5: Run tests, verify they pass** — run the test command. Expected: all five `AgeGateTests` PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hackertracker/Utils/AgeGate.swift hackertracker.xcodeproj/project.pbxproj hackertrackerTests/hackertrackerTests.swift
+git commit -m "Age gate: AgeGate service + visibility logic (TDD)"
+```
+
+---
+
+### Task 3: iOS 26 Declared Age Range provider
+
+**Files:**
+- Modify: `hackertracker/Utils/AgeGate.swift` (add the real provider)
+
+**Interfaces:**
+- Consumes: `AgeRangeProviding`, `AgeRangeResult`, `AgeGateConfig.requestedGates`.
+- Produces: `DeclaredAgeRangeProvider: AgeRangeProviding` (real API adapter), and a factory `AgeGate.makeDefault()` that picks the real provider on iOS 26+ and `NoopAgeRangeProvider` otherwise.
+
+> **API verification (do this first):** The exact `DeclaredAgeRange` symbol names — the service/request type, the request method signature, and the response cases — are from the iOS 26 API. Confirm them against current Apple documentation (search "Declared Age Range API" / the `DeclaredAgeRange` framework) before writing this adapter. The code below is the *shape*; adjust symbol names to match the shipped API. Nothing else in the feature depends on these names — only this adapter does.
+
+- [ ] **Step 1: Add the real provider + factory** — append to `hackertracker/Utils/AgeGate.swift`:
+
+```swift
+import DeclaredAgeRange   // iOS 26+; guarded at the call site
+
+/// Real adapter over Apple's Declared Age Range API. Maps the response to
+/// AgeRangeResult; any decline/error/indeterminate → .unknown (fail open).
+@available(iOS 26, *)
+struct DeclaredAgeRangeProvider: AgeRangeProviding {
+    func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult {
+        do {
+            // NOTE: confirm the exact API surface against Apple docs.
+            let service = AgeRangeService()
+            let response = try await service.requestAgeRange(ageGates: gates)
+            switch response {
+            case .sharing(let range):
+                return AgeRangeResult(lowerBound: range.lowerBound,
+                                      upperBound: range.upperBound)
+            default:
+                return .unknown   // declined / not shared → fail open
+            }
+        } catch {
+            Log.app.error("age range request failed: \(String(describing: error), privacy: .public)")
+            return .unknown
+        }
+    }
+}
+
+extension AgeGate {
+    /// Picks the real provider on iOS 26+, no-op otherwise.
+    static func makeDefault() -> AgeGate {
+        if #available(iOS 26, *) {
+            return AgeGate(provider: DeclaredAgeRangeProvider())
+        } else {
+            return AgeGate(provider: NoopAgeRangeProvider())
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run the build command. Expected: **BUILD SUCCEEDED**. (If the SDK in use predates iOS 26 and `import DeclaredAgeRange` fails to resolve, wrap the import and provider in `#if canImport(DeclaredAgeRange)` and have `makeDefault()` fall back to `NoopAgeRangeProvider` — the app still builds and the feature is inert until built against the iOS 26 SDK.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hackertracker/Utils/AgeGate.swift
+git commit -m "Age gate: iOS 26 DeclaredAgeRange provider + factory"
+```
+
+---
+
+### Task 4: Centralized filtering in `InfoViewModel`
+
+**Files:**
+- Modify: `hackertracker/ViewModels/InfoViewModel.swift`
+- Test: `hackertrackerTests/hackertrackerTests.swift` (append)
+
+**Interfaces:**
+- Consumes: `AgeGate`, `AgeGate.makeDefault()`, `AgeGate.isVisible(minAge:)`.
+- Produces on `InfoViewModel`:
+  - `let ageGate: AgeGate` (public, so views/Settings can read status + trigger refresh)
+  - `func refreshAgeGate(forcePrompt: Bool) async` — calls `ageGate.refresh` then re-applies the filter
+  - Behavior: `content`, `events`, `orgs` (and `contentById`/`eventsById`/`orgsById`) reflect the age filter.
+
+**Approach:** keep the public stored arrays (with their existing index-building `didSet`) but feed them from private raw arrays through one filter method. This preserves the O(1) id maps used on hot paths and changes only the assignment sites in `fetchContent`/`fetchOrgs`.
+
+- [ ] **Step 1: Write the failing test** — append to `hackertrackerTests/hackertrackerTests.swift`:
+
+```swift
+@MainActor
+func testInfoViewModelHidesUnderageContent() async {
+    let vm = InfoViewModel(
+        ageGate: AgeGate(provider: AgeGateTests.FakeProvider(
+            result: .init(lowerBound: 13, upperBound: 15)))   // confirmed under 18
+    )
+    await vm.ageGate.refresh()
+    vm._setDecodedContentForTesting([
+        Content.stub(id: 1, visibleAgeMin: nil),
+        Content.stub(id: 2, visibleAgeMin: 18)
+    ])
+    XCTAssertEqual(vm.content.map(\.id), [1])   // id 2 (18+) hidden from a 13–15 user
+}
+```
+
+(Also add a `Content.stub(...)` test helper and `InfoViewModel._setDecodedContentForTesting(_:)` + a test-only `init(ageGate:)` — see Steps 3–4. These `_`-prefixed test seams are acceptable because InfoViewModel is otherwise Firestore-driven and not constructible in a test without them.)
+
+- [ ] **Step 2: Run test, verify it fails** — run the test command. Expected: FAIL — `InfoViewModel` has no `ageGate` / `_setDecodedContentForTesting` (compile error).
+
+- [ ] **Step 3: Add the gate + private raw arrays + filter** — in `hackertracker/ViewModels/InfoViewModel.swift`:
+
+Add a stored gate near the top of the class:
+
+```swift
+    let ageGate: AgeGate
+```
+
+Add an initializer (the class currently relies on the implicit one; add an explicit one that defaults to the real gate, plus the injection point for tests):
+
+```swift
+    init(ageGate: AgeGate = .makeDefault()) {
+        self.ageGate = ageGate
+    }
+```
+
+Add private raw storage and the filter method:
+
+```swift
+    @ObservationIgnored private var rawContent: [Content] = []
+    @ObservationIgnored private var rawEvents: [Event] = []
+    @ObservationIgnored private var rawOrgs: [Organization] = []
+
+    /// Re-derive the public (age-filtered) collections from the raw decoded
+    /// arrays. Called after each decode and after the age bracket changes.
+    func applyAgeFilter() {
+        content = rawContent.filter { ageGate.isVisible(minAge: $0.visibleAgeMin) }
+        events  = rawEvents.filter  { ageGate.isVisible(minAge: $0.visibleAgeMin) }
+        orgs    = rawOrgs.filter    { ageGate.isVisible(minAge: $0.visibleAgeMin) }
+    }
+
+    /// Up-front + Settings entry point.
+    func refreshAgeGate(forcePrompt: Bool = false) async {
+        await ageGate.refresh(forcePrompt: forcePrompt)
+        applyAgeFilter()
+    }
+
+    // Test seams (used only by the unit tests).
+    func _setDecodedContentForTesting(_ c: [Content]) { rawContent = c; applyAgeFilter() }
+```
+
+- [ ] **Step 4: Route decode assignments through the raw arrays** — in `fetchContent`'s `MainActor.run` assignment, change `self.content = decodedContent` / `self.events = rebuiltEvents` to:
+
+```swift
+    self.rawContent = decodedContent
+    self.rawEvents = rebuiltEvents
+    self.applyAgeFilter()   // sets self.content / self.events (filtered)
+```
+
+In `fetchOrgs`'s assignment, change `self.orgs = decodedOrgs` to:
+
+```swift
+    self.rawOrgs = decodedOrgs
+    self.applyAgeFilter()
+```
+
+(Leave the existing `didSet` index-builders on `content`/`events`/`orgs` untouched — they now rebuild the maps from the filtered arrays, which is what we want.)
+
+Add the `Content.stub` test helper at the bottom of the test file:
+
+```swift
+extension Content {
+    static func stub(id: Int, visibleAgeMin: Int?) -> Content {
+        Content(id: id, conferenceName: nil, description: "", links: [], logo: nil,
+                media: [], people: [], sessions: [], tagIds: [], relatedIds: nil,
+                title: "stub", feedbackDisableTimestamp: nil, feedbackEnableTimestamp: nil,
+                feedbackFormId: nil, visibleAgeMin: visibleAgeMin)
+    }
+}
+```
+
+(If `Content`'s member-wise initializer differs, match its actual stored properties — check `Content.swift`.)
+
+- [ ] **Step 5: Run test, verify it passes** — run the test command. Expected: `testInfoViewModelHidesUnderageContent` PASSES.
+
+- [ ] **Step 6: Build the app** — run the build command. Expected: **BUILD SUCCEEDED** (confirms the `fetchContent`/`fetchOrgs` edits compile in context).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hackertracker/ViewModels/InfoViewModel.swift hackertrackerTests/hackertrackerTests.swift
+git commit -m "Age gate: centralized age filtering in InfoViewModel"
+```
+
+---
+
+### Task 5: Up-front trigger on launch
+
+**Files:**
+- Modify: `hackertracker/Views/ContentView.swift`
+
+**Interfaces:**
+- Consumes: `InfoViewModel.refreshAgeGate(forcePrompt:)`.
+
+- [ ] **Step 1: Call the gate on launch** — in `hackertracker/Views/ContentView.swift`, find the `.task { … }` on the populated `TabView` branch (the one that sets `launchScreen`/`viewModel.showNews`). Add at the end of that closure:
+
+```swift
+                // Age gate: query the declared age range up front so
+                // restricted content is filtered before the user browses.
+                await viewModel.refreshAgeGate()
+```
+
+- [ ] **Step 2: Build**
+
+Run the build command. Expected: **BUILD SUCCEEDED**.
+
+- [ ] **Step 3: Manual smoke (documented, not automated)** — on an iPad/ierPhone iOS 26 sim: launch → the system age sheet may appear once; with a Firestore item carrying `visible_age_min: 18` and a declared under-18 range, that item is absent from Schedule/All Content/Orgs/Search. On an iOS 17–25 sim: everything shows, no sheet. (No unit test — this is UI/OS behavior.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hackertracker/Views/ContentView.swift
+git commit -m "Age gate: query declared age range up front on launch"
+```
+
+---
+
+### Task 6: Settings — "Age Verification" row
+
+**Files:**
+- Modify: `hackertracker/Views/SettingsView.swift`
+
+**Interfaces:**
+- Consumes: `InfoViewModel.ageGate` (`lowerBound`/`upperBound`), `InfoViewModel.refreshAgeGate(forcePrompt:)`.
+
+- [ ] **Step 1: Add the settings section** — in `hackertracker/Views/SettingsView.swift`, add a new view struct following the existing `AISummarySettingsView` pattern (env `@Environment(InfoViewModel.self) private var viewModel`, `@Environment(ThemeManager.self) private var themeManager`, `.settingsCard(themeManager)`):
+
+```swift
+struct AgeVerificationSettingsView: View {
+    @Environment(InfoViewModel.self) private var viewModel
+    @Environment(ThemeManager.self) private var themeManager
+    @State private var verifying = false
+
+    private var statusText: String {
+        if #available(iOS 26, *) {
+            if let lower = viewModel.ageGate.lowerBound {
+                return "Verified: \(lower)+"
+            }
+            return "Not verified"
+        }
+        return "Unavailable on this iOS"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Age Verification")
+                .font(themeManager.headingFont)
+            Text(statusText)
+                .font(themeManager.captionFont)
+                .foregroundStyle(.secondary)
+            if #available(iOS 26, *) {
+                Button {
+                    verifying = true
+                    Task {
+                        await viewModel.refreshAgeGate(forcePrompt: true)
+                        verifying = false
+                    }
+                } label: {
+                    Text(verifying ? "Verifying…" : "Verify Age")
+                }
+                .disabled(verifying)
+                Text("Age-restricted content is shown based on your device's declared age range.")
+                    .font(themeManager.captionFont)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .settingsCard(themeManager)
+    }
+}
+```
+
+- [ ] **Step 2: Render it in the settings list** — in `SettingsView.body`, add `AgeVerificationSettingsView()` to both the iPad two-column layout (a `VStack(spacing: 0) { AgeVerificationSettingsView() }` in one of the columns) and the iPhone single-column list (alongside `AISummarySettingsView()`).
+
+- [ ] **Step 3: Build**
+
+Run the build command. Expected: **BUILD SUCCEEDED**.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hackertracker/Views/SettingsView.swift
+git commit -m "Age gate: Settings age-verification status + re-verify"
+```
+
+---
+
+### Task 7: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full build + test**
+
+Run the build command, then the test command. Expected: **BUILD SUCCEEDED** and all tests (including the new decode / AgeGate / InfoViewModel tests) PASS.
+
+- [ ] **Step 2: swiftlint** — run `swiftlint` and confirm no NEW violations attributable to the added files.
+
+- [ ] **Step 3: Confirm backward compatibility** — grep confirms `visible_age_min` decodes optionally and no deployment-target change was introduced:
+
+```bash
+grep -n "iOS 26" hackertracker/Utils/AgeGate.swift
+grep -n "IPHONEOS_DEPLOYMENT_TARGET" hackertracker.xcodeproj/project.pbxproj | sort -u
+```
+
+Expected: availability guards present in AgeGate; deployment target still `17.0`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- visible_age_min on Content/Org/Event → Task 1 ✓
+- AgeGate service, gates [13,16,18], caching, fail-open isVisible → Task 2 ✓
+- iOS 26 provider behind availability + protocol isolation → Task 3 ✓
+- Centralized InfoViewModel filtering (Approach A) covering all surfaces → Task 4 ✓
+- Up-front trigger → Task 5 ✓
+- Settings status + re-verify → Task 6 ✓
+- Default configurable (`AgeGateConfig.defaultMinAge`) → Task 2 ✓
+- Pre-26 no-op / iOS 17 floor unchanged → Tasks 2/3/7 ✓
+- Unit tests for isVisible matrix → Task 2 ✓
+- Privacy: only coarse bracket cached → Task 2 (UserDefaults ints) ✓
+
+**Placeholder scan:** No TBD/TODO. The one deliberate uncertainty (exact DeclaredAgeRange symbols) is isolated to Task 3 with an explicit "verify against docs first" instruction and a `#if canImport` fallback — not a silent gap.
+
+**Type consistency:** `AgeRangeResult(lowerBound:upperBound:)`, `AgeRangeProviding.requestRange(gates:forcePrompt:)`, `AgeGate.isVisible(minAge:)`, `AgeGate.refresh(forcePrompt:)`, `InfoViewModel.refreshAgeGate(forcePrompt:)`, `applyAgeFilter()` — names match across Tasks 2/3/4/5/6. `AgeGate.makeDefault()` (Task 3) is the default arg in `InfoViewModel.init` (Task 4). `FakeProvider` is defined in `AgeGateTests` (Task 2) and reused in Task 4's test via `AgeGateTests.FakeProvider`.
+
+**Known risk to watch during execution:** Task 4 assumes `fetchContent` assigns `self.content`/`self.events` in a `MainActor.run` block and `fetchOrgs` assigns `self.orgs` — confirm the exact current assignment lines before editing (they were touched by the Phase 3 off-main-decode work). The edit is "assign raw + call applyAgeFilter()" regardless of the surrounding structure.

--- a/docs/superpowers/specs/2026-07-17-age-verification-design.md
+++ b/docs/superpowers/specs/2026-07-17-age-verification-design.md
@@ -1,0 +1,165 @@
+# Age Verification — Design Spec
+
+**Date:** 2026-07-17
+**Status:** Approved for planning
+**Feature branch:** `feature/age-verification`
+
+## Summary
+
+Age-gate conference content and organizations using Apple's **Declared Age Range API**
+(`DeclaredAgeRange`, iOS 26+). A new optional `visible_age_min` field on Content and
+Organization documents declares the minimum age required to see an item. On iOS 26+ the
+app queries the user's declared age range up front and hides items the user is confirmed
+to be too young for. On iOS 17–25 the API does not exist, so the feature is a no-op and
+all content shows normally.
+
+This is a privacy-preserving design: the Declared Age Range API returns a coarse age
+*bracket*, never a birthdate, and for child/teen accounts it is parent-controlled via
+Family Sharing. It aligns with HackerTracker's existing posture (no tracking, no IDFA).
+
+## Requirements & decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Platform scope | **iOS 26+ only.** No self-attestation fallback. |
+| 2 | Pre-iOS-26 behavior | Feature is a no-op; **all content shown ungated**. |
+| 3 | iOS 26 trigger + visibility | **Query up front; hide until cleared.** Settings offers re-verify. |
+| 4 | Age thresholds (gates requested) | **Apple brackets: [13, 16, 18].** `visible_age_min` values are drawn from this set. |
+| 5 | Decline / error / indeterminate | **Fail open (show).** |
+| 6 | Absent `visible_age_min` | Use `AgeGateConfig.defaultMinAge` — **`nil` (no minimum)** today, changeable in one place. |
+| 7 | Architecture | **Approach A** — isolated `AgeGate` service + centralized filtering in `InfoViewModel`. |
+
+### Reconciling "hide until cleared" with "fail open"
+
+Taken together these mean: **an item is hidden only when the API positively confirms the
+user is below that item's minimum.** Every other state — declined, errored, indeterminate,
+query in flight, or iOS < 26 — resolves to *visible*. The gate's job is narrow and
+defensible: when Apple tells us a user is under the threshold, remove restricted items for
+that user; everyone else sees everything.
+
+## Scope
+
+**In scope**
+- `visible_age_min` decoding on Content and Organization; propagation to synthesized Events.
+- An `AgeGate` service wrapping the Declared Age Range API (iOS 26+), with caching and an
+  injectable range provider.
+- Centralized age filtering in `InfoViewModel` so all consuming surfaces are covered.
+- Up-front query on launch and a Settings "Verify Age" action.
+- Unit tests for the visibility decision logic.
+
+**Out of scope / non-goals**
+- Any pre-iOS-26 verification (self-attestation, birthdate entry).
+- Gating of Speakers (requirement covers Content + Organizations only). A speaker's linked
+  events are still individually gated through the Event filter; the speaker row itself is not.
+- Server/authoring changes for `visible_age_min` (handled on the backend).
+- Persisting anything sensitive: only a coarse age bracket is cached, never a birthdate.
+
+## Architecture
+
+### 1. Data model
+
+- `Content.visibleAgeMin: Int?` — CodingKey `visible_age_min`. Optional; absent → `nil`.
+- `Organization.visibleAgeMin: Int?` — CodingKey `visible_age_min`. Optional; absent → `nil`.
+- `Event.visibleAgeMin: Int?` — new stored property, populated from the parent `Content`
+  where `InfoViewModel.fetchContent` builds events
+  (`Event(… visibleAgeMin: c.visibleAgeMin)`).
+
+Decoding must remain backward-compatible: existing documents without the field decode with
+`nil` and are unaffected.
+
+### 2. `AgeGate` service
+
+The single place that references `DeclaredAgeRange`. Sketch (names indicative; see
+"API verification" below):
+
+```
+enum AgeGateConfig {
+    /// Applied when an item has no explicit visible_age_min. nil = no minimum.
+    /// Change here to flip the default policy app-wide.
+    static let defaultMinAge: Int? = nil
+    /// Age gates requested from the Declared Age Range API.
+    static let requestedGates: [Int] = [13, 16, 18]
+}
+
+/// Injectable so the Apple call is faked in tests and no-op'd on iOS < 26.
+protocol AgeRangeProviding {
+    func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult
+}
+struct AgeRangeResult { let lowerBound: Int?; let upperBound: Int? }  // nil/nil = unknown
+
+@Observable @MainActor final class AgeGate {
+    private(set) var lowerBound: Int?   // cached to @AppStorage
+    private(set) var upperBound: Int?   // cached to @AppStorage
+    private let provider: AgeRangeProviding
+
+    func refresh(forcePrompt: Bool = false) async { … }   // updates + caches bounds
+
+    /// Core decision. Hide ONLY when confidently under the minimum; else show.
+    func isVisible(minAge rawMin: Int?) -> Bool {
+        let minAge = rawMin ?? AgeGateConfig.defaultMinAge
+        guard let minAge else { return true }               // no minimum
+        guard let upper = upperBound else { return true }   // no confident signal → fail open
+        return upper >= minAge                              // hide only if confirmed under
+    }
+}
+```
+
+- **Real provider** (`if #available(iOS 26, *)`) calls the Declared Age Range API with
+  `AgeGateConfig.requestedGates` and maps the response to `AgeRangeResult`; declined / error
+  map to `nil/nil`.
+- **No-op provider** (iOS < 26, and the default in previews/tests) returns `nil/nil`.
+- **Caching:** `lowerBound`/`upperBound` persist in `@AppStorage` (a coarse bracket, no
+  birthdate) so filtering applies instantly on next launch before the async `refresh()`
+  resolves.
+
+### 3. Filtering in `InfoViewModel` (Approach A)
+
+- `InfoViewModel` holds the `AgeGate`. The raw decoded arrays stay private; the
+  consumer-facing `content`, `events`, `orgs` and their `*ById` maps return **age-filtered**
+  results via `ageGate.isVisible(minAge:)`.
+- Recompute trigger: when the cached bracket changes (initial `refresh()` resolves or the
+  user re-verifies), the filtered views recompute and SwiftUI refreshes.
+- `EventsView`'s `schedulePipelineKey` incorporates the bracket so its cached
+  filter+group schedule recomputes when the age result changes.
+- **Coverage (single chokepoint):** Schedule, All Content, Orgs list, Global Search, and the
+  combined-bookmark schedule all read these collections, so all are covered at once. Detail
+  views reached by id resolve against the filtered `*ById`, so a hidden item's detail does
+  not open.
+
+### 4. Trigger + Settings
+
+- **Up front:** `ContentView` (or `InfoView`) `.task` calls `ageGate.refresh()` on launch.
+  The system presents its sheet the first time or returns silently if already shared.
+- **Settings → "Age Verification":** shows status (`Verified 18+` / `Not verified` /
+  `Unavailable on this iOS`) and a **Verify Age** button calling
+  `ageGate.refresh(forcePrompt: true)`. Uses the existing `settingsCard` styling.
+
+### 5. Error handling
+
+- All failure/decline/indeterminate paths fold into `AgeRangeResult(nil, nil)` → fail open.
+- The Apple call is wrapped so a thrown error is logged (`Log.app`) and treated as unknown.
+- No user-facing error surface; the Settings status line reflects the current known state.
+
+## Testing
+
+- Unit-test `AgeGate.isVisible(minAge:)` against a fake `AgeRangeProviding`:
+  - `minAge == nil` (and default `nil`) → visible.
+  - default flipped to a value → gates a nil-min item.
+  - `upperBound` below / equal / above `minAge` for gates 13/16/18.
+  - unknown bounds (declined/error/pre-26) → visible (fail open).
+- The Declared Age Range call itself (system UI) is not unit-tested; it lives in the real
+  provider behind the protocol.
+
+## API verification (implementation-time)
+
+The exact `DeclaredAgeRange` symbol names — the request service type, the request method
+signature, and the response/enum cases — are from the iOS 26 API and must be confirmed
+against current Apple documentation when the real provider is implemented. The
+`AgeRangeProviding` protocol confines this uncertainty to one adapter; the rest of the
+feature depends only on `AgeRangeResult`.
+
+## Rollout notes
+
+- No deployment-target change (stays iOS 17.0). The real provider is gated by
+  `if #available(iOS 26, *)`.
+- Backward-compatible data: documents without `visible_age_min` behave exactly as today.

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3C04BD9E2A5FDFD900D01402 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C04BD9D2A5FDFD900D01402 /* Filters.swift */; };
 		3C04BDA02A5FE91500D01402 /* FiltersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C04BD9F2A5FE91500D01402 /* FiltersView.swift */; };
 		3C07C209285C6F7600CC9469 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C07C208285C6F7600CC9469 /* Theme.swift */; };
+		B2F695DFBD5E83F401AC1EFE /* AgeGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6C981E5BEC28D5626B1437 /* AgeGate.swift */; };
 		3C0E05CB2A53E5F500E7154F /* EventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0E05CA2A53E5F500E7154F /* EventDetailView.swift */; };
 		3C0E05CD2A53E6AD00E7154F /* GlobalSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0E05CC2A53E6AD00E7154F /* GlobalSearchView.swift */; };
 		3C0E05CF2A53E70200E7154F /* Searchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0E05CE2A53E70200E7154F /* Searchable.swift */; };
@@ -150,6 +151,7 @@
 		3C04BD9D2A5FDFD900D01402 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
 		3C04BD9F2A5FE91500D01402 /* FiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersView.swift; sourceTree = "<group>"; };
 		3C07C208285C6F7600CC9469 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		3C6C981E5BEC28D5626B1437 /* AgeGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeGate.swift; sourceTree = "<group>"; };
 		3C0E05CA2A53E5F500E7154F /* EventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailView.swift; sourceTree = "<group>"; };
 		3C0E05CC2A53E6AD00E7154F /* GlobalSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchView.swift; sourceTree = "<group>"; };
 		3C0E05CE2A53E70200E7154F /* Searchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Searchable.swift; sourceTree = "<group>"; };
@@ -490,6 +492,7 @@
 				3C0E05CE2A53E70200E7154F /* Searchable.swift */,
 				3C07C208285C6F7600CC9469 /* Theme.swift */,
 				B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */,
+				3C6C981E5BEC28D5626B1437 /* AgeGate.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -766,6 +769,7 @@
 				5DAE04B62820948B00930A2D /* ContentView.swift in Sources */,
 				3C07C209285C6F7600CC9469 /* Theme.swift in Sources */,
 				F35BEAD60BF24C4BB0AED8CF /* AppStorageKeys.swift in Sources */,
+				B2F695DFBD5E83F401AC1EFE /* AgeGate.swift in Sources */,
 				5DC0DE0000000000000000A1 /* Logger+HT.swift in Sources */,
 				5DC0DE0000000000000000B1 /* KFImage+HT.swift in Sources */,
 				5DC0DE0000000000000000C1 /* ClockService.swift in Sources */,

--- a/hackertracker/Models/Content.swift
+++ b/hackertracker/Models/Content.swift
@@ -24,6 +24,9 @@ struct Content: Codable, Identifiable {
     var feedbackDisableTimestamp: Date?
     var feedbackEnableTimestamp: Date?
     var feedbackFormId: Int?
+    /// Minimum age required to see this content. Absent → no minimum
+    /// (see AgeGateConfig.defaultMinAge). Enforced only on iOS 26+.
+    var visibleAgeMin: Int?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -40,6 +43,7 @@ struct Content: Codable, Identifiable {
         case feedbackDisableTimestamp = "feedback_disable_timestamp"
         case feedbackEnableTimestamp = "feedback_enable_timestamp"
         case feedbackFormId = "feedback_form_id"
+        case visibleAgeMin = "visible_age_min"
     }
 }
 

--- a/hackertracker/Models/Document.swift
+++ b/hackertracker/Models/Document.swift
@@ -13,10 +13,12 @@ struct Document: Codable, Identifiable {
     var id: Int
     var title: String
     var body: String
+    var visibleAgeMin: Int?
 
     private enum CodingKeys: String, CodingKey {
         case id
         case title = "title_text"
         case body = "body_text"
+        case visibleAgeMin = "visible_age_min"
     }
 }

--- a/hackertracker/Models/Event.swift
+++ b/hackertracker/Models/Event.swift
@@ -30,6 +30,10 @@ struct Event: Codable, Identifiable {
     /// events stay nil and the cell helpers fall through to the existing
     /// tag-color lookup.
     var customColorHex: String? = nil
+    /// Minimum age required to see this event, copied from the parent
+    /// Content by the synthesizer. NOT in CodingKeys (events are built in
+    /// code); nil = no minimum.
+    var visibleAgeMin: Int? = nil
 
     private enum CodingKeys: String, CodingKey {
         case id

--- a/hackertracker/Models/Organization.swift
+++ b/hackertracker/Models/Organization.swift
@@ -21,6 +21,7 @@ struct Organization: Codable, Identifiable {
     var visibleAgeMin: Int?
 
     private enum CodingKeys: String, CodingKey {
+        case id
         case name
         case description
         case logo

--- a/hackertracker/Models/Organization.swift
+++ b/hackertracker/Models/Organization.swift
@@ -17,9 +17,10 @@ struct Organization: Codable, Identifiable {
     var media: [Media]
     var tag_ids: [Int]
     var tag_id_as_organizer: Int?
+    /// Minimum age required to see this organization. Absent → no minimum.
+    var visibleAgeMin: Int?
 
     private enum CodingKeys: String, CodingKey {
-        case id
         case name
         case description
         case logo
@@ -27,6 +28,7 @@ struct Organization: Codable, Identifiable {
         case media
         case tag_ids
         case tag_id_as_organizer
+        case visibleAgeMin = "visible_age_min"
     }
 }
 

--- a/hackertracker/Models/Speaker.swift
+++ b/hackertracker/Models/Speaker.swift
@@ -22,6 +22,7 @@ struct Speaker: Codable, Equatable {
     var title: String?
     var twitter: String
     var eventIds: [Int]
+    var visibleAgeMin: Int?
 
     static func == (lhs: Speaker, rhs: Speaker) -> Bool {
         if lhs.id == rhs.id, lhs.name == rhs.name, lhs.description == rhs.description {
@@ -44,6 +45,7 @@ struct Speaker: Codable, Equatable {
         case title
         case twitter
         case eventIds = "event_ids"
+        case visibleAgeMin = "visible_age_min"
     }
 }
 

--- a/hackertracker/Utils/AgeGate.swift
+++ b/hackertracker/Utils/AgeGate.swift
@@ -71,3 +71,82 @@ final class AgeGate {
         return upper >= minAge
     }
 }
+
+// MARK: - iOS 26 Declared Age Range adapter
+//
+// API confirmed against Apple's current developer documentation for the
+// `DeclaredAgeRange` framework ("Requesting people share their age range
+// with your app", AgeRangeService / AgeRangeService.Response /
+// AgeRangeService.AgeRange), July 2026:
+//   - `AgeRangeService.shared.requestAgeRange(ageGates:_:_:in:) async throws
+//     -> AgeRangeService.Response` takes UP TO THREE separate `Int`/`Int?`
+//     gate parameters (not an array) plus a presentation anchor
+//     (`UIViewController` on iOS/iPadOS/Mac Catalyst, `NSWindow` on macOS).
+//   - `Response` has cases `.sharing(AgeRangeService.AgeRange)` and
+//     `.declinedSharing`.
+//   - `AgeRangeService.AgeRange` exposes `lowerBound: Int?` and
+//     `upperBound: Int?`.
+//   - Failures throw `AgeRangeService.Error`.
+// `AgeGateConfig.requestedGates` is exactly 3 entries ([13, 16, 18]), which
+// matches the API's 3-gate maximum.
+#if canImport(DeclaredAgeRange)
+import DeclaredAgeRange
+import UIKit
+
+/// Real adapter over Apple's Declared Age Range API. Maps the response to
+/// AgeRangeResult; any decline/error/indeterminate → .unknown (fail open).
+@available(iOS 26, *)
+struct DeclaredAgeRangeProvider: AgeRangeProviding {
+    func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult {
+        guard let anchor = await Self.presentationAnchor() else {
+            Log.app.error("age range request failed: no presentation anchor available")
+            return .unknown
+        }
+        guard let first = gates.first else { return .unknown }
+        let second = gates.count > 1 ? gates[1] : nil
+        let third = gates.count > 2 ? gates[2] : nil
+        do {
+            let response = try await AgeRangeService.shared.requestAgeRange(
+                ageGates: first, second, third, in: anchor
+            )
+            switch response {
+            case .sharing(let range):
+                return AgeRangeResult(lowerBound: range.lowerBound,
+                                      upperBound: range.upperBound)
+            case .declinedSharing:
+                return .unknown
+            @unknown default:
+                return .unknown
+            }
+        } catch {
+            Log.app.error("age range request failed: \(String(describing: error), privacy: .public)")
+            return .unknown
+        }
+    }
+
+    /// The system sheet needs a presentation anchor; there is no existing
+    /// convention in this codebase for finding one, so we look up the key
+    /// window's root view controller directly.
+    @MainActor
+    private static func presentationAnchor() -> UIViewController? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }?.rootViewController
+    }
+}
+#endif
+
+extension AgeGate {
+    /// Picks the real provider on iOS 26+, no-op otherwise (including when
+    /// building against an SDK that predates iOS 26 and doesn't ship the
+    /// `DeclaredAgeRange` module at all).
+    static func makeDefault() -> AgeGate {
+        #if canImport(DeclaredAgeRange)
+        if #available(iOS 26, *) {
+            return AgeGate(provider: DeclaredAgeRangeProvider())
+        }
+        #endif
+        return AgeGate(provider: NoopAgeRangeProvider())
+    }
+}

--- a/hackertracker/Utils/AgeGate.swift
+++ b/hackertracker/Utils/AgeGate.swift
@@ -53,6 +53,16 @@ final class AgeGate {
     private static let upperKey = "ageGate.upperBound.v1"
 
     func refresh(forcePrompt: Bool = false) async {
+        #if DEBUG
+        // Debug harness: when a simulated band is active, honor it instead
+        // of querying the provider, so the override survives the up-front
+        // launch refresh (and relaunches) during testing.
+        if UserDefaults.standard.bool(forKey: Self.debugOverrideKey) {
+            lowerBound = UserDefaults.standard.object(forKey: Self.debugLowerKey) as? Int
+            upperBound = UserDefaults.standard.object(forKey: Self.debugUpperKey) as? Int
+            return
+        }
+        #endif
         let result = await provider.requestRange(gates: AgeGateConfig.requestedGates,
                                                   forcePrompt: forcePrompt)
         lowerBound = result.lowerBound
@@ -70,6 +80,42 @@ final class AgeGate {
         guard let upper = upperBound else { return true }  // no signal → fail open
         return upper >= minAge
     }
+
+    #if DEBUG
+    // MARK: - Debug band override (test harness, DEBUG builds only)
+    //
+    // Lets a tester force the effective declared-age band from Settings so
+    // gated content can be reviewed without the real iOS 26 flow. The band
+    // is persisted and re-applied by refresh(), so it sticks across the
+    // launch query and relaunches until cleared.
+    private static let debugOverrideKey = "ageGate.debug.override.v1"
+    private static let debugLowerKey = "ageGate.debug.lower.v1"
+    private static let debugUpperKey = "ageGate.debug.upper.v1"
+
+    var debugOverrideActive: Bool { UserDefaults.standard.bool(forKey: Self.debugOverrideKey) }
+
+    /// Force the effective band. Caller should re-run the filter afterward
+    /// (see InfoViewModel.debugSetAgeBracket).
+    func debugSetBracket(lower: Int?, upper: Int?) {
+        lowerBound = lower
+        upperBound = upper
+        let d = UserDefaults.standard
+        d.set(true, forKey: Self.debugOverrideKey)
+        d.set(lower, forKey: Self.debugLowerKey)
+        d.set(upper, forKey: Self.debugUpperKey)
+        // Mirror into the normal cache so first-frame filtering matches.
+        d.set(lower, forKey: Self.lowerKey)
+        d.set(upper, forKey: Self.upperKey)
+    }
+
+    /// Turn the override off and return to the real/device-driven flow.
+    func debugClearOverride() {
+        let d = UserDefaults.standard
+        d.removeObject(forKey: Self.debugOverrideKey)
+        d.removeObject(forKey: Self.debugLowerKey)
+        d.removeObject(forKey: Self.debugUpperKey)
+    }
+    #endif
 }
 
 // MARK: - iOS 26 Declared Age Range adapter

--- a/hackertracker/Utils/AgeGate.swift
+++ b/hackertracker/Utils/AgeGate.swift
@@ -17,6 +17,21 @@ enum AgeGateConfig {
     static let requestedGates: [Int] = [13, 16, 18]
 }
 
+/// Whether the age-band debug override (the Settings test harness) is
+/// reachable in this build. True in DEBUG and in TestFlight (the app
+/// carries a `sandboxReceipt`), but FALSE in App Store production — so
+/// real users can never simulate or bypass their declared age band.
+/// The override is additionally hidden behind a 7-tap chord in Settings.
+enum AgeDebugAccess {
+    static var isAvailable: Bool {
+        #if DEBUG
+        return true
+        #else
+        return Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+        #endif
+    }
+}
+
 /// Coarse age bracket. nil bounds = unknown (declined / error / iOS < 26).
 struct AgeRangeResult {
     let lowerBound: Int?
@@ -53,16 +68,17 @@ final class AgeGate {
     private static let upperKey = "ageGate.upperBound.v1"
 
     func refresh(forcePrompt: Bool = false) async {
-        #if DEBUG
-        // Debug harness: when a simulated band is active, honor it instead
-        // of querying the provider, so the override survives the up-front
-        // launch refresh (and relaunches) during testing.
-        if UserDefaults.standard.bool(forKey: Self.debugOverrideKey) {
+        // Debug/TestFlight harness: when a simulated band is active AND this
+        // build allows it, honor it instead of querying the provider, so the
+        // override survives the up-front launch refresh (and relaunches).
+        // Gated by AgeDebugAccess so a stray override key is inert in
+        // App Store production.
+        if AgeDebugAccess.isAvailable,
+           UserDefaults.standard.bool(forKey: Self.debugOverrideKey) {
             lowerBound = UserDefaults.standard.object(forKey: Self.debugLowerKey) as? Int
             upperBound = UserDefaults.standard.object(forKey: Self.debugUpperKey) as? Int
             return
         }
-        #endif
         let result = await provider.requestRange(gates: AgeGateConfig.requestedGates,
                                                   forcePrompt: forcePrompt)
         lowerBound = result.lowerBound
@@ -81,13 +97,13 @@ final class AgeGate {
         return upper >= minAge
     }
 
-    #if DEBUG
-    // MARK: - Debug band override (test harness, DEBUG builds only)
+    // MARK: - Debug band override (test harness)
     //
     // Lets a tester force the effective declared-age band from Settings so
     // gated content can be reviewed without the real iOS 26 flow. The band
     // is persisted and re-applied by refresh(), so it sticks across the
-    // launch query and relaunches until cleared.
+    // launch query and relaunches until cleared. Only reachable when
+    // AgeDebugAccess.isAvailable (DEBUG / TestFlight) — never in App Store.
     private static let debugOverrideKey = "ageGate.debug.override.v1"
     private static let debugLowerKey = "ageGate.debug.lower.v1"
     private static let debugUpperKey = "ageGate.debug.upper.v1"
@@ -115,7 +131,6 @@ final class AgeGate {
         d.removeObject(forKey: Self.debugLowerKey)
         d.removeObject(forKey: Self.debugUpperKey)
     }
-    #endif
 }
 
 // MARK: - iOS 26 Declared Age Range adapter

--- a/hackertracker/Utils/AgeGate.swift
+++ b/hackertracker/Utils/AgeGate.swift
@@ -1,0 +1,73 @@
+//
+//  AgeGate.swift
+//  hackertracker
+//
+//  Age-restriction gate backed by Apple's Declared Age Range API (iOS 26+).
+//  On iOS < 26 there is no provider, so nothing is ever hidden.
+//
+
+import Foundation
+import SwiftUI
+
+enum AgeGateConfig {
+    /// Applied when an item has no explicit visible_age_min.
+    /// nil = no minimum. Change here to flip the default policy app-wide.
+    static let defaultMinAge: Int? = nil
+    /// Age gates requested from the Declared Age Range API.
+    static let requestedGates: [Int] = [13, 16, 18]
+}
+
+/// Coarse age bracket. nil bounds = unknown (declined / error / iOS < 26).
+struct AgeRangeResult {
+    let lowerBound: Int?
+    let upperBound: Int?
+    static let unknown = AgeRangeResult(lowerBound: nil, upperBound: nil)
+}
+
+/// Injectable source of the declared age range. The real iOS-26 adapter is
+/// added in Task 3; tests and iOS < 26 use NoopAgeRangeProvider.
+protocol AgeRangeProviding: Sendable {
+    func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult
+}
+
+struct NoopAgeRangeProvider: AgeRangeProviding {
+    func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult { .unknown }
+}
+
+@Observable
+@MainActor
+final class AgeGate {
+    private(set) var lowerBound: Int?
+    private(set) var upperBound: Int?
+    @ObservationIgnored private let provider: AgeRangeProviding
+
+    init(provider: AgeRangeProviding = NoopAgeRangeProvider()) {
+        self.provider = provider
+        // Restore the cached bracket so filtering applies before refresh().
+        let d = UserDefaults.standard
+        self.lowerBound = d.object(forKey: Self.lowerKey) as? Int
+        self.upperBound = d.object(forKey: Self.upperKey) as? Int
+    }
+
+    private static let lowerKey = "ageGate.lowerBound.v1"
+    private static let upperKey = "ageGate.upperBound.v1"
+
+    func refresh(forcePrompt: Bool = false) async {
+        let result = await provider.requestRange(gates: AgeGateConfig.requestedGates,
+                                                  forcePrompt: forcePrompt)
+        lowerBound = result.lowerBound
+        upperBound = result.upperBound
+        let d = UserDefaults.standard
+        d.set(result.lowerBound, forKey: Self.lowerKey)
+        d.set(result.upperBound, forKey: Self.upperKey)
+    }
+
+    /// Fail-open decision: hide ONLY when the user's maximum possible age is
+    /// below the item's minimum. Everything else is visible.
+    func isVisible(minAge rawMin: Int?) -> Bool {
+        let minAge = rawMin ?? AgeGateConfig.defaultMinAge
+        guard let minAge else { return true }        // no minimum
+        guard let upper = upperBound else { return true }  // no signal → fail open
+        return upper >= minAge
+    }
+}

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -611,7 +611,7 @@ final class InfoViewModel {
                                     continue
                                 }
                                 seenEventIds.insert(s.id)
-                                let e = Event(id: s.id, contentId: c.id, description: c.description, beginTimestamp: s.beginTimestamp, endTimestamp: s.endTimestamp, title: c.title, locationId: s.locationId, people: c.people, tagIds: c.tagIds, relatedIds: c.relatedIds)
+                                let e = Event(id: s.id, contentId: c.id, description: c.description, beginTimestamp: s.beginTimestamp, endTimestamp: s.endTimestamp, title: c.title, locationId: s.locationId, people: c.people, tagIds: c.tagIds, relatedIds: c.relatedIds, visibleAgeMin: c.visibleAgeMin)
                                 rebuiltEvents.append(e)
                                 /* Task {
                                     if await NotificationUtility.notificationExists(id: e.id) {

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -23,6 +23,12 @@ import SwiftUI
 @Observable
 @MainActor
 final class InfoViewModel {
+    let ageGate: AgeGate
+
+    init(ageGate: AgeGate = .makeDefault()) {
+        self.ageGate = ageGate
+    }
+
     var conference: Conference?
     var documents = [Document]() {
         didSet { documentsById = Dictionary(uniqueKeysWithValues: documents.map { ($0.id, $0) }) }
@@ -88,6 +94,27 @@ final class InfoViewModel {
             orgsById = idx
         }
     }
+    @ObservationIgnored private var rawContent: [Content] = []
+    @ObservationIgnored private var rawEvents: [Event] = []
+    @ObservationIgnored private var rawOrgs: [Organization] = []
+
+    /// Re-derive the public (age-filtered) collections from the raw decoded
+    /// arrays. Called after each decode and after the age bracket changes.
+    func applyAgeFilter() {
+        content = rawContent.filter { ageGate.isVisible(minAge: $0.visibleAgeMin) }
+        events  = rawEvents.filter  { ageGate.isVisible(minAge: $0.visibleAgeMin) }
+        orgs    = rawOrgs.filter    { ageGate.isVisible(minAge: $0.visibleAgeMin) }
+    }
+
+    /// Up-front + Settings entry point.
+    func refreshAgeGate(forcePrompt: Bool = false) async {
+        await ageGate.refresh(forcePrompt: forcePrompt)
+        applyAgeFilter()
+    }
+
+    // Test seams (used only by the unit tests).
+    func _setDecodedContentForTesting(_ c: [Content]) { rawContent = c; applyAgeFilter() }
+
     var faqs = [FAQ]()
     var news = [Article]()
     var menus = [InfoMenu]()
@@ -627,8 +654,9 @@ final class InfoViewModel {
                     await MainActor.run {
                         // Discard this result if a newer snapshot's decode already landed.
                         guard let self, generation == self.contentGeneration else { return }
-                        self.content = decodedContent
-                        self.events = rebuiltEvents
+                        self.rawContent = decodedContent
+                        self.rawEvents = rebuiltEvents
+                        self.applyAgeFilter()   // sets self.content / self.events (filtered)
                         NSLog("InfoViewModel: \(self.content.count) content (cache hits \(cache), firestore hits \(firestore))")
                     }
                 }
@@ -712,7 +740,8 @@ final class InfoViewModel {
                 // Finding B: sort the local array before assigning to `orgs`
                 // so there's exactly one didSet/observation invalidation per tick.
                 decodedOrgs.sort(using: KeyPathComparator(\.self.name, comparator: .localizedStandard))
-                self.orgs = decodedOrgs
+                self.rawOrgs = decodedOrgs
+                self.applyAgeFilter()
                 NSLog("InfoViewModel: \(self.orgs.count) organizations (cache hits \(cache), firestore hits \(firestore))")
             }
     }

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -119,6 +119,21 @@ final class InfoViewModel {
     // Test seams (used only by the unit tests).
     func _setDecodedContentForTesting(_ c: [Content]) { rawContent = c; applyAgeFilter() }
 
+    #if DEBUG
+    /// Debug harness: force a simulated age band and immediately re-filter
+    /// every gated list. Wired to the Settings band picker (DEBUG builds).
+    func debugSetAgeBracket(lower: Int?, upper: Int?) {
+        ageGate.debugSetBracket(lower: lower, upper: upper)
+        applyAgeFilter()
+    }
+
+    /// Debug harness: drop the override and re-query the real/device gate.
+    func debugClearAgeOverride() async {
+        ageGate.debugClearOverride()
+        await refreshAgeGate()
+    }
+    #endif
+
     var faqs = [FAQ]()
     var news = [Article]()
     var menus = [InfoMenu]()

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -119,20 +119,19 @@ final class InfoViewModel {
     // Test seams (used only by the unit tests).
     func _setDecodedContentForTesting(_ c: [Content]) { rawContent = c; applyAgeFilter() }
 
-    #if DEBUG
-    /// Debug harness: force a simulated age band and immediately re-filter
-    /// every gated list. Wired to the Settings band picker (DEBUG builds).
+    /// Debug/TestFlight harness: force a simulated age band and immediately
+    /// re-filter every gated list. Wired to the Settings band picker, which
+    /// is gated by AgeDebugAccess (never reachable in App Store production).
     func debugSetAgeBracket(lower: Int?, upper: Int?) {
         ageGate.debugSetBracket(lower: lower, upper: upper)
         applyAgeFilter()
     }
 
-    /// Debug harness: drop the override and re-query the real/device gate.
+    /// Debug/TestFlight harness: drop the override and re-query the real gate.
     func debugClearAgeOverride() async {
         ageGate.debugClearOverride()
         await refreshAgeGate()
     }
-    #endif
 
     var faqs = [FAQ]()
     var news = [Article]()

--- a/hackertracker/ViewModels/InfoViewModel.swift
+++ b/hackertracker/ViewModels/InfoViewModel.swift
@@ -97,6 +97,8 @@ final class InfoViewModel {
     @ObservationIgnored private var rawContent: [Content] = []
     @ObservationIgnored private var rawEvents: [Event] = []
     @ObservationIgnored private var rawOrgs: [Organization] = []
+    @ObservationIgnored private var rawDocuments: [Document] = []
+    @ObservationIgnored private var rawSpeakers: [Speaker] = []
 
     /// Re-derive the public (age-filtered) collections from the raw decoded
     /// arrays. Called after each decode and after the age bracket changes.
@@ -104,6 +106,8 @@ final class InfoViewModel {
         content = rawContent.filter { ageGate.isVisible(minAge: $0.visibleAgeMin) }
         events  = rawEvents.filter  { ageGate.isVisible(minAge: $0.visibleAgeMin) }
         orgs    = rawOrgs.filter    { ageGate.isVisible(minAge: $0.visibleAgeMin) }
+        documents = rawDocuments.filter { ageGate.isVisible(minAge: $0.visibleAgeMin) }
+        speakers  = rawSpeakers.filter  { ageGate.isVisible(minAge: $0.visibleAgeMin) }
     }
 
     /// Up-front + Settings entry point.
@@ -476,7 +480,7 @@ final class InfoViewModel {
                 }
                 var cache = 0
                 var firestore = 0
-                self.documents = docs.compactMap { queryDocumentSnapshot -> Document? in
+                self.rawDocuments = docs.compactMap { queryDocumentSnapshot -> Document? in
                     do {
                         if queryDocumentSnapshot.metadata.isFromCache {
                             cache = cache + 1
@@ -490,6 +494,7 @@ final class InfoViewModel {
                         return nil
                     }
                 }
+                self.applyAgeFilter()
                 NSLog("InfoViewModel: \(self.documents.count) documents (cache hits \(cache), firestore hits \(firestore))")
             }
     }
@@ -703,7 +708,8 @@ final class InfoViewModel {
 
                     await MainActor.run {
                         guard let self, generation == self.speakerGeneration else { return }
-                        self.speakers = decodedSpeakers
+                        self.rawSpeakers = decodedSpeakers
+                        self.applyAgeFilter()
                         NSLog("InfoViewModel: \(self.speakers.count) speakers (cache hits \(cache), firestore hits \(firestore))")
                     }
                 }

--- a/hackertracker/ViewModels/SharedScheduleStore.swift
+++ b/hackertracker/ViewModels/SharedScheduleStore.swift
@@ -55,7 +55,12 @@ final class SharedScheduleStore {
     /// Refresh entries against the given bookmark IDs and the full conference
     /// list (typically `ConferencesViewModel.conferences`). Safe to call
     /// repeatedly; idempotent.
-    func refresh(bookmarkIds: Set<Int>, allConferences: [Conference]) async {
+    ///
+    /// `ageGate` is the same gate `InfoViewModel` uses to filter `content`/
+    /// `events`/`orgs` for the active conference -- passed in here so this
+    /// store's cross-conference fetch respects the same age-restriction
+    /// decision instead of bypassing it.
+    func refresh(bookmarkIds: Set<Int>, allConferences: [Conference], ageGate: AgeGate) async {
         // 1. Find conferences whose date ranges overlap with at least one other.
         let overlapping = Self.overlappingConferences(from: allConferences)
         guard overlapping.count >= 2, !bookmarkIds.isEmpty else {
@@ -86,7 +91,8 @@ final class SharedScheduleStore {
                 group.addTask {
                     let events = await self.fetchBookmarkedEvents(
                         conferenceCode: code,
-                        bookmarkIds: ids
+                        bookmarkIds: ids,
+                        ageGate: ageGate
                     )
                     return (code, events)
                 }
@@ -147,7 +153,8 @@ final class SharedScheduleStore {
     /// collection, returning the Event-flattened subset whose `id` is in
     /// `bookmarkIds`. Mirrors the logic in InfoViewModel.fetchContent.
     private func fetchBookmarkedEvents(conferenceCode: String,
-                                       bookmarkIds: Set<Int>) async -> [Event] {
+                                       bookmarkIds: Set<Int>,
+                                       ageGate: AgeGate) async -> [Event] {
         do {
             let snap = try await db.collection("conferences")
                 .document(conferenceCode)
@@ -157,6 +164,11 @@ final class SharedScheduleStore {
             var seen: Set<Int> = []
             for doc in snap.documents {
                 guard let content = try? doc.data(as: Content.self) else { continue }
+                // Same age-gate decision InfoViewModel applies to its own
+                // `content`/`events` arrays -- skip age-restricted content
+                // the gate says shouldn't be visible, so bookmarks don't
+                // leak it into the combined cross-conference schedule.
+                guard ageGate.isVisible(minAge: content.visibleAgeMin) else { continue }
                 for session in content.sessions where bookmarkIds.contains(session.id) {
                     guard !seen.contains(session.id) else { continue }
                     seen.insert(session.id)
@@ -170,7 +182,8 @@ final class SharedScheduleStore {
                         locationId: session.locationId,
                         people: content.people,
                         tagIds: content.tagIds,
-                        relatedIds: content.relatedIds
+                        relatedIds: content.relatedIds,
+                        visibleAgeMin: content.visibleAgeMin
                     )
                     events.append(event)
                 }

--- a/hackertracker/Views/ContentView.swift
+++ b/hackertracker/Views/ContentView.swift
@@ -136,6 +136,9 @@ struct ContentView: View {
                 viewModel.showNews = showNews
                 viewModel.easterEgg = easterEgg
 
+                // Age gate: query the declared age range up front so
+                // restricted content is filtered before the user browses.
+                await viewModel.refreshAgeGate()
 
                 // viewModel.fetchData(code: selected.code)
             }

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -371,7 +371,8 @@ struct InfoView: View {
                     let ids = Set(bookmarks.map { Int($0.id) })
                     await sharedSchedule.refresh(
                         bookmarkIds: ids,
-                        allConferences: consViewModel.conferences
+                        allConferences: consViewModel.conferences,
+                        ageGate: viewModel.ageGate
                     )
                 }
                 .onAppear {

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -847,7 +847,28 @@ struct AgeVerificationSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
     @State private var verifying = false
 
+    #if DEBUG
+    // Test harness: force a declared-age band from Settings so gated
+    // content can be reviewed on any OS without the real iOS 26 flow.
+    private static let debugOff = "Off (use device)"
+    private static let debugBands: [(label: String, lower: Int?, upper: Int?)] = [
+        ("Unknown (fail-open)", nil, nil),
+        ("Under 13", nil, 12),
+        ("13–15", 13, 15),
+        ("16–17", 16, 17),
+        ("18+", 18, nil)
+    ]
+    @State private var debugBand: String = AgeVerificationSettingsView.debugOff
+    #endif
+
     private var statusText: String {
+        #if DEBUG
+        if viewModel.ageGate.debugOverrideActive {
+            let lo = viewModel.ageGate.lowerBound.map(String.init) ?? "nil"
+            let up = viewModel.ageGate.upperBound.map(String.init) ?? "nil"
+            return "DEBUG band active — lower: \(lo), upper: \(up)"
+        }
+        #endif
         if #available(iOS 26, *) {
             if let lower = viewModel.ageGate.lowerBound {
                 return "Verified: \(lower)+"
@@ -879,8 +900,42 @@ struct AgeVerificationSettingsView: View {
                     .font(themeManager.captionFont)
                     .foregroundStyle(.secondary)
             }
+            #if DEBUG
+            Divider().padding(.vertical, 4)
+            Text("DEBUG · Simulate age band")
+                .font(themeManager.captionFont)
+                .foregroundStyle(.secondary)
+            Picker("Age band", selection: $debugBand) {
+                Text(Self.debugOff).tag(Self.debugOff)
+                ForEach(Self.debugBands, id: \.label) { band in
+                    Text(band.label).tag(band.label)
+                }
+            }
+            .pickerStyle(.menu)
+            .onChange(of: debugBand) { _, label in
+                if label == Self.debugOff {
+                    Task { await viewModel.debugClearAgeOverride() }
+                } else if let band = Self.debugBands.first(where: { $0.label == label }) {
+                    viewModel.debugSetAgeBracket(lower: band.lower, upper: band.upper)
+                }
+            }
+            Text("Overrides the declared age range so you can review gated content on any OS. Lists re-filter immediately; the choice persists until set back to “\(Self.debugOff)”.")
+                .font(themeManager.captionFont)
+                .foregroundStyle(.secondary)
+            #endif
         }
         .settingsCard(themeManager)
+        #if DEBUG
+        .onAppear {
+            if viewModel.ageGate.debugOverrideActive {
+                let lo = viewModel.ageGate.lowerBound
+                let up = viewModel.ageGate.upperBound
+                debugBand = Self.debugBands.first { $0.lower == lo && $0.upper == up }?.label ?? Self.debugOff
+            } else {
+                debugBand = Self.debugOff
+            }
+        }
+        #endif
     }
 }
 

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -117,6 +117,7 @@ struct SettingsView: View {
                             VStack(spacing: 0) { StartScreenPickerView() }
                             VStack(spacing: 0) { NotificationSettingsView() }
                             VStack(spacing: 0) { AISummarySettingsView() }
+                            VStack(spacing: 0) { AgeVerificationSettingsView() }
                             VStack(spacing: 0) { ShowCustomEventsSettingsView() }
                             VStack(spacing: 0) { EasterEggSettingsView() }
                             Spacer(minLength: 0)
@@ -132,6 +133,7 @@ struct SettingsView: View {
                     ShowNewsSettingsView()
                     NotificationSettingsView()
                     AISummarySettingsView()
+                    AgeVerificationSettingsView()
                     ShowCustomEventsSettingsView()
                     EasterEggSettingsView()
                 }
@@ -834,6 +836,51 @@ struct AISummarySettingsView: View {
                 if speakerAISummaries { showSpeakerToggle = true }
             }
         }
+    }
+}
+
+/// Settings row showing Declared Age Range verification status, with a
+/// re-verify button on iOS 26+. On older iOS the row explains the
+/// feature is unavailable rather than showing a dead button.
+struct AgeVerificationSettingsView: View {
+    @Environment(InfoViewModel.self) private var viewModel
+    @Environment(ThemeManager.self) private var themeManager
+    @State private var verifying = false
+
+    private var statusText: String {
+        if #available(iOS 26, *) {
+            if let lower = viewModel.ageGate.lowerBound {
+                return "Verified: \(lower)+"
+            }
+            return "Not verified"
+        }
+        return "Unavailable on this iOS"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Age Verification")
+                .font(themeManager.headingFont)
+            Text(statusText)
+                .font(themeManager.captionFont)
+                .foregroundStyle(.secondary)
+            if #available(iOS 26, *) {
+                Button {
+                    verifying = true
+                    Task {
+                        await viewModel.refreshAgeGate(forcePrompt: true)
+                        verifying = false
+                    }
+                } label: {
+                    Text(verifying ? "Verifying…" : "Verify Age")
+                }
+                .disabled(verifying)
+                Text("Age-restricted content is shown based on your device's declared age range.")
+                    .font(themeManager.captionFont)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .settingsCard(themeManager)
     }
 }
 

--- a/hackertracker/Views/SettingsView.swift
+++ b/hackertracker/Views/SettingsView.swift
@@ -847,9 +847,11 @@ struct AgeVerificationSettingsView: View {
     @Environment(ThemeManager.self) private var themeManager
     @State private var verifying = false
 
-    #if DEBUG
     // Test harness: force a declared-age band from Settings so gated
     // content can be reviewed on any OS without the real iOS 26 flow.
+    // Compiled into all builds but only reachable when
+    // AgeDebugAccess.isAvailable (DEBUG / TestFlight) AND revealed by a
+    // 7-tap chord on the heading — never in App Store production.
     private static let debugOff = "Off (use device)"
     private static let debugBands: [(label: String, lower: Int?, upper: Int?)] = [
         ("Unknown (fail-open)", nil, nil),
@@ -859,16 +861,24 @@ struct AgeVerificationSettingsView: View {
         ("18+", 18, nil)
     ]
     @State private var debugBand: String = AgeVerificationSettingsView.debugOff
-    #endif
+    /// 7-tap chord counter on the heading. Transient — resets on rebuild.
+    @State private var debugTapCount = 0
+    /// Set true once the chord is entered this session (or if an override
+    /// is already active, so it can be turned off without re-chording).
+    @State private var debugRevealed = false
+
+    /// The band picker is shown only in DEBUG/TestFlight builds, and only
+    /// after the chord is entered (or an override is already in effect).
+    private var showDebugBandPicker: Bool {
+        AgeDebugAccess.isAvailable && (debugRevealed || viewModel.ageGate.debugOverrideActive)
+    }
 
     private var statusText: String {
-        #if DEBUG
-        if viewModel.ageGate.debugOverrideActive {
+        if AgeDebugAccess.isAvailable, viewModel.ageGate.debugOverrideActive {
             let lo = viewModel.ageGate.lowerBound.map(String.init) ?? "nil"
             let up = viewModel.ageGate.upperBound.map(String.init) ?? "nil"
             return "DEBUG band active — lower: \(lo), upper: \(up)"
         }
-        #endif
         if #available(iOS 26, *) {
             if let lower = viewModel.ageGate.lowerBound {
                 return "Verified: \(lower)+"
@@ -882,6 +892,17 @@ struct AgeVerificationSettingsView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Age Verification")
                 .font(themeManager.headingFont)
+                // 7-tap chord reveals the debug band picker (only takes
+                // effect in DEBUG / TestFlight builds).
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    guard AgeDebugAccess.isAvailable else { return }
+                    debugTapCount += 1
+                    if debugTapCount >= 7 {
+                        debugRevealed = true
+                        debugTapCount = 0
+                    }
+                }
             Text(statusText)
                 .font(themeManager.captionFont)
                 .foregroundStyle(.secondary)
@@ -900,34 +921,35 @@ struct AgeVerificationSettingsView: View {
                     .font(themeManager.captionFont)
                     .foregroundStyle(.secondary)
             }
-            #if DEBUG
-            Divider().padding(.vertical, 4)
-            Text("DEBUG · Simulate age band")
-                .font(themeManager.captionFont)
-                .foregroundStyle(.secondary)
-            Picker("Age band", selection: $debugBand) {
-                Text(Self.debugOff).tag(Self.debugOff)
-                ForEach(Self.debugBands, id: \.label) { band in
-                    Text(band.label).tag(band.label)
+            if showDebugBandPicker {
+                Divider().padding(.vertical, 4)
+                Text("DEBUG · Simulate age band")
+                    .font(themeManager.captionFont)
+                    .foregroundStyle(.secondary)
+                Picker("Age band", selection: $debugBand) {
+                    Text(Self.debugOff).tag(Self.debugOff)
+                    ForEach(Self.debugBands, id: \.label) { band in
+                        Text(band.label).tag(band.label)
+                    }
                 }
-            }
-            .pickerStyle(.menu)
-            .onChange(of: debugBand) { _, label in
-                if label == Self.debugOff {
-                    Task { await viewModel.debugClearAgeOverride() }
-                } else if let band = Self.debugBands.first(where: { $0.label == label }) {
-                    viewModel.debugSetAgeBracket(lower: band.lower, upper: band.upper)
+                .pickerStyle(.menu)
+                .onChange(of: debugBand) { _, label in
+                    if label == Self.debugOff {
+                        Task { await viewModel.debugClearAgeOverride() }
+                    } else if let band = Self.debugBands.first(where: { $0.label == label }) {
+                        viewModel.debugSetAgeBracket(lower: band.lower, upper: band.upper)
+                    }
                 }
+                Text("Overrides the declared age range so you can review gated content on any OS. Lists re-filter immediately; the choice persists until set back to “\(Self.debugOff)”.")
+                    .font(themeManager.captionFont)
+                    .foregroundStyle(.secondary)
             }
-            Text("Overrides the declared age range so you can review gated content on any OS. Lists re-filter immediately; the choice persists until set back to “\(Self.debugOff)”.")
-                .font(themeManager.captionFont)
-                .foregroundStyle(.secondary)
-            #endif
         }
         .settingsCard(themeManager)
-        #if DEBUG
         .onAppear {
+            guard AgeDebugAccess.isAvailable else { return }
             if viewModel.ageGate.debugOverrideActive {
+                debugRevealed = true
                 let lo = viewModel.ageGate.lowerBound
                 let up = viewModel.ageGate.upperBound
                 debugBand = Self.debugBands.first { $0.lower == lo && $0.upper == up }?.label ?? Self.debugOff
@@ -935,7 +957,6 @@ struct AgeVerificationSettingsView: View {
                 debugBand = Self.debugOff
             }
         }
-        #endif
     }
 }
 

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -51,6 +51,29 @@ class hackertrackerTests: XCTestCase {
         let content = try JSONDecoder().decode(Content.self, from: json)
         XCTAssertNil(content.visibleAgeMin)
     }
+
+    func testDocumentDecodesVisibleAgeMin() throws {
+        let json = """
+        {"id": 1, "title_text": "t", "body_text": "b", "visible_age_min": 18}
+        """.data(using: .utf8)!
+        let doc = try JSONDecoder().decode(Document.self, from: json)
+        XCTAssertEqual(doc.visibleAgeMin, 18)
+    }
+
+    func testDocumentDefaultsVisibleAgeMinNilWhenAbsent() throws {
+        let json = #"{"id": 2, "title_text": "t", "body_text": "b"}"#.data(using: .utf8)!
+        let doc = try JSONDecoder().decode(Document.self, from: json)
+        XCTAssertNil(doc.visibleAgeMin)
+    }
+
+    func testSpeakerDecodesVisibleAgeMin() throws {
+        let json = """
+        {"id": 1, "conference": "c", "description": "d", "link": "", "links": [],
+         "name": "n", "twitter": "", "event_ids": [], "visible_age_min": 16}
+        """.data(using: .utf8)!
+        let speaker = try JSONDecoder().decode(Speaker.self, from: json)
+        XCTAssertEqual(speaker.visibleAgeMin, 16)
+    }
 }
 
 @MainActor

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -51,3 +51,44 @@ class hackertrackerTests: XCTestCase {
         XCTAssertNil(content.visibleAgeMin)
     }
 }
+
+@MainActor
+final class AgeGateTests: XCTestCase {
+    /// Feeds a fixed range so the decision logic can be tested without the OS.
+    struct FakeProvider: AgeRangeProviding {
+        let result: AgeRangeResult
+        func requestRange(gates: [Int], forcePrompt: Bool) async -> AgeRangeResult { result }
+    }
+
+    private func gate(lower: Int?, upper: Int?) async -> AgeGate {
+        let g = AgeGate(provider: FakeProvider(result: .init(lowerBound: lower, upperBound: upper)))
+        await g.refresh(forcePrompt: false)
+        return g
+    }
+
+    func testNilMinIsAlwaysVisible() async {
+        let g = await gate(lower: 13, upper: 15)   // confirmed under 18
+        XCTAssertTrue(g.isVisible(minAge: nil))     // no minimum → visible
+    }
+
+    func testConfirmedUnderIsHidden() async {
+        let g = await gate(lower: 13, upper: 15)
+        XCTAssertFalse(g.isVisible(minAge: 18))     // max age 15 < 18 → hidden
+    }
+
+    func testAtOrAboveMinIsVisible() async {
+        let g = await gate(lower: 18, upper: nil)   // 18+
+        XCTAssertTrue(g.isVisible(minAge: 18))
+    }
+
+    func testStraddleFailsOpen() async {
+        let g = await gate(lower: 16, upper: 17)
+        XCTAssertTrue(g.isVisible(minAge: 16))      // 17 >= 16 → visible
+        XCTAssertFalse(g.isVisible(minAge: 18))     // 17 < 18 → hidden
+    }
+
+    func testUnknownRangeFailsOpen() async {
+        let g = await gate(lower: nil, upper: nil)  // declined/error/pre-26
+        XCTAssertTrue(g.isVisible(minAge: 18))      // no signal → visible
+    }
+}

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -76,9 +76,14 @@ final class AgeGateTests: XCTestCase {
         XCTAssertFalse(g.isVisible(minAge: 18))     // max age 15 < 18 → hidden
     }
 
-    func testAtOrAboveMinIsVisible() async {
-        let g = await gate(lower: 18, upper: nil)   // 18+
-        XCTAssertTrue(g.isVisible(minAge: 18))
+    func testEqualBoundaryIsVisible() async {
+        let g = await gate(lower: 16, upper: 16)   // upperBound == minAge
+        XCTAssertTrue(g.isVisible(minAge: 16))     // 16 >= 16 → visible
+    }
+
+    func testAboveMinWithKnownUpperIsVisible() async {
+        let g = await gate(lower: 16, upper: 17)
+        XCTAssertTrue(g.isVisible(minAge: 13))     // 17 >= 13 → visible (known upper)
     }
 
     func testStraddleFailsOpen() async {

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -31,4 +31,31 @@ class hackertrackerTests: XCTestCase {
             // Put the code you want to measure the time of here.
         }
     }
+
+    func testContentDecodesVisibleAgeMin() throws {
+        let json = """
+        {"id": 1, "description": "d", "links": [], "media": [], "people": [],
+         "sessions": [], "tag_ids": [], "title": "t", "visible_age_min": 18}
+        """.data(using: .utf8)!
+        let content = try JSONDecoder().decode(Content.self, from: json)
+        XCTAssertEqual(content.visibleAgeMin, 18)
+    }
+
+    func testContentDefaultsVisibleAgeMinToNilWhenAbsent() throws {
+        let json = """
+        {"id": 2, "description": "d", "links": [], "media": [], "people": [],
+         "sessions": [], "tag_ids": [], "title": "t"}
+        """.data(using: .utf8)!
+        let content = try JSONDecoder().decode(Content.self, from: json)
+        XCTAssertNil(content.visibleAgeMin)
+    }
+
+    func testOrganizationDecodesVisibleAgeMin() throws {
+        let json = """
+        {"name": "n", "description": "d", "links": [], "media": [],
+         "tag_ids": [], "visible_age_min": 21}
+        """.data(using: .utf8)!
+        let org = try JSONDecoder().decode(Organization.self, from: json)
+        XCTAssertEqual(org.visibleAgeMin, 21)
+    }
 }

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -32,6 +32,7 @@ class hackertrackerTests: XCTestCase {
         }
     }
 
+    // Organization is not decode-tested here: its @DocumentID id cannot be decoded by a plain JSONDecoder. The visible_age_min CodingKey wiring is identical to Content's, which IS covered above.
     func testContentDecodesVisibleAgeMin() throws {
         let json = """
         {"id": 1, "description": "d", "links": [], "media": [], "people": [],
@@ -48,14 +49,5 @@ class hackertrackerTests: XCTestCase {
         """.data(using: .utf8)!
         let content = try JSONDecoder().decode(Content.self, from: json)
         XCTAssertNil(content.visibleAgeMin)
-    }
-
-    func testOrganizationDecodesVisibleAgeMin() throws {
-        let json = """
-        {"name": "n", "description": "d", "links": [], "media": [],
-         "tag_ids": [], "visible_age_min": 21}
-        """.data(using: .utf8)!
-        let org = try JSONDecoder().decode(Organization.self, from: json)
-        XCTAssertEqual(org.visibleAgeMin, 21)
     }
 }

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -6,6 +6,7 @@
 //
 
 @testable import hackertracker
+import FirebaseCore
 import XCTest
 
 class hackertrackerTests: XCTestCase {
@@ -95,5 +96,40 @@ final class AgeGateTests: XCTestCase {
     func testUnknownRangeFailsOpen() async {
         let g = await gate(lower: nil, upper: nil)  // declined/error/pre-26
         XCTAssertTrue(g.isVisible(minAge: 18))      // no signal → visible
+    }
+}
+
+@MainActor
+final class InfoViewModelAgeFilterTests: XCTestCase {
+    override func setUpWithError() throws {
+        // InfoViewModel's init reaches for Firestore.firestore(), which
+        // crashes if FirebaseApp.configure() hasn't run in this test host.
+        // Guard so repeated test runs / other suites configuring it don't
+        // trigger "already configured" assertions.
+        if FirebaseApp.app() == nil {
+            FirebaseApp.configure()
+        }
+    }
+
+    func testInfoViewModelHidesUnderageContent() async {
+        let vm = InfoViewModel(
+            ageGate: AgeGate(provider: AgeGateTests.FakeProvider(
+                result: .init(lowerBound: 13, upperBound: 15)))   // confirmed under 18
+        )
+        await vm.ageGate.refresh()
+        vm._setDecodedContentForTesting([
+            Content.stub(id: 1, visibleAgeMin: nil),
+            Content.stub(id: 2, visibleAgeMin: 18)
+        ])
+        XCTAssertEqual(vm.content.map(\.id), [1])   // id 2 (18+) hidden from a 13–15 user
+    }
+}
+
+extension Content {
+    static func stub(id: Int, visibleAgeMin: Int?) -> Content {
+        Content(id: id, conferenceName: nil, description: "", links: [], logo: nil,
+                media: [], people: [], sessions: [], tagIds: [], relatedIds: nil,
+                title: "stub", feedbackDisableTimestamp: nil, feedbackEnableTimestamp: nil,
+                feedbackFormId: nil, visibleAgeMin: visibleAgeMin)
     }
 }


### PR DESCRIPTION
Gates age-restricted Content and Organizations behind an optional `visible_age_min`, using Apple's **Declared Age Range API** on iOS 26+. Built spec-first (brainstorm → spec → plan → subagent-driven execution with per-task + final review). Spec: `docs/superpowers/specs/2026-07-17-age-verification-design.md`; plan: `docs/superpowers/plans/2026-07-17-age-verification.md`.

## What it does
- **Data:** optional `visible_age_min` on Content + Organization (decodes absent → nil, backward-compatible); propagated onto synthesized `Event`s.
- **AgeGate service** (`Utils/AgeGate.swift`): requests Apple bracket gates `[13,16,18]`, caches a coarse bracket (two ints in UserDefaults — never a birthdate), exposes fail-open `isVisible(minAge:)`. iOS 26 `DeclaredAgeRange` adapter behind an injectable protocol + `#if canImport`; **no-op on iOS 17–25** (deployment target unchanged at 17.0).
- **Fail-open:** an item is hidden ONLY when Apple confirms the user is under its minimum (`upperBound < minAge`); decline / error / indeterminate / in-flight / iOS <26 all show.
- **Enforcement:** centralized in `InfoViewModel` (raw arrays private; filtered `content`/`events`/`orgs` + `*ById` maps) so Schedule, All Content, Orgs, Global Search, and detail-by-id are covered at one chokepoint; the cross-conference bookmark schedule (`SharedScheduleStore`) is gated too.
- **Trigger:** queried up front on launch; **Settings → Age Verification** shows status and re-runs it.
- **Default:** absent `visible_age_min` → `AgeGateConfig.defaultMinAge` (nil today; single changeable constant).

## Quality
- TDD on the core: `AgeGate.isVisible` matrix (6 tests) + Content decode + InfoViewModel filtering. Full suite green (unit + UI).
- Per-task reviews caught a **Critical** production regression (removing `case id` made `Organization.id` always-nil — traced through the Firebase SDK) and an Important test-hygiene gap; the final whole-branch review caught the `SharedScheduleStore` bypass (now fixed).

## ⚠️ Before merge — needs your verification
- **iOS 26 runtime QA (only thing a build can't cover):** on a real iOS 26 device/sim, confirm the system age sheet appears, brackets resolve, and gated content hides for an under-age declared range / shows on decline. The adapter compiled against SDK 26.5, but its live behavior + exact API surface should be eyeballed once.
- Accepted Minors (non-blocking): presentation anchor is the root VC (fail-open if busy); no precondition tying `requestedGates` to 3 entries; a slightly stale `AgeGate` doc-comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)