### PR TITLE
Per-section Any/All filters + Report-an-issue feedback

### DIFF
--- a/docs/superpowers/plans/2026-07-20-per-section-filters.md
+++ b/docs/superpowers/plans/2026-07-20-per-section-filters.md
@@ -1,0 +1,297 @@
+# Per-Section Any/All Filters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each tagtype section in the Schedule + All Content filter its own Any/All mode, combined with AND across sections.
+
+**Architecture:** A `SectionFilterModes` value (persisted as JSON `[tagTypeId: mode]` in AppStorage) drives a unified `filters()` predicate on `[Event]` and `[Content]`; the shared `EventFilters` sheet renders a per-section Any/All control shown only when a section has ≥2 chips selected.
+
+**Tech Stack:** Swift 6, SwiftUI, `@Observable`/`@AppStorage`, XCTest.
+
+## Global Constraints
+
+- Deployment target stays iOS 17.0.
+- Cross-section combination is **AND**; per-section is Any/All. Pseudo-toggles (Bookmarks/Custom/Has Notes) are each their own AND constraint (no Any/All).
+- Per-section control appears only when that section has **≥2** chips selected. Default mode `.any`.
+- Scope: Schedule (`EventsView`) + All Content (`ContentListView`) via the shared `EventFilters` sheet. Speakers/Merch (`filterMatchModeSpeakers`/`filterMatchModeMerch`) are **unchanged**.
+- New source files need manual `project.pbxproj` wiring (not a synchronized group). Tests append to `hackertrackerTests/hackertrackerTests.swift`.
+- Build: `xcodebuild -project hackertracker.xcodeproj -scheme hackertracker -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' build`; Test: same with `test`.
+
+---
+
+### Task 1: `SectionFilterModes` store
+
+**Files:**
+- Create: `hackertracker/Utils/SectionFilterModes.swift`
+- Modify: `hackertracker/Utils/AppStorageKeys.swift` (add `sectionFilterModes` key)
+- Modify: `hackertracker.xcodeproj/project.pbxproj` (wire the new file)
+- Test: `hackertrackerTests/hackertrackerTests.swift`
+
+**Interfaces:**
+- Produces: `struct SectionFilterModes` with `init(json: String)`, `var jsonString: String`, `func mode(for tagTypeId: Int) -> FilterMatchMode` (default `.any`), `mutating func setMode(_:for:)`.
+- Consumes: existing `FilterMatchMode` (`Utils/ModelExt.swift`).
+
+- [ ] **Step 1: Failing tests** — append:
+
+```swift
+func testSectionModesDefaultsToAny() {
+    let m = SectionFilterModes(json: "")
+    XCTAssertEqual(m.mode(for: 5), .any)
+}
+func testSectionModesRoundTripsJSON() {
+    var m = SectionFilterModes(json: "")
+    m.setMode(.all, for: 5)
+    let restored = SectionFilterModes(json: m.jsonString)
+    XCTAssertEqual(restored.mode(for: 5), .all)
+    XCTAssertEqual(restored.mode(for: 6), .any)
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`cannot find 'SectionFilterModes'`).
+
+- [ ] **Step 3: Implement** — `hackertracker/Utils/SectionFilterModes.swift`:
+
+```swift
+import Foundation
+
+/// Per-tagtype-section Any/All modes for the Schedule + All Content filter.
+/// Persisted as a JSON object [tagTypeId(String): "any"|"all"] in a single
+/// AppStorage string. Sections with no stored entry default to `.any`.
+struct SectionFilterModes: Equatable {
+    private var modes: [Int: FilterMatchMode]
+
+    init(json: String) {
+        guard let data = json.data(using: .utf8),
+              let raw = try? JSONDecoder().decode([String: String].self, from: data) else {
+            modes = [:]; return
+        }
+        modes = raw.reduce(into: [:]) { acc, kv in
+            if let id = Int(kv.key), let mode = FilterMatchMode(rawValue: kv.value) {
+                acc[id] = mode
+            }
+        }
+    }
+
+    var jsonString: String {
+        let raw = modes.reduce(into: [String: String]()) { $0[String($1.key)] = $1.value.rawValue }
+        guard let data = try? JSONEncoder().encode(raw),
+              let s = String(data: data, encoding: .utf8) else { return "" }
+        return s
+    }
+
+    func mode(for tagTypeId: Int) -> FilterMatchMode { modes[tagTypeId] ?? .any }
+    mutating func setMode(_ mode: FilterMatchMode, for tagTypeId: Int) { modes[tagTypeId] = mode }
+
+    /// Convenience: the raw dictionary, for passing into the predicate.
+    var asDictionary: [Int: FilterMatchMode] { modes }
+}
+```
+
+- [ ] **Step 4: Add the AppStorage key** — in `AppStorageKeys.swift` add:
+
+```swift
+    static let sectionFilterModes = "sectionFilterModes.v1"
+```
+
+- [ ] **Step 5: Wire the file into project.pbxproj** — mirror an existing `Utils` file (e.g. `AgeGate.swift`): add a PBXBuildFile, a PBXFileReference, a Utils-group child entry, and a Sources build-phase entry, using two fresh 24-hex-char UUIDs (`openssl rand -hex 12 | tr a-z A-Z`). Verify: `plutil -lint hackertracker.xcodeproj/project.pbxproj` → OK.
+
+- [ ] **Step 6: Run tests — expect PASS.**
+
+- [ ] **Step 7: Commit** `git commit -m "Filters: SectionFilterModes store + AppStorage key"`
+
+---
+
+### Task 2: Unified per-section predicate (`ModelExt.swift`)
+
+**Files:**
+- Modify: `hackertracker/Utils/ModelExt.swift` (both `[Event]` and `[Content]` `filters(...)`)
+- Test: `hackertrackerTests/hackertrackerTests.swift`
+
+**Interfaces:**
+- Consumes: `SectionFilterModes.asDictionary` (`[Int: FilterMatchMode]`), `FilterMatchMode`, `PseudoTagID`.
+- Produces: `[Event].filters(typeIds:bookmarks:tagTypes:eventNoteIDs:contentNoteIDs:sectionModes:)` and `[Content].filters(typeIds:bookmarks:tagTypes:contentNoteIDs:sectionModes:)`, where `sectionModes: [Int: FilterMatchMode]`. A shared free function `ageAgnosticSectionMatch(tagIds:selectedByType:sectionModes:) -> Bool`.
+
+- [ ] **Step 1: Failing tests** — append (using real `TagType`/`Tag` construction; check `Models/Tag.swift` for the initializer and adapt):
+
+```swift
+func testSectionAnyMatchesEitherTag() {
+    // Section 100 has tags 1,2 selected in .any mode.
+    let match = sectionFilterMatch(tagIds: [2, 9],
+                                   selectedByType: [100: [1, 2]],
+                                   sectionModes: [100: .any])
+    XCTAssertTrue(match)   // has tag 2 → any passes
+}
+func testSectionAllRequiresBothTags() {
+    XCTAssertFalse(sectionFilterMatch(tagIds: [1], selectedByType: [100: [1, 2]], sectionModes: [100: .all]))
+    XCTAssertTrue(sectionFilterMatch(tagIds: [1, 2], selectedByType: [100: [1, 2]], sectionModes: [100: .all]))
+}
+func testTwoSectionsAreANDed() {
+    // Type 100 {1} any, Organizer 200 {5} any → needs a 100-tag AND a 200-tag.
+    let sel = [100: [1], 200: [5]]
+    XCTAssertFalse(sectionFilterMatch(tagIds: [1], selectedByType: sel, sectionModes: [:]))       // missing 200
+    XCTAssertTrue(sectionFilterMatch(tagIds: [1, 5], selectedByType: sel, sectionModes: [:]))       // both → default .any each
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`cannot find 'sectionFilterMatch'`).
+
+- [ ] **Step 3: Implement the shared matcher** — add to `ModelExt.swift` (top-level, file-private-free function so both overloads and the tests can call it; if tests need access use `internal`):
+
+```swift
+/// Core per-section filter decision. `selectedByType` maps tagTypeId ->
+/// selected real tag ids in that section. For each active section, `.any`
+/// requires the item to carry at least one of the section's tags; `.all`
+/// requires all of them. Active sections are combined with AND. No sections
+/// → true (caller handles the empty-selection short-circuit).
+func sectionFilterMatch(tagIds: [Int],
+                        selectedByType: [Int: [Int]],
+                        sectionModes: [Int: FilterMatchMode]) -> Bool {
+    let itemTags = Set(tagIds)
+    for (typeId, selected) in selectedByType {
+        let mode = sectionModes[typeId] ?? .any
+        let ok: Bool
+        switch mode {
+        case .any: ok = selected.contains { itemTags.contains($0) }
+        case .all: ok = selected.allSatisfy { itemTags.contains($0) }
+        }
+        if !ok { return false }   // AND across sections
+    }
+    return true
+}
+```
+
+- [ ] **Step 4: Rewrite `[Event].filters(...)`** — replace its `mode: FilterMatchMode` parameter with `sectionModes: [Int: FilterMatchMode] = [:]`. Build `selectedByType` by grouping the real (non-pseudo) selected tag ids by their tagtype (reuse the existing `filterTypes` grouping loop). The predicate:
+
+```swift
+return filter { event in
+    // Tag sections (AND across sections, per-section any/all).
+    if !selectedByType.isEmpty,
+       !sectionFilterMatch(tagIds: event.tagIds, selectedByType: selectedByType, sectionModes: sectionModes) {
+        return false
+    }
+    // Pseudo constraints — each active one is its own AND.
+    if useBookmarks, !bookmarks.contains(Int32(event.id)) { return false }
+    if useCustom, event.customEventID == nil { return false }
+    if useHasNotes, !(eventNoteIDs.contains(Int32(event.id)) || contentNoteIDs.contains(Int32(event.contentId))) { return false }
+    return true
+}
+```
+Keep the `typeIds.isEmpty → return self` short-circuit. `useBookmarks/useCustom/useHasNotes` are the existing `typeIds.contains(PseudoTagID.x)` checks.
+
+- [ ] **Step 5: Rewrite `[Content].filters(...)`** — give it the same shape: parameters `typeIds:bookmarks:tagTypes:contentNoteIDs:sectionModes:` (Content has no per-event bookmark/custom; keep the existing bookmark pseudo via `bookmarks` set keyed on content id, and Has-Notes via `contentNoteIDs`). Group real tags into `selectedByType`, then:
+
+```swift
+return filter { content in
+    if !selectedByType.isEmpty,
+       !sectionFilterMatch(tagIds: content.tagIds, selectedByType: selectedByType, sectionModes: sectionModes) {
+        return false
+    }
+    if typeIds.contains(PseudoTagID.bookmarks), !bookmarks.contains(Int32(content.id)) { return false }
+    if typeIds.contains(PseudoTagID.hasNotes), !contentNoteIDs.contains(Int32(content.id)) { return false }
+    return true
+}
+```
+Remove the old `isFiltered(...)` helper if no longer referenced (grep first; delete only if unused).
+
+- [ ] **Step 6: Run tests — expect PASS.**
+
+- [ ] **Step 7: Commit** `git commit -m "Filters: unified per-section AND predicate for events + content"`
+
+---
+
+### Task 3: Per-section Any/All control in `EventFilters`
+
+**Files:**
+- Modify: `hackertracker/Views/FiltersView.swift`
+- Test: none (UI); build only.
+
+**Interfaces:**
+- Consumes: `SectionFilterModes`, `AppStorageKeys.sectionFilterModes`, existing `Filters` env object, `MatchModePickerRow` (reuse its segmented styling or a small inline `Picker`).
+
+- [ ] **Step 1: Bind a SectionFilterModes to AppStorage** — replace the `@AppStorage(AppStorageKeys.filterMatchMode) … filterMatchModeRaw` with:
+
+```swift
+    @AppStorage(AppStorageKeys.sectionFilterModes) private var sectionModesRaw: String = ""
+```
+
+Add a helper to read/mutate it:
+
+```swift
+    private func binding(forTagType id: Int) -> Binding<FilterMatchMode> {
+        Binding(
+            get: { SectionFilterModes(json: sectionModesRaw).mode(for: id) },
+            set: { newValue in
+                var m = SectionFilterModes(json: sectionModesRaw)
+                m.setMode(newValue, for: id)
+                sectionModesRaw = m.jsonString
+            }
+        )
+    }
+```
+
+- [ ] **Step 2: Remove the global `MatchModePickerRow(raw: $filterMatchModeRaw)`** line at the top of the ScrollView (keep `FilterMatchCountLabel`).
+
+- [ ] **Step 3: Add the per-section control to each tagtype header** — in the `ForEach(tagtypes...)` section `header:`, show an Any/All segmented control only when ≥2 chips of that tagtype are selected:
+
+```swift
+} header: {
+    HStack {
+        Text(tagtype.label)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        let selectedInSection = tagtype.tags.filter { filters.filters.contains($0.id) }.count
+        if selectedInSection >= 2 {
+            Picker("", selection: binding(forTagType: tagtype.id)) {
+                Text("Any").tag(FilterMatchMode.any)
+                Text("All").tag(FilterMatchMode.all)
+            }
+            .pickerStyle(.segmented)
+            .fixedSize()
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build — expect BUILD SUCCEEDED.**
+
+- [ ] **Step 5: Commit** `git commit -m "Filters: per-section Any/All control in the filter sheet"`
+
+---
+
+### Task 4: Wire consumers (`EventsView`, `ContentListView`)
+
+**Files:**
+- Modify: `hackertracker/Views/EventsView.swift`
+- Modify: `hackertracker/Views/ContentListView.swift`
+- Test: none; build only.
+
+**Interfaces:**
+- Consumes: `SectionFilterModes`, `AppStorageKeys.sectionFilterModes`, the Task-2 `filters(... sectionModes:)`.
+
+- [ ] **Step 1: EventsView** — replace `@AppStorage(...filterMatchMode) filterMatchModeRaw` + the `filterMatchMode` computed var with:
+
+```swift
+    @AppStorage(AppStorageKeys.sectionFilterModes) private var sectionModesRaw: String = ""
+    private var sectionModes: [Int: FilterMatchMode] { SectionFilterModes(json: sectionModesRaw).asDictionary }
+```
+
+Update every `.filters(... mode: filterMatchMode)` call to `.filters(... sectionModes: sectionModes)`. In `schedulePipelineKey`, replace `hasher.combine(filterMatchModeRaw)` with `hasher.combine(sectionModesRaw)`.
+
+- [ ] **Step 2: ContentListView** — same replacement: `sectionModesRaw` + `sectionModes`, and pass `sectionModes:` into its `.filters(...)` / grouping predicate (where it currently uses `let mode = filterMatchMode`).
+
+- [ ] **Step 3: Remove the now-unused `filterMatchMode` AppStorage key** — grep `AppStorageKeys.filterMatchMode` across the app; if only Speakers/Merch keys (`filterMatchModeSpeakers`/`Merch`) remain used and plain `filterMatchMode` has no readers, delete the `static let filterMatchMode` line from `AppStorageKeys.swift`. If any reader remains, leave it.
+
+- [ ] **Step 4: Build — expect BUILD SUCCEEDED.**
+
+- [ ] **Step 5: Full test run — expect the Task 1/2 tests still pass.**
+
+- [ ] **Step 6: Commit** `git commit -m "Filters: drive Schedule + All Content from per-section modes"`
+
+---
+
+## Self-Review
+
+- Spec §"Section-mode model" → Task 1 ✓; §"Predicate change" → Task 2 ✓; §"Filter sheet UI" → Task 3 ✓; §"Consumers" → Task 4 ✓.
+- Pseudo-toggles as AND constraints → Task 2 Steps 4/5 ✓. Default `.any` → Task 1 `mode(for:)` ✓. ≥2-selected visibility → Task 3 Step 3 ✓. Speakers/Merch untouched (their own keys) ✓.
+- No placeholders; the one "grep before deleting" (isFiltered / filterMatchMode key) is a conditional cleanup with explicit criteria, not a TODO.
+- Type consistency: `sectionModes: [Int: FilterMatchMode]`, `SectionFilterModes(json:)`/`.asDictionary`/`.mode(for:)`/`.setMode(_:for:)`, `sectionFilterMatch(tagIds:selectedByType:sectionModes:)` used consistently across Tasks 1–4.
+- **Execution note:** Task 2 must confirm `Tag`/`TagType` initializers before writing the test fixtures, and confirm the exact current `[Content].filters` call site in `ContentListView` (it uses an inline predicate, not necessarily the extension) — adapt the wiring to whichever it uses.

--- a/docs/superpowers/plans/2026-07-20-report-an-issue.md
+++ b/docs/superpowers/plans/2026-07-20-report-an-issue.md
@@ -1,0 +1,405 @@
+# Report-an-Issue (Content Feedback) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users report a piece of content to the developers from the detail screens via a POST to the feedback endpoint.
+
+**Architecture:** A `FeedbackReporter` service builds the exact JSON payload (stamping a UTC timestamp, per-report UUID, client string, and an anonymous Keychain install id) and POSTs it; a `ReportContentSheet` collects the message; a toolbar "Report an issue" item on each detail screen presents it with the right `object_type`/`object_id`.
+
+**Tech Stack:** Swift 6, SwiftUI, URLSession, Security (Keychain), XCTest.
+
+## Global Constraints
+
+- Deployment target stays iOS 17.0.
+- Endpoint: `POST https://feedback1.junctorconf.net/reporting.php`, `Content-Type: application/json`.
+- Payload keys (snake_case, exact): `message`, `conference_id` (Int), `conference_name`, `object_type` (one of `content`/`org`/`person`/`document`), `object_id` (Int), `report_timestamp` (`"yyyy-MM-dd HH:mm:ss"`, **UTC**, `en_US_POSIX`), `report_uuid` (fresh per report), `client` (`"HackerTracker iOS <marketingVersion> (<build>)"`), `device_identifier` (anonymous Keychain install UUID).
+- `object_type` mapping: content/event → `content`, speaker → `person`, org → `org`, document → `document`. Orgs send `object_id: 0` (no Int identity).
+- Only the message + anonymous install id leave the device (no tracking/PII).
+- New source files need manual `project.pbxproj` wiring. Tests append to `hackertrackerTests/hackertrackerTests.swift`.
+- Build: `xcodebuild -project hackertracker.xcodeproj -scheme hackertracker -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' build`; Test: same with `test`.
+
+---
+
+### Task 1: `FeedbackReporter` service (payload, device id, POST)
+
+**Files:**
+- Create: `hackertracker/Utils/FeedbackReporter.swift`
+- Modify: `hackertracker.xcodeproj/project.pbxproj`
+- Test: `hackertrackerTests/hackertrackerTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum ReportObjectType: String { case content, org, person, document }`
+  - `struct FeedbackReport: Encodable` (snake_case CodingKeys per the payload).
+  - `enum ReportDeviceIdentifier { static func current() -> String }`
+  - `enum FeedbackReporter { static func makeReport(message:conference:objectType:objectId:now:uuid:deviceID:) -> FeedbackReport; static func send(message:conference:objectType:objectId:) async -> Result<Void, ReportError> }`
+  - `struct ReportError: Error { let message: String }`
+
+- [ ] **Step 1: Failing tests** — append. These test the deterministic payload builder (no network) and encoding:
+
+```swift
+func testFeedbackReportEncodesExactKeys() throws {
+    let conf = Conference.reportStub(id: 258, name: "DEF CON 34")   // add stub below
+    let fixedDate = Date(timeIntervalSince1970: 1_767_400_000)       // deterministic
+    let report = FeedbackReporter.makeReport(
+        message: "nope", conference: conf, objectType: .person, objectId: 42,
+        now: fixedDate, uuid: "UUID-1", deviceID: "DEV-1")
+    let data = try JSONEncoder().encode(report)
+    let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    XCTAssertEqual(obj["conference_id"] as? Int, 258)
+    XCTAssertEqual(obj["object_type"] as? String, "person")
+    XCTAssertEqual(obj["object_id"] as? Int, 42)
+    XCTAssertEqual(obj["report_uuid"] as? String, "UUID-1")
+    XCTAssertEqual(obj["device_identifier"] as? String, "DEV-1")
+    XCTAssertNotNil(obj["report_timestamp"] as? String)
+    XCTAssertTrue((obj["client"] as? String)?.hasPrefix("HackerTracker iOS") ?? false)
+    // UTC "yyyy-MM-dd HH:mm:ss" shape
+    XCTAssertEqual((obj["report_timestamp"] as? String)?.count, 19)
+}
+func testDeviceIdentifierIsStable() {
+    XCTAssertEqual(ReportDeviceIdentifier.current(), ReportDeviceIdentifier.current())
+}
+```
+
+Add a `Conference.reportStub` helper at the bottom of the test file — check `Models/Conference.swift` for the member-wise initializer and fill all stored properties (id, name, code, dates, timestamps, hidden, enableMerch, enableMerchCart, homeMenuId, and the optionals as nil). If the initializer is large, prefer decoding a minimal JSON fixture instead.
+
+- [ ] **Step 2: Run — expect FAIL** (`cannot find 'FeedbackReporter'`).
+
+- [ ] **Step 3: Implement** — `hackertracker/Utils/FeedbackReporter.swift`:
+
+```swift
+import Foundation
+import Security
+
+enum ReportObjectType: String { case content, org, person, document }
+
+struct ReportError: Error { let message: String }
+
+struct FeedbackReport: Encodable {
+    let message: String
+    let conferenceId: Int
+    let conferenceName: String
+    let objectType: String
+    let objectId: Int
+    let reportTimestamp: String
+    let reportUuid: String
+    let client: String
+    let deviceIdentifier: String
+
+    enum CodingKeys: String, CodingKey {
+        case message
+        case conferenceId = "conference_id"
+        case conferenceName = "conference_name"
+        case objectType = "object_type"
+        case objectId = "object_id"
+        case reportTimestamp = "report_timestamp"
+        case reportUuid = "report_uuid"
+        case client = "client"
+        case deviceIdentifier = "device_identifier"
+    }
+}
+
+/// Anonymous, app-generated install identifier. Random UUID created once
+/// and stored in the Keychain (not device/IDFV-derived) — no tracking.
+enum ReportDeviceIdentifier {
+    private static let account = "org.beezle.hackertracker.reportDeviceID"
+
+    static func current() -> String {
+        if let existing = read() { return existing }
+        let new = UUID().uuidString
+        save(new)
+        return new
+    }
+
+    private static func read() -> String? {
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var out: AnyObject?
+        guard SecItemCopyMatching(q as CFDictionary, &out) == errSecSuccess,
+              let data = out as? Data, let s = String(data: data, encoding: .utf8) else { return nil }
+        return s
+    }
+
+    private static func save(_ value: String) {
+        let data = Data(value.utf8)
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(q as CFDictionary)
+        SecItemAdd(q as CFDictionary, nil)
+    }
+}
+
+enum FeedbackReporter {
+    private static let endpoint = URL(string: "https://feedback1.junctorconf.net/reporting.php")!
+
+    private static let timestampFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f
+    }()
+
+    static func clientString() -> String {
+        let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let b = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        return "HackerTracker iOS \(v) (\(b))"
+    }
+
+    /// Deterministic builder (injectable stamps for tests).
+    static func makeReport(message: String, conference: Conference,
+                           objectType: ReportObjectType, objectId: Int,
+                           now: Date, uuid: String, deviceID: String) -> FeedbackReport {
+        FeedbackReport(
+            message: message,
+            conferenceId: conference.id,
+            conferenceName: conference.name,
+            objectType: objectType.rawValue,
+            objectId: objectId,
+            reportTimestamp: timestampFormatter.string(from: now),
+            reportUuid: uuid,
+            client: clientString(),
+            deviceIdentifier: deviceID
+        )
+    }
+
+    static func send(message: String, conference: Conference,
+                     objectType: ReportObjectType, objectId: Int) async -> Result<Void, ReportError> {
+        let report = makeReport(message: message, conference: conference,
+                                objectType: objectType, objectId: objectId,
+                                now: Date(), uuid: UUID().uuidString,
+                                deviceID: ReportDeviceIdentifier.current())
+        do {
+            var req = URLRequest(url: endpoint)
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = try JSONEncoder().encode(report)
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                Log.network.error("feedback POST non-2xx")
+                return .failure(ReportError(message: "The report couldn’t be sent. Please try again."))
+            }
+            return .success(())
+        } catch {
+            Log.network.error("feedback POST failed: \(String(describing: error), privacy: .public)")
+            return .failure(ReportError(message: "The report couldn’t be sent. Please try again."))
+        }
+    }
+}
+```
+(`Date()`/`UUID()` are used only inside `send`, never on the test path — the tests call `makeReport` with injected stamps, so they don't hit the `Date.now`-forbidden path.)
+
+- [ ] **Step 4: Wire the file into project.pbxproj** (mirror `AgeGate.swift`, two fresh UUIDs; `plutil -lint` → OK).
+
+- [ ] **Step 5: Run tests — expect PASS.**
+
+- [ ] **Step 6: Commit** `git commit -m "Feedback: FeedbackReporter service + anonymous Keychain device id"`
+
+---
+
+### Task 2: `ReportContentSheet` UI
+
+**Files:**
+- Create: `hackertracker/Views/ReportContentSheet.swift`
+- Modify: `hackertracker.xcodeproj/project.pbxproj`
+- Test: none; build only.
+
+**Interfaces:**
+- Consumes: `FeedbackReporter.send(...)`, `ReportObjectType`, `Conference`, `InfoViewModel` (for `conference`), `ThemeManager`.
+- Produces: `struct ReportContentSheet: View { init(objectType: ReportObjectType, objectId: Int) }` — presented via `.sheet`.
+
+- [ ] **Step 1: Implement** — `hackertracker/Views/ReportContentSheet.swift`:
+
+```swift
+import SwiftUI
+
+struct ReportContentSheet: View {
+    let objectType: ReportObjectType
+    let objectId: Int
+
+    @Environment(InfoViewModel.self) private var viewModel
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var message = ""
+    @State private var sending = false
+    @State private var errorText: String?
+    @State private var sent = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextEditor(text: $message)
+                        .frame(minHeight: 140)
+                } header: {
+                    Text("What’s wrong with this content?")
+                } footer: {
+                    Text("Please don’t include personal information. Your message and an anonymous app identifier are sent to the organizers.")
+                }
+            }
+            .navigationTitle("Report an Issue")
+            .themedNavTitle("Report an Issue", themeManager)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if sending { ProgressView() }
+                    else {
+                        Button("Send") { submit() }
+                            .disabled(message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+            .alert("Couldn’t Send", isPresented: .constant(errorText != nil)) {
+                Button("Retry") { submit() }
+                Button("Cancel", role: .cancel) { errorText = nil }
+            } message: { Text(errorText ?? "") }
+            .alert("Report Sent", isPresented: $sent) {
+                Button("OK") { dismiss() }
+            } message: { Text("Thanks — the organizers will take a look.") }
+        }
+    }
+
+    private func submit() {
+        guard let conference = viewModel.conference else {
+            errorText = "No active conference."; return
+        }
+        errorText = nil
+        sending = true
+        Task {
+            let result = await FeedbackReporter.send(
+                message: message.trimmingCharacters(in: .whitespacesAndNewlines),
+                conference: conference, objectType: objectType, objectId: objectId)
+            sending = false
+            switch result {
+            case .success: sent = true
+            case .failure(let e): errorText = e.message
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire into project.pbxproj** (mirror `ListChrome.swift`, two fresh UUIDs; `plutil -lint` → OK).
+
+- [ ] **Step 3: Build — expect BUILD SUCCEEDED.**
+
+- [ ] **Step 4: Commit** `git commit -m "Feedback: ReportContentSheet UI"`
+
+---
+
+### Task 3: Toolbar entry on Content + Speaker detail
+
+**Files:**
+- Modify: `hackertracker/Views/ContentDetailView.swift`
+- Modify: `hackertracker/Views/SpeakerDetailView.swift`
+- Test: none; build only.
+
+**Interfaces:**
+- Consumes: `ReportContentSheet`, `ReportObjectType`.
+
+- [ ] **Step 1: ContentDetailView** — add `@State private var showReport = false`. In the existing `.toolbar { … }` (around line 120), add a trailing item:
+
+```swift
+ToolbarItem(placement: .topBarTrailing) {
+    Button {
+        showReport = true
+    } label: { Image(systemName: "exclamationmark.bubble") }
+    .accessibilityLabel("Report an issue")
+}
+```
+
+Attach the sheet on the same view:
+
+```swift
+.sheet(isPresented: $showReport) {
+    ReportContentSheet(objectType: .content, objectId: contentId)
+}
+```
+(Confirm the content id property name — `ContentDetailView(contentId:)` → use that stored id. Events route here, so `.content` is correct for both.)
+
+- [ ] **Step 2: SpeakerDetailView** — same pattern, in its `.toolbar` (around line 85): a `showReport` state, a trailing "Report an issue" button, and `.sheet { ReportContentSheet(objectType: .person, objectId: id) }` (`id: Int` is the speaker id).
+
+- [ ] **Step 3: Build — expect BUILD SUCCEEDED.**
+
+- [ ] **Step 4: Commit** `git commit -m "Feedback: report entry on Content + Speaker detail"`
+
+---
+
+### Task 4: Toolbar entry on Org + Document detail
+
+**Files:**
+- Modify: `hackertracker/Views/OrgView.swift`
+- Modify: `hackertracker/Views/DocumentView.swift`
+- (Modify call sites that present a real Document with `DocumentView`, to pass a report context.)
+- Test: none; build only.
+
+**Interfaces:**
+- Consumes: `ReportContentSheet`, `ReportObjectType`.
+- Produces: `DocumentView` gains `var reportContext: (type: ReportObjectType, id: Int)? = nil` (default nil → no report item), so the generic viewer (privacy doc, org descriptions, emergency doc) shows nothing extra.
+
+- [ ] **Step 1: OrgView** — add `@State private var showReport = false`. OrgView currently has no `.toolbar`; add one to its root view:
+
+```swift
+.toolbar {
+    ToolbarItem(placement: .topBarTrailing) {
+        Button { showReport = true } label: { Image(systemName: "exclamationmark.bubble") }
+            .accessibilityLabel("Report an issue")
+    }
+}
+.sheet(isPresented: $showReport) {
+    ReportContentSheet(objectType: .org, objectId: 0)   // Organization has no Int id
+}
+```
+(`org` is the `Organization` in scope; `object_id: 0` per spec.)
+
+- [ ] **Step 2: DocumentView** — add the optional context parameter and a report item shown only when it's set:
+
+```swift
+var reportContext: (type: ReportObjectType, id: Int)? = nil
+@State private var showReport = false
+```
+In DocumentView's `.toolbar` (add one if absent), conditionally:
+
+```swift
+if reportContext != nil {
+    ToolbarItem(placement: .topBarTrailing) {
+        Button { showReport = true } label: { Image(systemName: "exclamationmark.bubble") }
+            .accessibilityLabel("Report an issue")
+    }
+}
+```
+And:
+
+```swift
+.sheet(isPresented: $showReport) {
+    if let ctx = reportContext {
+        ReportContentSheet(objectType: ctx.type, objectId: ctx.id)
+    }
+}
+```
+
+- [ ] **Step 3: Pass the context only for real documents** — grep `DocumentView(` across `Views/`. For the call site(s) that open an actual `Document` from the documents list (a `Document` with an `id: Int` in scope), add `reportContext: (.document, doc.id)`. Leave privacy-doc / org-description / emergency-doc call sites at the default `nil`.
+
+- [ ] **Step 4: Build — expect BUILD SUCCEEDED.**
+
+- [ ] **Step 5: Commit** `git commit -m "Feedback: report entry on Org + Document detail"`
+
+---
+
+## Self-Review
+
+- Spec §"DeviceIdentifier" → Task 1 (`ReportDeviceIdentifier`) ✓; §"FeedbackReporter" → Task 1 ✓; §"ReportContentSheet" → Task 2 ✓; §"Wiring" (Content/Speaker/Org/Document) → Tasks 3–4 ✓; org `object_id: 0` → Task 4 Step 1 ✓; UTC timestamp + client string + snake_case keys → Task 1 (formatter + CodingKeys + test) ✓; anonymous-only privacy → Task 1 (Keychain UUID) ✓.
+- Placeholders: none. The two "grep the call sites" steps (Document real-vs-generic) carry explicit criteria, not TODOs.
+- Type consistency: `ReportObjectType`, `FeedbackReporter.makeReport(...)`/`.send(...)`, `ReportDeviceIdentifier.current()`, `ReportContentSheet(objectType:objectId:)`, `DocumentView.reportContext` used consistently across Tasks 1–4.
+- **Execution notes:** Task 1 must confirm the `Conference` initializer to build the test stub (or decode a fixture). Tasks 3–4 must confirm each detail screen's exact toolbar/property (ContentDetailView content-id name; OrgView/DocumentView have no toolbar today — add one).

--- a/docs/superpowers/specs/2026-07-20-per-section-filters-design.md
+++ b/docs/superpowers/specs/2026-07-20-per-section-filters-design.md
@@ -1,0 +1,104 @@
+# Per-Section Any/All Filters — Design Spec
+
+**Date:** 2026-07-20
+**Status:** Approved for planning
+**Feature branch:** `feature/filters-and-feedback`
+
+## Summary
+
+Make the Schedule and All Content filters smarter: instead of one global Any/All that
+applies to every selected chip, give **each tagtype section its own Any/All mode**, and
+combine sections with **AND**. This lets a user express, e.g., "Contests (Type) under
+organizer A **or** B (Organizer, Any)" — a query the current single-mode model can't form.
+
+## Decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Cross-section combination | **AND** across active sections; Any/All is configurable *within* each section. |
+| 2 | Pseudo-toggles (Bookmarks / Custom Events / Has Notes) | Each remains its own **AND** constraint; no Any/All (single concepts). |
+| 3 | Per-section control visibility | Show the section's Any/All control **only when ≥2 chips are selected** in that section. |
+| 4 | Default section mode | `.any`. |
+| 5 | Scope | **Schedule + All Content only.** Speakers and Merch keep their existing single-mode pickers. |
+
+## Current state (verified)
+
+- Schedule (`EventsView`) and All Content (`ContentListView`) present the **same** filter
+  sheet `EventFilters` (`Views/FiltersView.swift`), share the same `Filters` store, and
+  read the same `@AppStorage(AppStorageKeys.filterMatchMode)` — one global Any/All.
+- The predicate lives in `Utils/ModelExt.swift` as `filters(...)` overloads on `[Event]`
+  and `[Content]`. Today all selected real tags are flattened into one OR bucket, and the
+  global `mode` only distinguishes the four buckets (tags / bookmarks / custom / hasNotes).
+- `FilterMatchMode` (`.any`/`.all`) and `MatchModePickerRow` already exist and are reused
+  by Speakers/Merch — those are out of scope and unchanged.
+
+## Design
+
+### 1. Section-mode model
+
+Add a lightweight store for per-tagtype modes, shared by Schedule + All Content (mirroring
+how they already share `filterMatchMode`):
+
+```swift
+/// Per-tagtype-section Any/All modes for the Schedule + All Content filter.
+/// Persisted as JSON [tagTypeId: "any"|"all"] under one AppStorage key.
+struct SectionFilterModes {
+    private(set) var modes: [Int: FilterMatchMode]   // tagTypeId -> mode
+    func mode(for tagTypeId: Int) -> FilterMatchMode  // default .any
+    mutating func setMode(_ mode: FilterMatchMode, for tagTypeId: Int)
+    // Codable to/from the AppStorage JSON string.
+}
+```
+
+Stored under a new key `AppStorageKeys.sectionFilterModes` (JSON string). The old
+`filterMatchMode` key is retired for Schedule/All Content (left in `AppStorageKeys` only if
+Speakers/Merch still use their own keys — they use `filterMatchModeSpeakers`/`Merch`, so the
+plain `filterMatchMode` key becomes unused and is removed).
+
+### 2. Predicate change (`ModelExt.swift`)
+
+Both `[Event].filters(...)` and `[Content].filters(...)` replace the single
+`mode: FilterMatchMode` parameter with `sectionModes: [Int: FilterMatchMode]`. New logic:
+
+1. Group the selected real tag ids by their tagtype → `[tagTypeId: Set<tagId>]`.
+2. For each **active** tagtype (≥1 selected tag), compute a per-section match:
+   - `.any` → the item has **any** of that section's selected tags.
+   - `.all` → the item has **all** of that section's selected tags.
+3. Combine all active tagtype sections with **AND**.
+4. Combine the pseudo constraints (Bookmarks, Custom, Has Notes) — each, when active, is an
+   additional **AND** constraint (must be bookmarked / custom / have notes).
+5. No selection anywhere → return everything (unchanged).
+
+This is a behavior change from today's global OR-bucket + single Any/All. It is intentional
+and is the point of the feature.
+
+### 3. Filter sheet UI (`FiltersView.swift` / `EventFilters`)
+
+- Remove the single top-of-sheet `MatchModePickerRow`.
+- In each tagtype section header, render a compact **Any / All** segmented control, bound to
+  `SectionFilterModes.mode(for: tagTypeId)`. Show it **only when that section has ≥2 chips
+  selected**; hide otherwise (a lone selection has no Any/All meaning).
+- Pseudo-toggle rows (Bookmarks / Custom / Has Notes) get no control.
+- The live "matched count" label continues to reflect the composed predicate.
+
+### 4. Consumers
+
+- `EventsView` schedule pipeline: pass `sectionModes` into `filters(...)`; include the
+  section-modes identity in `schedulePipelineKey` so the cached result recomputes when a
+  section mode changes.
+- `ContentListView`: pass `sectionModes` into its `filters(...)` / grouping call.
+
+## Testing
+
+Unit tests on the predicate (no UI), for both `[Event]` and `[Content]`:
+- Single section, `.any` vs `.all` (item with one vs both tags).
+- Two sections combine with AND (must satisfy both).
+- Pseudo-toggle (e.g. Bookmarks) AND-combines with a tag section.
+- Empty selection → all returned.
+- The "Contests under organizer A or B" worked example.
+
+## Non-goals
+
+- No change to Speakers or Merch filtering.
+- No OR-across-sections mode, no global override toggle.
+- No change to which chips exist or how tagtypes are sourced.

--- a/docs/superpowers/specs/2026-07-20-report-an-issue-design.md
+++ b/docs/superpowers/specs/2026-07-20-report-an-issue-design.md
@@ -1,0 +1,135 @@
+# Report-an-Issue (Content Feedback) — Design Spec
+
+**Date:** 2026-07-20
+**Status:** Approved for planning
+**Feature branch:** `feature/filters-and-feedback`
+
+## Summary
+
+Let users report a piece of content back to the developers from the detail screens. A
+"Report an issue" toolbar action opens a sheet with a free-text message; sending POSTs a
+JSON payload to `https://feedback1.junctorconf.net/reporting.php`. Privacy-preserving:
+only the user's message and an anonymous, app-generated install identifier leave the device.
+
+## Decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | `device_identifier` | **App-generated random UUID**, created once and stored in the Keychain; not device/IDFV-derived. |
+| 2 | Placement | **Toolbar "Report an issue" item** on each detail screen → modal sheet with a message field. |
+| 3 | object_type mapping | event/content → `content`, speaker → `person`, org → `org`, document → `document`. |
+| 4 | `report_timestamp` | `"yyyy-MM-dd HH:mm:ss"` in **UTC**. |
+| 5 | `report_uuid` | Fresh `UUID()` per report. |
+| 6 | `client` | `"HackerTracker iOS <marketingVersion> (<build>)"`. |
+
+## Endpoint & payload
+
+`POST https://feedback1.junctorconf.net/reporting.php`, `Content-Type: application/json`:
+
+```json
+{
+  "message": "<user free text>",
+  "conference_id": 258,
+  "conference_name": "DEF CON 34",
+  "object_type": "content",
+  "object_id": 0,
+  "report_timestamp": "2026-01-02 23:45:59",
+  "report_uuid": "1B2A3695-7D25-412F-B442-CF9094E1B6B8",
+  "client": "HackerTracker iOS 6.2 (26072001)",
+  "device_identifier": "<persisted install UUID>"
+}
+```
+
+- `conference_id` (Int) / `conference_name` — from `InfoViewModel.conference` (`id: Int`, `name`).
+- `object_type` / `object_id` — supplied by the calling detail screen.
+- `report_timestamp` — a `DateFormatter` with `yyyy-MM-dd HH:mm:ss`, `TimeZone(identifier: "UTC")`, `Locale(identifier: "en_US_POSIX")`.
+- `client` — `CFBundleShortVersionString` + `CFBundleVersion`.
+
+## Design
+
+### 1. `DeviceIdentifier` (Keychain-backed install UUID)
+
+```swift
+enum ReportDeviceIdentifier {
+    /// Random UUID generated once and stored in the Keychain (survives app
+    /// reinstall on the same device/keychain; not derived from the device).
+    static func current() -> String
+}
+```
+On first call, generate `UUID().uuidString`, store under a fixed Keychain key, return it;
+subsequent calls read it back. This is anonymous and not cross-app — consistent with the
+app's no-tracking / no-IDFA posture.
+
+### 2. `FeedbackReporter` (service)
+
+```swift
+enum ReportObjectType: String { case content, org, person, document }
+
+struct FeedbackReport: Encodable {
+    let message: String
+    let conferenceId: Int
+    let conferenceName: String
+    let objectType: String          // ReportObjectType.rawValue
+    let objectId: Int
+    let reportTimestamp: String      // UTC "yyyy-MM-dd HH:mm:ss"
+    let reportUuid: String
+    let client: String
+    let deviceIdentifier: String
+    // CodingKeys map to snake_case exactly per the payload above.
+}
+
+enum FeedbackReporter {
+    /// Builds the payload (stamping timestamp/uuid/client/device id) and
+    /// POSTs it. Returns success or a user-presentable failure.
+    static func send(message: String,
+                     conference: Conference,
+                     objectType: ReportObjectType,
+                     objectId: Int) async -> Result<Void, ReportError>
+}
+```
+- Endpoint URL is a single constant.
+- Timestamp/uuid/client/device-id are stamped inside `send` (injectable in tests via
+  a small internal builder so payload construction is testable without the network).
+- Non-2xx or transport error → `.failure(ReportError)` with a friendly message.
+
+### 3. `ReportContentSheet` (UI)
+
+A modal sheet: title, a short "Please don't include personal information" caption, a
+`TextEditor` bound to the message, and Cancel / Send. Send is disabled while empty or
+in flight; shows a spinner; on success dismisses with a brief confirmation; on failure
+shows an alert with Retry. Styled with the existing `themeManager` fonts/`settingsCard`
+conventions.
+
+### 4. Wiring
+
+Add a **"Report an issue"** toolbar item (in the existing ⋯/options menu where present,
+else a dedicated toolbar button) that presents `ReportContentSheet` with the right
+`objectType`/`objectId` on:
+- `ContentDetailView` → `.content`, `content.id` (events route here).
+- `SpeakerDetailView` → `.person`, `speaker.id`.
+- `OrgView` → `.org`. `Organization.id` is a `@DocumentID String?` — there is **no Int
+  identity** for an organization — so send `object_id: 0` (matching the sample payload's
+  `"object_id": 0`); the report is identified by `object_type` + `conference_id` + the
+  message text. (If the server later needs to pin the exact org, we'd add a string id
+  field server-side; out of scope here.)
+- `DocumentView` → `.document`, `document.id`.
+
+## Error handling
+
+- All failures fold into a single `ReportError` with a user-facing string; the sheet shows
+  an alert with Retry and stays open so the message isn't lost.
+- No offline queue / retry-later (out of scope) — the user simply retries.
+
+## Testing
+
+- Unit-test payload construction: given fixed message/conference/objectType/objectId and an
+  injected timestamp + uuid + device id, assert the encoded JSON has the exact snake_case
+  keys and values (`object_type`, `report_timestamp` format, `client` string).
+- Unit-test `ReportDeviceIdentifier.current()` returns a stable value across calls.
+- The live network POST is integration/manual (verify a 2xx against the real endpoint from
+  a build); not unit-tested.
+
+## Non-goals
+
+- No server-side changes, no rate limiting, no attachments/screenshots, no categories/reason
+  codes (free text only), no offline queue, no auth. Message + anonymous install id only.

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		61AE145FB3CF4CEF9CD898DC /* ListChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C3F9C2929744A6948A2200 /* ListChrome.swift */; };
 		B2F695DFBD5E83F401AC1EFE /* AgeGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6C981E5BEC28D5626B1437 /* AgeGate.swift */; };
 		F35BEAD60BF24C4BB0AED8CF /* AppStorageKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */; };
+		3ABFD5C49EADA3BA420469D9 /* SectionFilterModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C9AE3D73B886A43F9DE173 /* SectionFilterModes.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -265,6 +266,7 @@
 		5DF51ADF28526C0C007BCB83 /* UserEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEvent.swift; sourceTree = "<group>"; };
 		5DF82B252A5F3B29001395C7 /* NotificationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationUtility.swift; sourceTree = "<group>"; };
 		B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageKeys.swift; sourceTree = "<group>"; };
+		66C9AE3D73B886A43F9DE173 /* SectionFilterModes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionFilterModes.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -493,6 +495,7 @@
 				3C07C208285C6F7600CC9469 /* Theme.swift */,
 				B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */,
 				3C6C981E5BEC28D5626B1437 /* AgeGate.swift */,
+				66C9AE3D73B886A43F9DE173 /* SectionFilterModes.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -803,6 +806,7 @@
 				5DF51ABC2851203F007BCB83 /* Document.swift in Sources */,
 				5DDF035E2C28B4F10087BA59 /* ContentDetailView.swift in Sources */,
 				5D9681162C5946E000D246B0 /* FeedbackUtility.swift in Sources */,
+				3ABFD5C49EADA3BA420469D9 /* SectionFilterModes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -973,7 +977,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26072001;
+				CURRENT_PROJECT_VERSION = 26072201;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;
@@ -991,7 +995,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.2;
+				MARKETING_VERSION = 6.3;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = org.beezle.hackertracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1013,7 +1017,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26072001;
+				CURRENT_PROJECT_VERSION = 26072201;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;
@@ -1031,7 +1035,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.2;
+				MARKETING_VERSION = 6.3;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = org.beezle.hackertracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		5DF51AE028526C0C007BCB83 /* UserEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF51ADF28526C0C007BCB83 /* UserEvent.swift */; };
 		5DF82B262A5F3B29001395C7 /* NotificationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF82B252A5F3B29001395C7 /* NotificationUtility.swift */; };
 		61AE145FB3CF4CEF9CD898DC /* ListChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C3F9C2929744A6948A2200 /* ListChrome.swift */; };
+		75D53422EDBEC6A9BF596470 /* ReportContentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911621ED8D381CEAB74614CA /* ReportContentSheet.swift */; };
 		B2F695DFBD5E83F401AC1EFE /* AgeGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6C981E5BEC28D5626B1437 /* AgeGate.swift */; };
 		F35BEAD60BF24C4BB0AED8CF /* AppStorageKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */; };
 		3ABFD5C49EADA3BA420469D9 /* SectionFilterModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C9AE3D73B886A43F9DE173 /* SectionFilterModes.swift */; };
@@ -150,6 +151,7 @@
 
 /* Begin PBXFileReference section */
 		39C3F9C2929744A6948A2200 /* ListChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListChrome.swift; sourceTree = "<group>"; };
+		911621ED8D381CEAB74614CA /* ReportContentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportContentSheet.swift; sourceTree = "<group>"; };
 		3C04BD9D2A5FDFD900D01402 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
 		3C04BD9F2A5FE91500D01402 /* FiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersView.swift; sourceTree = "<group>"; };
 		3C07C208285C6F7600CC9469 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 				5D9E5758285A4710001374D4 /* SpeakerDetailView.swift */,
 				5D9E5754285A3C86001374D4 /* SpeakerRow.swift */,
 				39C3F9C2929744A6948A2200 /* ListChrome.swift */,
+				911621ED8D381CEAB74614CA /* ReportContentSheet.swift */,
 				5D9E5752285A3C25001374D4 /* SpeakersView.swift */,
 				3CE59E3A285B3ACD00B453C9 /* ViewModifiers.swift */,
 			);
@@ -734,6 +737,7 @@
 				5D9E5759285A4710001374D4 /* SpeakerDetailView.swift in Sources */,
 				5D9E5755285A3C86001374D4 /* SpeakerRow.swift in Sources */,
 				61AE145FB3CF4CEF9CD898DC /* ListChrome.swift in Sources */,
+				75D53422EDBEC6A9BF596470 /* ReportContentSheet.swift in Sources */,
 				5D9E57492859037C001374D4 /* BookmarkUtility.swift in Sources */,
 				5DF51AC928514F33007BCB83 /* Article.swift in Sources */,
 				5DF51AD8285155BC007BCB83 /* FAQ.swift in Sources */,

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -985,7 +985,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26072201;
+				CURRENT_PROJECT_VERSION = 26072901;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;
@@ -1025,7 +1025,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26072201;
+				CURRENT_PROJECT_VERSION = 26072901;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;

--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		B2F695DFBD5E83F401AC1EFE /* AgeGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6C981E5BEC28D5626B1437 /* AgeGate.swift */; };
 		F35BEAD60BF24C4BB0AED8CF /* AppStorageKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */; };
 		3ABFD5C49EADA3BA420469D9 /* SectionFilterModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C9AE3D73B886A43F9DE173 /* SectionFilterModes.swift */; };
+		7FDC4E93EAE5728D00BF80D5 /* FeedbackReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73232F834512272FAE40AD00 /* FeedbackReporter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -156,6 +157,7 @@
 		3C0E05CC2A53E6AD00E7154F /* GlobalSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchView.swift; sourceTree = "<group>"; };
 		3C0E05CE2A53E70200E7154F /* Searchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Searchable.swift; sourceTree = "<group>"; };
 		3C6C981E5BEC28D5626B1437 /* AgeGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeGate.swift; sourceTree = "<group>"; };
+		73232F834512272FAE40AD00 /* FeedbackReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackReporter.swift; sourceTree = "<group>"; };
 		3C92B96B2859DED600523901 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3C92B96C2859E51F00523901 /* ColorUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorUtility.swift; sourceTree = "<group>"; };
 		3CD532D62A29A992009D17F3 /* EventCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventCellView.swift; sourceTree = "<group>"; };
@@ -496,6 +498,7 @@
 				B3769181BE2945B88CBA7D99 /* AppStorageKeys.swift */,
 				3C6C981E5BEC28D5626B1437 /* AgeGate.swift */,
 				66C9AE3D73B886A43F9DE173 /* SectionFilterModes.swift */,
+				73232F834512272FAE40AD00 /* FeedbackReporter.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -773,6 +776,7 @@
 				3C07C209285C6F7600CC9469 /* Theme.swift in Sources */,
 				F35BEAD60BF24C4BB0AED8CF /* AppStorageKeys.swift in Sources */,
 				B2F695DFBD5E83F401AC1EFE /* AgeGate.swift in Sources */,
+				7FDC4E93EAE5728D00BF80D5 /* FeedbackReporter.swift in Sources */,
 				5DC0DE0000000000000000A1 /* Logger+HT.swift in Sources */,
 				5DC0DE0000000000000000B1 /* KFImage+HT.swift in Sources */,
 				5DC0DE0000000000000000C1 /* ClockService.swift in Sources */,

--- a/hackertracker/Models/Conference.swift
+++ b/hackertracker/Models/Conference.swift
@@ -9,7 +9,11 @@ import FirebaseFirestore
 import Foundation
 import SwiftUI
 
-struct Conference: Codable, Identifiable, Equatable {
+/// `@unchecked Sendable`: all stored properties are value types that are
+/// safe to copy across actor boundaries; the compiler can't verify this
+/// automatically because `DocumentID<String>` (Firebase) and the nested
+/// `Map`/`Document` models aren't themselves marked `Sendable`.
+struct Conference: Codable, Identifiable, Equatable, @unchecked Sendable {
     static func == (lhs: Conference, rhs: Conference) -> Bool {
         lhs.code == rhs.code
     }

--- a/hackertracker/Models/Conference.swift
+++ b/hackertracker/Models/Conference.swift
@@ -9,11 +9,7 @@ import FirebaseFirestore
 import Foundation
 import SwiftUI
 
-/// `@unchecked Sendable`: all stored properties are value types that are
-/// safe to copy across actor boundaries; the compiler can't verify this
-/// automatically because `DocumentID<String>` (Firebase) and the nested
-/// `Map`/`Document` models aren't themselves marked `Sendable`.
-struct Conference: Codable, Identifiable, Equatable, @unchecked Sendable {
+struct Conference: Codable, Identifiable, Equatable {
     static func == (lhs: Conference, rhs: Conference) -> Bool {
         lhs.code == rhs.code
     }

--- a/hackertracker/Utils/AppStorageKeys.swift
+++ b/hackertracker/Utils/AppStorageKeys.swift
@@ -20,7 +20,6 @@ enum AppStorageKeys {
     static let notifyAt = "notifyAt"
     static let showLocaltime = "showLocaltime"
     static let show24hourtime = "show24hourtime"
-    static let filterMatchMode = "filterMatchMode"
     static let easterEgg = "easterEgg"
     static let aiSummaries = "aiSummaries"
     static let showNews = "showNews"

--- a/hackertracker/Utils/AppStorageKeys.swift
+++ b/hackertracker/Utils/AppStorageKeys.swift
@@ -39,4 +39,5 @@ enum AppStorageKeys {
     static let easterEggMaxOpacity = "easterEggMaxOpacity"
     static let lastMapIndex = "lastMapIndex"
     static let infoLogoCollapsedCodes = "infoLogoCollapsedCodes"
+    static let sectionFilterModes = "sectionFilterModes.v1"
 }

--- a/hackertracker/Utils/FeedbackReporter.swift
+++ b/hackertracker/Utils/FeedbackReporter.swift
@@ -98,13 +98,13 @@ enum FeedbackReporter {
     }
 
     /// Deterministic builder (injectable stamps for tests).
-    static func makeReport(message: String, conference: Conference,
+    static func makeReport(message: String, conferenceId: Int, conferenceName: String,
                            objectType: ReportObjectType, objectId: Int,
                            now: Date, uuid: String, deviceID: String) -> FeedbackReport {
         FeedbackReport(
             message: message,
-            conferenceId: conference.id,
-            conferenceName: conference.name,
+            conferenceId: conferenceId,
+            conferenceName: conferenceName,
             objectType: objectType.rawValue,
             objectId: objectId,
             reportTimestamp: timestampFormatter.string(from: now),
@@ -114,9 +114,9 @@ enum FeedbackReporter {
         )
     }
 
-    static func send(message: String, conference: Conference,
+    static func send(message: String, conferenceId: Int, conferenceName: String,
                      objectType: ReportObjectType, objectId: Int) async -> Result<Void, ReportError> {
-        let report = makeReport(message: message, conference: conference,
+        let report = makeReport(message: message, conferenceId: conferenceId, conferenceName: conferenceName,
                                 objectType: objectType, objectId: objectId,
                                 now: Date(), uuid: UUID().uuidString,
                                 deviceID: ReportDeviceIdentifier.current())

--- a/hackertracker/Utils/FeedbackReporter.swift
+++ b/hackertracker/Utils/FeedbackReporter.swift
@@ -1,0 +1,139 @@
+//
+//  FeedbackReporter.swift
+//  hackertracker
+//
+//  Service layer for the "report an issue" feedback flow. Builds a
+//  deterministic payload (`makeReport`) for testability and POSTs it
+//  to the feedback endpoint (`send`). Includes an anonymous,
+//  app-generated device identifier stored in the Keychain.
+//
+
+import Foundation
+import Security
+
+enum ReportObjectType: String {
+    case content, org, person, document
+}
+
+struct ReportError: Error {
+    let message: String
+}
+
+struct FeedbackReport: Encodable {
+    let message: String
+    let conferenceId: Int
+    let conferenceName: String
+    let objectType: String
+    let objectId: Int
+    let reportTimestamp: String
+    let reportUuid: String
+    let client: String
+    let deviceIdentifier: String
+
+    enum CodingKeys: String, CodingKey {
+        case message
+        case conferenceId = "conference_id"
+        case conferenceName = "conference_name"
+        case objectType = "object_type"
+        case objectId = "object_id"
+        case reportTimestamp = "report_timestamp"
+        case reportUuid = "report_uuid"
+        case client = "client"
+        case deviceIdentifier = "device_identifier"
+    }
+}
+
+/// Anonymous, app-generated install identifier. Random UUID created once
+/// and stored in the Keychain (not device/IDFV-derived) — no tracking.
+enum ReportDeviceIdentifier {
+    private static let account = "org.beezle.hackertracker.reportDeviceID"
+
+    static func current() -> String {
+        if let existing = read() { return existing }
+        let new = UUID().uuidString
+        save(new)
+        return new
+    }
+
+    private static func read() -> String? {
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var out: AnyObject?
+        guard SecItemCopyMatching(q as CFDictionary, &out) == errSecSuccess,
+              let data = out as? Data, let s = String(data: data, encoding: .utf8) else { return nil }
+        return s
+    }
+
+    private static func save(_ value: String) {
+        let data = Data(value.utf8)
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(q as CFDictionary)
+        SecItemAdd(q as CFDictionary, nil)
+    }
+}
+
+enum FeedbackReporter {
+    private static let endpoint = URL(string: "https://feedback1.junctorconf.net/reporting.php")!
+
+    private static let timestampFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f
+    }()
+
+    static func clientString() -> String {
+        let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let b = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        return "HackerTracker iOS \(v) (\(b))"
+    }
+
+    /// Deterministic builder (injectable stamps for tests).
+    static func makeReport(message: String, conference: Conference,
+                           objectType: ReportObjectType, objectId: Int,
+                           now: Date, uuid: String, deviceID: String) -> FeedbackReport {
+        FeedbackReport(
+            message: message,
+            conferenceId: conference.id,
+            conferenceName: conference.name,
+            objectType: objectType.rawValue,
+            objectId: objectId,
+            reportTimestamp: timestampFormatter.string(from: now),
+            reportUuid: uuid,
+            client: clientString(),
+            deviceIdentifier: deviceID
+        )
+    }
+
+    static func send(message: String, conference: Conference,
+                     objectType: ReportObjectType, objectId: Int) async -> Result<Void, ReportError> {
+        let report = makeReport(message: message, conference: conference,
+                                objectType: objectType, objectId: objectId,
+                                now: Date(), uuid: UUID().uuidString,
+                                deviceID: ReportDeviceIdentifier.current())
+        do {
+            var req = URLRequest(url: endpoint)
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = try JSONEncoder().encode(report)
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                Log.network.error("feedback POST non-2xx")
+                return .failure(ReportError(message: "The report couldn’t be sent. Please try again."))
+            }
+            return .success(())
+        } catch {
+            Log.network.error("feedback POST failed: \(String(describing: error), privacy: .public)")
+            return .failure(ReportError(message: "The report couldn’t be sent. Please try again."))
+        }
+    }
+}

--- a/hackertracker/Utils/ModelExt.swift
+++ b/hackertracker/Utils/ModelExt.swift
@@ -75,10 +75,10 @@ enum PseudoTagID {
     static let all: Set<Int> = [bookmarks, customEvents, hasNotes]
 }
 
-/// Filter-chip composition mode. Read from @AppStorage(AppStorageKeys.filterMatchMode)
-/// by FiltersView (writes) and the predicate consumers (reads). Storing
-/// the raw string lets us swap it cleanly via @AppStorage on multiple
-/// independent views without an envelope object.
+/// Filter-chip composition mode, selectable per tag section. Persisted as
+/// JSON (tagTypeId -> raw mode) under @AppStorage(AppStorageKeys.sectionFilterModes)
+/// via `SectionFilterModes`; FiltersView writes it and predicate consumers
+/// (`sectionFilterMatch`, `[Event].filters`, `[Content].filters`) read it.
 enum FilterMatchMode: String, CaseIterable {
     case any = "any"
     case all = "all"

--- a/hackertracker/Utils/ModelExt.swift
+++ b/hackertracker/Utils/ModelExt.swift
@@ -30,45 +30,36 @@ extension [TagType] {
 }
 
 extension [Content] {
-    func filters(typeIds: Set<Int>, bookmarks: Set<Int32>, tagTypes: [TagType]) -> Self {
+    func filters(
+        typeIds: Set<Int>,
+        bookmarks: Set<Int32>,
+        tagTypes: [TagType],
+        contentNoteIDs: Set<Int32> = [],
+        sectionModes: [Int: FilterMatchMode] = [:]
+    ) -> Self {
         if typeIds.isEmpty {
             return self
         } else {
-            var filterTypes: [Int: [Int]] = [:]
-            for typeId in typeIds {
+            var selectedByType: [Int: [Int]] = [:]
+            for typeId in typeIds where !PseudoTagID.all.contains(typeId) {
                 if let tagType = tagTypes.first(where: { $0.tags.contains(where: { $0.id == typeId }) }) {
-                    if filterTypes.keys.contains(tagType.id) {
-                        filterTypes[tagType.id]?.append(typeId)
+                    if selectedByType.keys.contains(tagType.id) {
+                        selectedByType[tagType.id]?.append(typeId)
                     } else {
-                        filterTypes[tagType.id] = [typeId]
+                        selectedByType[tagType.id] = [typeId]
                     }
                 }
             }
-            
-            if typeIds.contains(1337) {
-                return filter {
-                    isFiltered(tagIds: $0.tagIds, filterTypes: filterTypes)
-                    && bookmarks.contains(Int32($0.id))
+
+            return filter { content in
+                if !selectedByType.isEmpty,
+                   !sectionFilterMatch(tagIds: content.tagIds, selectedByType: selectedByType, sectionModes: sectionModes) {
+                    return false
                 }
-            } else {
-                return filter { isFiltered(tagIds: $0.tagIds, filterTypes: filterTypes) }
+                if typeIds.contains(PseudoTagID.bookmarks), !bookmarks.contains(Int32(content.id)) { return false }
+                if typeIds.contains(PseudoTagID.hasNotes), !contentNoteIDs.contains(Int32(content.id)) { return false }
+                return true
             }
-        }
-    }
-    
-    func isFiltered(tagIds: [Int], filterTypes: [Int: [Int]]) -> Bool {
-        var results: [Bool] = []
-        for ft in filterTypes {
-            var myR = false
-            if ft.value.contains(where: { tagIds.contains($0) }) {
-                myR = true
-            }
-            results.append(myR)
-        }
-        if results.contains(false) {
-            return false
-        } else {
-            return true
         }
     }
 }
@@ -97,6 +88,27 @@ enum FilterMatchMode: String, CaseIterable {
     }
 }
 
+/// Core per-section filter decision. `selectedByType` maps tagTypeId ->
+/// selected real tag ids in that section. For each active section, `.any`
+/// requires the item to carry at least one of the section's tags; `.all`
+/// requires all of them. Active sections are combined with AND. No sections
+/// → true (caller handles the empty-selection short-circuit).
+func sectionFilterMatch(tagIds: [Int],
+                        selectedByType: [Int: [Int]],
+                        sectionModes: [Int: FilterMatchMode]) -> Bool {
+    let itemTags = Set(tagIds)
+    for (typeId, selected) in selectedByType {
+        let mode = sectionModes[typeId] ?? .any
+        let ok: Bool
+        switch mode {
+        case .any: ok = selected.contains { itemTags.contains($0) }
+        case .all: ok = selected.allSatisfy { itemTags.contains($0) }
+        }
+        if !ok { return false }   // AND across sections
+    }
+    return true
+}
+
 extension [Event] {
     /* func types() -> [Int: EventType] {
         return reduce(into: [:]) { tags, event in
@@ -110,52 +122,35 @@ extension [Event] {
         tagTypes: [TagType],
         eventNoteIDs: Set<Int32> = [],
         contentNoteIDs: Set<Int32> = [],
-        mode: FilterMatchMode = .any
+        sectionModes: [Int: FilterMatchMode] = [:]
     ) -> Self {
         if typeIds.isEmpty {
             return self
         } else {
-            var filterTypes: [Int: [Int]] = [:]
-            for typeId in typeIds {
+            var selectedByType: [Int: [Int]] = [:]
+            for typeId in typeIds where !PseudoTagID.all.contains(typeId) {
                 if let tagType = tagTypes.first(where: { $0.tags.contains(where: { $0.id == typeId }) }) {
-                    if filterTypes.keys.contains(tagType.id) {
-                        filterTypes[tagType.id]?.append(typeId)
+                    if selectedByType.keys.contains(tagType.id) {
+                        selectedByType[tagType.id]?.append(typeId)
                     } else {
-                        filterTypes[tagType.id] = [typeId]
+                        selectedByType[tagType.id] = [typeId]
                     }
                 }
             }
-            // Each chip category contributes independently. In .any
-            // mode (OR) a row survives when ANY active category
-            // matches it. In .all mode (AND) a row must satisfy
-            // EVERY active category. "Active" = at least one chip
-            // from that category is selected; categories with no
-            // selection don't constrain the result either way.
-            let realTagIDs = Set(filterTypes.values.flatMap { $0 })
-            let useTags = !realTagIDs.isEmpty
             let useBookmarks = typeIds.contains(PseudoTagID.bookmarks)
             let useCustom = typeIds.contains(PseudoTagID.customEvents)
             let useHasNotes = typeIds.contains(PseudoTagID.hasNotes)
             return filter { event in
-                let tagMatch: Bool? = useTags
-                    ? event.tagIds.contains(where: { realTagIDs.contains($0) })
-                    : nil
-                let bookmarkMatch: Bool? = useBookmarks
-                    ? bookmarks.contains(Int32(event.id))
-                    : nil
-                let customMatch: Bool? = useCustom
-                    ? (event.customEventID != nil)
-                    : nil
-                let hasNotesMatch: Bool? = useHasNotes
-                    ? (eventNoteIDs.contains(Int32(event.id))
-                       || contentNoteIDs.contains(Int32(event.contentId)))
-                    : nil
-                let checks = [tagMatch, bookmarkMatch, customMatch, hasNotesMatch].compactMap { $0 }
-                guard !checks.isEmpty else { return true }
-                switch mode {
-                case .any: return checks.contains(true)
-                case .all: return checks.allSatisfy { $0 }
+                // Tag sections (AND across sections, per-section any/all).
+                if !selectedByType.isEmpty,
+                   !sectionFilterMatch(tagIds: event.tagIds, selectedByType: selectedByType, sectionModes: sectionModes) {
+                    return false
                 }
+                // Pseudo constraints — each active one is its own AND.
+                if useBookmarks, !bookmarks.contains(Int32(event.id)) { return false }
+                if useCustom, event.customEventID == nil { return false }
+                if useHasNotes, !(eventNoteIDs.contains(Int32(event.id)) || contentNoteIDs.contains(Int32(event.contentId))) { return false }
+                return true
             }
         }
     }
@@ -181,22 +176,6 @@ extension [Event] {
         }
         return eventDict.sorted {
             ($0.value.first?.beginTimestamp ?? Date()) < ($1.value.first?.beginTimestamp ?? Date())
-        }
-    }
-    
-    func isFiltered(tagIds: [Int], filterTypes: [Int: [Int]]) -> Bool {
-        var results: [Bool] = []
-        for ft in filterTypes {
-            var myR = false
-            if ft.value.contains(where: { tagIds.contains($0) }) {
-                myR = true
-            }
-            results.append(myR)
-        }
-        if results.contains(false) {
-            return false
-        } else {
-            return true
         }
     }
 }

--- a/hackertracker/Utils/SectionFilterModes.swift
+++ b/hackertracker/Utils/SectionFilterModes.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Per-tagtype-section Any/All modes for the Schedule + All Content filter.
+/// Persisted as a JSON object [tagTypeId(String): "any"|"all"] in a single
+/// AppStorage string. Sections with no stored entry default to `.any`.
+struct SectionFilterModes: Equatable {
+    private var modes: [Int: FilterMatchMode]
+
+    init(json: String) {
+        guard let data = json.data(using: .utf8),
+              let raw = try? JSONDecoder().decode([String: String].self, from: data) else {
+            modes = [:]; return
+        }
+        modes = raw.reduce(into: [:]) { acc, kv in
+            if let id = Int(kv.key), let mode = FilterMatchMode(rawValue: kv.value) {
+                acc[id] = mode
+            }
+        }
+    }
+
+    var jsonString: String {
+        let raw = modes.reduce(into: [String: String]()) { $0[String($1.key)] = $1.value.rawValue }
+        guard let data = try? JSONEncoder().encode(raw),
+              let s = String(data: data, encoding: .utf8) else { return "" }
+        return s
+    }
+
+    func mode(for tagTypeId: Int) -> FilterMatchMode { modes[tagTypeId] ?? .any }
+    mutating func setMode(_ mode: FilterMatchMode, for tagTypeId: Int) { modes[tagTypeId] = mode }
+
+    /// Convenience: the raw dictionary, for passing into the predicate.
+    var asDictionary: [Int: FilterMatchMode] { modes }
+}

--- a/hackertracker/Views/ContentDetailView.swift
+++ b/hackertracker/Views/ContentDetailView.swift
@@ -14,6 +14,7 @@ struct ContentDetailView: View {
     @State private var showFeedback: Bool = false
     // @State private var showFeedbackButton = true
     @State private var showAlert: Bool = false
+    @State private var showReport: Bool = false
     @State private var alertMessage: String = ""
     /// Polish: drives the iOS Mail-style nav-bar title handoff. Continuous
     /// 0...1 -- 0 means the body title is still fully in view (nav title
@@ -128,6 +129,15 @@ struct ContentDetailView: View {
                             .opacity(navTitleOpacity)
                     }
                 }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showReport = true
+                    } label: { Image(systemName: "exclamationmark.bubble") }
+                    .accessibilityLabel("Report an issue")
+                }
+            }
+            .sheet(isPresented: $showReport) {
+                ReportContentSheet(objectType: .content, objectId: contentId)
             }
             .onAppear() {
                 Log.ui.debug("ContentDetailView loading \(item.id) - \(item.title, privacy: .public)")

--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -16,11 +16,11 @@ struct ContentListView: View {
     /// Perf C: debounced mirror of `searchText`. contentGroup() reads
     /// this so the group/filter pipeline runs once per typing pause.
     @State private var debouncedSearch = ""
-    /// Filter-chip composition mode. Mirrors EventsView so both
-    /// lists honor the same user choice from the Filters sheet.
-    @AppStorage(AppStorageKeys.filterMatchMode) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
-    private var filterMatchMode: FilterMatchMode {
-        FilterMatchMode(rawOrDefault: filterMatchModeRaw)
+    /// Per-section filter-chip composition modes. Mirrors EventsView so
+    /// both lists honor the same user choices from the Filters sheet.
+    @AppStorage(AppStorageKeys.sectionFilterModes) private var sectionModesRaw: String = ""
+    private var sectionModes: [Int: FilterMatchMode] {
+        SectionFilterModes(json: sectionModesRaw).asDictionary
     }
     @State private var showFilters = false
     @Environment(InfoViewModel.self) private var viewModel
@@ -81,38 +81,41 @@ struct ContentListView: View {
     /// Grouped content computed once per body evaluation, shared by
     /// contentFilteredCount and grouped to avoid duplicate filtering.
     private var groupedContent: [String.Element: [Content]] {
-        let bookmarkIds = Set(bookmarks.map(\.id))
-        // Predicate composes search text + filter chips. The chips OR
-        // with each other (matches any one keeps the row). Real tags
-        // hit via tagIds.intersects; pseudo-tags 1337 (Bookmarks),
-        // 1339 (Has Notes) hit via their dedicated membership sets.
-        // Each category contributes a Bool? — non-nil only when at
-        // least one chip from that category is selected. Compose by
-        // mode: .any → OR (current default), .all → AND. Categories
-        // without a chip selection don't constrain the result.
+        // NOTE: deliberately NOT calling the shared `[Content].filters`
+        // extension (ModelExt.swift) here. That extension matches its
+        // Bookmarks pseudo-chip against `Int32(content.id)`, but bookmarks
+        // are actually keyed by session/event id (see
+        // ContentDetailView.bookmarkAction / `s.id`, where `s` is a
+        // `Content.sessions` entry) — `Content.id` and its session ids are
+        // different numbers. Reusing it here would silently break the
+        // Bookmarks chip on this screen. Instead, this predicate composes
+        // search text + filter chips using the same shared building blocks
+        // (`sectionFilterMatch`, `PseudoTagID`) with the intended
+        // semantics: tag sections are ANDed together, each with its own
+        // any/all mode from `sectionModes`; pseudo-tags (Bookmarks 1337,
+        // Has Notes 1339) are each their own AND constraint — matching
+        // `[Event].filters`/`[Content].filters`'s pseudo-constraint
+        // handling, just with a correct session-based bookmark check.
+        let bookmarkedSessionIds = Set(bookmarks.map(\.id))
         let realTagIDs = filters.filters.subtracting(PseudoTagID.all)
-        let useTags = !realTagIDs.isEmpty
+        var selectedByType: [Int: [Int]] = [:]
+        for typeId in realTagIDs {
+            if let tagType = viewModel.tagtypes.first(where: { $0.tags.contains(where: { $0.id == typeId }) }) {
+                selectedByType[tagType.id, default: []].append(typeId)
+            }
+        }
         let useBookmarks = filters.filters.contains(PseudoTagID.bookmarks)
         let useHasNotes = filters.filters.contains(PseudoTagID.hasNotes)
-        let mode = filterMatchMode
         return Dictionary(
             grouping: content.search(text: debouncedSearch).filter { c in
                 if filters.filters.isEmpty { return true }
-                let tagMatch: Bool? = useTags
-                    ? c.tagIds.contains(where: { realTagIDs.contains($0) })
-                    : nil
-                let bookmarkMatch: Bool? = useBookmarks
-                    ? c.sessions.contains(where: { bookmarkIds.contains(Int32($0.id)) })
-                    : nil
-                let hasNotesMatch: Bool? = useHasNotes
-                    ? noteContentIDsForScope.contains(Int32(c.id))
-                    : nil
-                let checks = [tagMatch, bookmarkMatch, hasNotesMatch].compactMap { $0 }
-                guard !checks.isEmpty else { return true }
-                switch mode {
-                case .any: return checks.contains(true)
-                case .all: return checks.allSatisfy { $0 }
+                if !selectedByType.isEmpty,
+                   !sectionFilterMatch(tagIds: c.tagIds, selectedByType: selectedByType, sectionModes: sectionModes) {
+                    return false
                 }
+                if useBookmarks, !c.sessions.contains(where: { bookmarkedSessionIds.contains(Int32($0.id)) }) { return false }
+                if useHasNotes, !noteContentIDsForScope.contains(Int32(c.id)) { return false }
+                return true
             },
             by: { $0.title.lowercased().first ?? "-" }
         )

--- a/hackertracker/Views/DocumentView.swift
+++ b/hackertracker/Views/DocumentView.swift
@@ -17,6 +17,8 @@ struct DocumentView: View {
     /// bar (not duplicated in the scroll body). Emergency / merch-help docs
     /// still want the prominent in-body banner, so this defaults to true.
     var showInlineTitle: Bool = true
+    var reportContext: (type: ReportObjectType, id: Int)? = nil
+    @State private var showReport = false
     @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
 
     @Environment(ThemeManager.self) private var themeManager
@@ -54,6 +56,19 @@ struct DocumentView: View {
         .iPadReadableContent()
         .analyticsScreen(name: "DocumentView")
         .padding(15)
+        .toolbar {
+            if reportContext != nil {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { showReport = true } label: { Image(systemName: "exclamationmark.bubble") }
+                        .accessibilityLabel("Report an issue")
+                }
+            }
+        }
+        .sheet(isPresented: $showReport) {
+            if let ctx = reportContext {
+                ReportContentSheet(objectType: ctx.type, objectId: ctx.id)
+            }
+        }
     }
 }
 

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -161,7 +161,7 @@ struct EventsView: View {
     /// @State copies above.
     private func recomputeSchedulePipeline() {
         let filtered = scheduleEvents
-            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, mode: filterMatchMode)
+            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, sectionModes: [:])
         scheduleDayKeys = filtered
             .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference)
             .map { $0.key }

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -82,11 +82,11 @@ struct EventsView: View {
     /// the schedule at all. Lives next to the rest of the schedule
     /// state so its value is read inline with the synthesizer.
     @AppStorage(AppStorageKeys.showCustomEvents) private var showCustomEventsInSchedule: Bool = true
-    /// Filter-chip composition mode. Read from the same
+    /// Per-section filter-chip composition modes. Read from the same
     /// AppStorage key the Filters sheet writes to.
-    @AppStorage(AppStorageKeys.filterMatchMode) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
-    private var filterMatchMode: FilterMatchMode {
-        FilterMatchMode(rawOrDefault: filterMatchModeRaw)
+    @AppStorage(AppStorageKeys.sectionFilterModes) private var sectionModesRaw: String = ""
+    private var sectionModes: [Int: FilterMatchMode] {
+        SectionFilterModes(json: sectionModesRaw).asDictionary
     }
 
     // MARK: Perf A: shared filter+search+group cache
@@ -141,7 +141,7 @@ struct EventsView: View {
         }
         // Filter / search selection.
         hasher.combine(filters.filters)
-        hasher.combine(filterMatchModeRaw)
+        hasher.combine(sectionModesRaw)
         hasher.combine(debouncedSearch)
         hasher.combine(viewModel.tagtypes.count)
         hasher.combine(viewModel.speakers.count)
@@ -161,7 +161,7 @@ struct EventsView: View {
     /// @State copies above.
     private func recomputeSchedulePipeline() {
         let filtered = scheduleEvents
-            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, sectionModes: [:])
+            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, eventNoteIDs: noteEventIDsForScope, contentNoteIDs: noteContentIDsForScope, sectionModes: sectionModes)
         scheduleDayKeys = filtered
             .eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference)
             .map { $0.key }

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -22,9 +22,20 @@ struct EventFilters: View {
     /// Singular noun used in the live tally label ("event", "talk",
     /// etc.). Plural is auto-derived with a trailing s.
     var unitLabel: String = "event"
-    @AppStorage(AppStorageKeys.filterMatchMode) private var filterMatchModeRaw: String = FilterMatchMode.defaultRaw
+    @AppStorage(AppStorageKeys.sectionFilterModes) private var sectionModesRaw: String = ""
 
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
+
+    private func binding(forTagType id: Int) -> Binding<FilterMatchMode> {
+        Binding(
+            get: { SectionFilterModes(json: sectionModesRaw).mode(for: id) },
+            set: { newValue in
+                var m = SectionFilterModes(json: sectionModesRaw)
+                m.setMode(newValue, for: id)
+                sectionModesRaw = m.jsonString
+            }
+        )
+    }
 
     var body: some View {
         // Wrap in a NavigationStack so the sheet picks up the system's
@@ -35,7 +46,6 @@ struct EventFilters: View {
         // app's other modal forms.
         NavigationStack {
             ScrollView {
-                MatchModePickerRow(raw: $filterMatchModeRaw)
                 FilterMatchCountLabel(count: matchedCount, unit: unitLabel)
                 if showBookmarks {
                     FilterRow(id: PseudoTagID.bookmarks, name: "Bookmarks", color: ThemeColors.blue)
@@ -55,8 +65,19 @@ struct EventFilters: View {
                             }
                         }
                     } header: {
-                        Text(tagtype.label)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        HStack {
+                            Text(tagtype.label)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            let selectedInSection = tagtype.tags.filter { filters.filters.contains($0.id) }.count
+                            if selectedInSection >= 2 {
+                                Picker("", selection: binding(forTagType: tagtype.id)) {
+                                    Text("Any").tag(FilterMatchMode.any)
+                                    Text("All").tag(FilterMatchMode.all)
+                                }
+                                .pickerStyle(.segmented)
+                                .fixedSize()
+                            }
+                        }
                     }
                 }
                 .headerProminence(.increased)

--- a/hackertracker/Views/GlobalSearchView.swift
+++ b/hackertracker/Views/GlobalSearchView.swift
@@ -57,7 +57,7 @@ struct GlobalSearchView: View {
                             ForEach(viewModel.documents.search(text: debouncedSearch).sorted {
                                 $0.title < $1.title
                             }, id: \.id) { document in
-                                NavigationLink(destination: DocumentView(title_text: document.title, body_text: document.body)) {
+                                NavigationLink(destination: DocumentView(title_text: document.title, body_text: document.body, reportContext: (.document, document.id))) {
                                     docSearchRow(title_text: document.title, themeColor: colorMode ? themeManager.carouselColor(index: document.id) : Color(.systemGray2))
                                         .foregroundColor(.primary)
                                         .padding(1)

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -21,6 +21,14 @@ struct InfoView: View {
     /// screen. Stored as a JSON-encoded Set<String> of conference
     /// codes that the user has collapsed; persists across launches.
     @AppStorage(AppStorageKeys.infoLogoCollapsedCodes) private var collapsedLogoCodesRaw: String = "[]"
+    /// Per-section filter-chip composition modes. Read from the same
+    /// AppStorage key the Filters sheet writes to, so the shared/combined
+    /// schedule respects the same per-section any/all selection as
+    /// EventsView.
+    @AppStorage(AppStorageKeys.sectionFilterModes) private var sectionModesRaw: String = ""
+    private var sectionModes: [Int: FilterMatchMode] {
+        SectionFilterModes(json: sectionModesRaw).asDictionary
+    }
     @EnvironmentObject var selected: SelectedConference
     @EnvironmentObject var filters: Filters
     @Environment(ConferencesViewModel.self) private var consViewModel
@@ -521,7 +529,7 @@ struct InfoView: View {
                 case "SharedEvents":
                     EventScrollView(events:
                         sharedEvents
-                            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes)
+                            .filters(typeIds: filters.filters, bookmarks: Set(bookmarks.map { $0.id }), tagTypes: viewModel.tagtypes, sectionModes: sectionModes)
                             .search(text: searchText, speakers: viewModel.speakers)
                             .eventDayGroup(
                                 showLocaltime: showLocaltime, conference: viewModel.conference

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -194,7 +194,7 @@ struct InfoView: View {
                         LazyVGrid(columns: gridItemLayout, alignment: .center, spacing: 20) {
                             if let emergId = viewModel.conference?.emergencyDocId, emergId > 0 {
                                 if let doc = viewModel.documentsById[emergId] {
-                                    NavigationLink(destination: DocumentView(title_text: doc.title, body_text: doc.body, reportContext: (.document, doc.id))) {
+                                    NavigationLink(destination: DocumentView(title_text: doc.title, body_text: doc.body)) {
                                         CardView(systemImage: "doc", text: doc.title, color: themeManager.danger)
                                     }
                                 }

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -182,7 +182,7 @@ struct InfoView: View {
                                 .font(themeManager.subheadlineFont)
                             LazyVGrid(columns: gridItemLayout, alignment: .center, spacing: 20) {
                                 ForEach(self.viewModel.documents, id: \.id) { doc in
-                                    NavigationLink(destination: DocumentView(title_text: doc.title, body_text: doc.body)) {
+                                    NavigationLink(destination: DocumentView(title_text: doc.title, body_text: doc.body, reportContext: (.document, doc.id))) {
                                         CardView(systemImage: "doc", text: doc.title, color: colorMode ? ThemeColors.blue : themeManager.cardSurface)
                                     }
                                 }
@@ -194,7 +194,7 @@ struct InfoView: View {
                         LazyVGrid(columns: gridItemLayout, alignment: .center, spacing: 20) {
                             if let emergId = viewModel.conference?.emergencyDocId, emergId > 0 {
                                 if let doc = viewModel.documentsById[emergId] {
-                                    NavigationLink(destination: DocumentView(title_text: doc.title, body_text: doc.body)) {
+                                    NavigationLink(destination: DocumentView(title_text: doc.title, body_text: doc.body, reportContext: (.document, doc.id))) {
                                         CardView(systemImage: "doc", text: doc.title, color: themeManager.danger)
                                     }
                                 }
@@ -711,7 +711,7 @@ struct MenuView: View {
                 switch item.function {
                 case "document":
                     if let docId = item.documentId, let doc = self.viewModel.documentsById[docId] {
-                        NavigationLink(destination: DocumentView(title_text: doc.title, body_text: doc.body)) {
+                        NavigationLink(destination: DocumentView(title_text: doc.title, body_text: doc.body, reportContext: (.document, doc.id))) {
                             CardView(systemImage: item.symbol ?? "doc", text: doc.title, color: colorMode ? ThemeColors.blue : themeManager.cardSurface)
                             }
                     }

--- a/hackertracker/Views/OrgView.swift
+++ b/hackertracker/Views/OrgView.swift
@@ -16,6 +16,7 @@ struct OrgView: View {
     @EnvironmentObject var filters: Filters
     @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     @Binding var tabSelection: Int
+    @State private var showReport = false
 
     @Environment(ThemeManager.self) private var themeManager
 
@@ -74,6 +75,15 @@ struct OrgView: View {
         .padding(5)
         .themedBackground(themeManager)
         .analyticsScreen(name: "OrgView")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button { showReport = true } label: { Image(systemName: "exclamationmark.bubble") }
+                    .accessibilityLabel("Report an issue")
+            }
+        }
+        .sheet(isPresented: $showReport) {
+            ReportContentSheet(objectType: .org, objectId: 0)
+        }
     }
 }
 

--- a/hackertracker/Views/ReportContentSheet.swift
+++ b/hackertracker/Views/ReportContentSheet.swift
@@ -1,0 +1,79 @@
+//
+//  ReportContentSheet.swift
+//  hackertracker
+//
+//  Message-entry sheet for the "report an issue" feedback flow.
+//  Collects a free-text message from the user and submits it via
+//  `FeedbackReporter.send` for the given object type/id.
+//
+
+import SwiftUI
+
+struct ReportContentSheet: View {
+    let objectType: ReportObjectType
+    let objectId: Int
+
+    @Environment(InfoViewModel.self) private var viewModel
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var message = ""
+    @State private var sending = false
+    @State private var errorText: String?
+    @State private var sent = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextEditor(text: $message)
+                        .frame(minHeight: 140)
+                } header: {
+                    Text("What’s wrong with this content?")
+                } footer: {
+                    Text("Please don’t include personal information. Your message and an anonymous app identifier are sent to the organizers.")
+                }
+            }
+            .navigationTitle("Report an Issue")
+            .themedNavTitle("Report an Issue", themeManager)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if sending { ProgressView() }
+                    else {
+                        Button("Send") { submit() }
+                            .disabled(message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+            .alert("Couldn’t Send", isPresented: Binding(get: { errorText != nil }, set: { if !$0 { errorText = nil } })) {
+                Button("Retry") { submit() }
+                Button("Cancel", role: .cancel) { errorText = nil }
+            } message: { Text(errorText ?? "") }
+            .alert("Report Sent", isPresented: $sent) {
+                Button("OK") { dismiss() }
+            } message: { Text("Thanks — the organizers will take a look.") }
+        }
+    }
+
+    private func submit() {
+        guard let conference = viewModel.conference else {
+            errorText = "No active conference."; return
+        }
+        errorText = nil
+        sending = true
+        Task {
+            let result = await FeedbackReporter.send(
+                message: message.trimmingCharacters(in: .whitespacesAndNewlines),
+                conference: conference, objectType: objectType, objectId: objectId)
+            sending = false
+            switch result {
+            case .success: sent = true
+            case .failure(let e): errorText = e.message
+            }
+        }
+    }
+}

--- a/hackertracker/Views/ReportContentSheet.swift
+++ b/hackertracker/Views/ReportContentSheet.swift
@@ -34,7 +34,6 @@ struct ReportContentSheet: View {
                     Text("Please don’t include personal information. Your message and an anonymous app identifier are sent to the organizers.")
                 }
             }
-            .navigationTitle("Report an Issue")
             .themedNavTitle("Report an Issue", themeManager)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -63,12 +62,15 @@ struct ReportContentSheet: View {
         guard let conference = viewModel.conference else {
             errorText = "No active conference."; return
         }
+        let conferenceId = conference.id
+        let conferenceName = conference.name
         errorText = nil
         sending = true
         Task {
             let result = await FeedbackReporter.send(
                 message: message.trimmingCharacters(in: .whitespacesAndNewlines),
-                conference: conference, objectType: objectType, objectId: objectId)
+                conferenceId: conferenceId, conferenceName: conferenceName,
+                objectType: objectType, objectId: objectId)
             sending = false
             switch result {
             case .success: sent = true

--- a/hackertracker/Views/SpeakerDetailView.swift
+++ b/hackertracker/Views/SpeakerDetailView.swift
@@ -16,6 +16,8 @@ struct SpeakerDetailView: View {
 
     var id: Int
 
+    @State private var showReport: Bool = false
+
     /// Polish: drives the nav-bar title handoff. Continuous 0...1 so the
     /// inline title crossfades in smoothly as the in-body speaker name
     /// scrolls past the nav bar.
@@ -97,6 +99,15 @@ struct SpeakerDetailView: View {
                         }
                     }
                 }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showReport = true
+                    } label: { Image(systemName: "exclamationmark.bubble") }
+                    .accessibilityLabel("Report an issue")
+                }
+            }
+            .sheet(isPresented: $showReport) {
+                ReportContentSheet(objectType: .person, objectId: id)
             }
             .themedBackground(themeManager)
             .analyticsScreen(name: "SpeakerDetailView")

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -87,6 +87,24 @@ class hackertrackerTests: XCTestCase {
         XCTAssertEqual(restored.mode(for: 5), .all)
         XCTAssertEqual(restored.mode(for: 6), .any)
     }
+
+    func testSectionAnyMatchesEitherTag() {
+        // Section 100 has tags 1,2 selected in .any mode.
+        let match = sectionFilterMatch(tagIds: [2, 9],
+                                       selectedByType: [100: [1, 2]],
+                                       sectionModes: [100: .any])
+        XCTAssertTrue(match)   // has tag 2 → any passes
+    }
+    func testSectionAllRequiresBothTags() {
+        XCTAssertFalse(sectionFilterMatch(tagIds: [1], selectedByType: [100: [1, 2]], sectionModes: [100: .all]))
+        XCTAssertTrue(sectionFilterMatch(tagIds: [1, 2], selectedByType: [100: [1, 2]], sectionModes: [100: .all]))
+    }
+    func testTwoSectionsAreANDed() {
+        // Type 100 {1} any, Organizer 200 {5} any → needs a 100-tag AND a 200-tag.
+        let sel = [100: [1], 200: [5]]
+        XCTAssertFalse(sectionFilterMatch(tagIds: [1], selectedByType: sel, sectionModes: [:]))       // missing 200
+        XCTAssertTrue(sectionFilterMatch(tagIds: [1, 5], selectedByType: sel, sectionModes: [:]))       // both → default .any each
+    }
 }
 
 @MainActor

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -74,6 +74,19 @@ class hackertrackerTests: XCTestCase {
         let speaker = try JSONDecoder().decode(Speaker.self, from: json)
         XCTAssertEqual(speaker.visibleAgeMin, 16)
     }
+
+    func testSectionModesDefaultsToAny() {
+        let m = SectionFilterModes(json: "")
+        XCTAssertEqual(m.mode(for: 5), .any)
+    }
+
+    func testSectionModesRoundTripsJSON() {
+        var m = SectionFilterModes(json: "")
+        m.setMode(.all, for: 5)
+        let restored = SectionFilterModes(json: m.jsonString)
+        XCTAssertEqual(restored.mode(for: 5), .all)
+        XCTAssertEqual(restored.mode(for: 6), .any)
+    }
 }
 
 @MainActor

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -187,3 +187,58 @@ extension Content {
                 feedbackFormId: nil, visibleAgeMin: visibleAgeMin)
     }
 }
+
+final class FeedbackReporterTests: XCTestCase {
+    func testFeedbackReportEncodesExactKeys() throws {
+        let conf = Conference.reportStub(id: 258, name: "DEF CON 34")
+        let fixedDate = Date(timeIntervalSince1970: 1_767_400_000)
+        let report = FeedbackReporter.makeReport(
+            message: "nope", conference: conf, objectType: .person, objectId: 42,
+            now: fixedDate, uuid: "UUID-1", deviceID: "DEV-1")
+        let data = try JSONEncoder().encode(report)
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(obj["conference_id"] as? Int, 258)
+        XCTAssertEqual(obj["object_type"] as? String, "person")
+        XCTAssertEqual(obj["object_id"] as? Int, 42)
+        XCTAssertEqual(obj["report_uuid"] as? String, "UUID-1")
+        XCTAssertEqual(obj["device_identifier"] as? String, "DEV-1")
+        XCTAssertNotNil(obj["report_timestamp"] as? String)
+        XCTAssertTrue((obj["client"] as? String)?.hasPrefix("HackerTracker iOS") ?? false)
+        // UTC "yyyy-MM-dd HH:mm:ss" shape
+        XCTAssertEqual((obj["report_timestamp"] as? String)?.count, 19)
+    }
+
+    func testDeviceIdentifierIsStable() {
+        XCTAssertEqual(ReportDeviceIdentifier.current(), ReportDeviceIdentifier.current())
+    }
+}
+
+extension Conference {
+    /// Minimal fixture for feedback-reporter tests, decoded through
+    /// `Conference`'s real `Codable` conformance (rather than fighting
+    /// the `@DocumentID`-bearing memberwise initializer) so every
+    /// stored property gets a valid, uncontroversial value.
+    static func reportStub(id: Int, name: String) -> Conference {
+        let json = """
+        {
+            "id": \(id),
+            "name": "\(name)",
+            "description": "",
+            "code": "stub",
+            "end_date": "2026-08-09",
+            "start_date": "2026-08-06",
+            "kickoff_timestamp": 1767200000,
+            "start_timestamp": 1767200000,
+            "end_timestamp": 1767400000,
+            "hidden": false,
+            "enable_merch": false,
+            "enable_merch_cart": false,
+            "home_menu_id": 1
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        // swiftlint:disable:next force_try
+        return try! decoder.decode(Conference.self, from: Data(json.utf8))
+    }
+}

--- a/hackertrackerTests/hackertrackerTests.swift
+++ b/hackertrackerTests/hackertrackerTests.swift
@@ -190,10 +190,9 @@ extension Content {
 
 final class FeedbackReporterTests: XCTestCase {
     func testFeedbackReportEncodesExactKeys() throws {
-        let conf = Conference.reportStub(id: 258, name: "DEF CON 34")
         let fixedDate = Date(timeIntervalSince1970: 1_767_400_000)
         let report = FeedbackReporter.makeReport(
-            message: "nope", conference: conf, objectType: .person, objectId: 42,
+            message: "nope", conferenceId: 258, conferenceName: "DEF CON 34", objectType: .person, objectId: 42,
             now: fixedDate, uuid: "UUID-1", deviceID: "DEV-1")
         let data = try JSONEncoder().encode(report)
         let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
@@ -210,35 +209,5 @@ final class FeedbackReporterTests: XCTestCase {
 
     func testDeviceIdentifierIsStable() {
         XCTAssertEqual(ReportDeviceIdentifier.current(), ReportDeviceIdentifier.current())
-    }
-}
-
-extension Conference {
-    /// Minimal fixture for feedback-reporter tests, decoded through
-    /// `Conference`'s real `Codable` conformance (rather than fighting
-    /// the `@DocumentID`-bearing memberwise initializer) so every
-    /// stored property gets a valid, uncontroversial value.
-    static func reportStub(id: Int, name: String) -> Conference {
-        let json = """
-        {
-            "id": \(id),
-            "name": "\(name)",
-            "description": "",
-            "code": "stub",
-            "end_date": "2026-08-09",
-            "start_date": "2026-08-06",
-            "kickoff_timestamp": 1767200000,
-            "start_timestamp": 1767200000,
-            "end_timestamp": 1767400000,
-            "hidden": false,
-            "enable_merch": false,
-            "enable_merch_cart": false,
-            "home_menu_id": 1
-        }
-        """
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
-        // swiftlint:disable:next force_try
-        return try! decoder.decode(Conference.self, from: Data(json.utf8))
     }
 }


### PR DESCRIPTION
Two release features, built spec → plan → subagent-driven execution (per-task + final whole-branch review). Specs/plans under `docs/superpowers/`.

## 1. Per-section Any/All filters
Replaces the single global filter mode on **Schedule + All Content** with a **per-tagtype-section Any/All**, combined with **AND** across sections — so you can express e.g. "Contests (Type) under organizer A **or** B (Organizer = Any)".
- `SectionFilterModes` store (JSON `[tagTypeId: mode]` in one AppStorage key).
- Unified `sectionFilterMatch` predicate on `[Event]`/`[Content]`: per-section Any/All, AND across sections; Bookmarks/Custom/Has-Notes each an AND constraint.
- Filter sheet: per-section Any/All segmented control, shown only when a section has ≥2 chips selected.
- Wired through EventsView, the combined-bookmark schedule (InfoView), and ContentListView; the old `filterMatchMode` key is gone. **Speakers/Merch unchanged.**

## 2. Report-an-issue
"Report an issue" toolbar action on Content / Speaker / Org / Document detail → a message sheet → `POST https://feedback1.junctorconf.net/reporting.php`.
- Exact payload (snake_case): message, conference_id, conference_name, object_type (content/person/org/document), object_id, report_timestamp (UTC `yyyy-MM-dd HH:mm:ss`), report_uuid, client (`HackerTracker iOS <ver> (<build>)`), device_identifier.
- `device_identifier` = anonymous **Keychain** install UUID (not device/IDFV-derived) — only the message + that id leave the device.
- Mapping: event/content→content, speaker→person, org→org (object_id 0, no Int id), document→document. Emergency-doc **banner** is not reportable; DocumentView reports only real documents.

## Review journey (what the gates caught)
- **Filters:** ContentListView kept its inline predicate (reusing `sectionFilterMatch`) rather than calling `[Content].filters`, because that extension checks Bookmarks against `content.id` while bookmarks are session-id-keyed — routing through it would've silently broken the Bookmarks chip. (That latent `[Content].filters` bug is dead code — no callers — left as a tracked follow-up.)
- **Feedback:** an implementer marked `Conference` `@unchecked Sendable` to pass it into the async `send`; review flagged the broad blast radius, and it was reverted in favor of passing `id`/`name` primitives. Emergency-doc reportability was made consistent.

## Verification
- Full suite green (21 unit + UI). `plutil -lint` OK. Both features build.
- **Needs your check (can't verify from here):** (a) a **live POST** to the feedback endpoint returns 2xx and the payload looks right server-side; (b) the per-section filter combinations behave on device with the seeded Test + DEF CON 34 data.
- **For your call (non-blocking):** the emergency doc is reportable when it appears in the general documents *grid* (not the dedicated banner) — say if you want it excluded there too. Optional Keychain hardening: `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` on the install id.

Branch is at MARKETING_VERSION 6.3 / build 26072201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)