### PR TITLE
Floating count chip: filter sheet + Schedule / All Content / Combined Schedule

### DIFF
--- a/hackertracker/Views/ContentListView.swift
+++ b/hackertracker/Views/ContentListView.swift
@@ -259,6 +259,11 @@ struct ContentListView: View {
 
                 Spacer()
 
+                // Live count of talks currently shown (filter + search applied).
+                FloatingCountChip(count: contentFilteredCount, unit: "talk", systemImage: "doc.text")
+
+                Spacer()
+
                 jumpToGroupMenu
                     .font(themeManager.title2Font)
                     .foregroundStyle(.primary)

--- a/hackertracker/Views/EventsView.swift
+++ b/hackertracker/Views/EventsView.swift
@@ -170,6 +170,21 @@ struct EventsView: View {
         scheduleGrouped = searched.eventDayGroup(showLocaltime: showLocaltime, conference: viewModel.conference)
     }
 
+    /// Count of schedule events currently visible in the list, honoring the
+    /// "Show Past Events" toggle (past events are excluded when it's off,
+    /// matching EventScrollView.visibleEvents). Drives the floating count
+    /// chip. Computed on render so it reflects filter/bookmark changes and
+    /// events aging past their end time the next time the schedule re-renders.
+    private var visibleScheduleCount: Int {
+        guard !showPastEvents else {
+            return scheduleGrouped.reduce(0) { $0 + $1.value.count }
+        }
+        let now = Date()
+        return scheduleGrouped.reduce(0) { acc, group in
+            acc + group.value.filter { now < $0.endTimestamp }.count
+        }
+    }
+
     /// Firestore events + synthesized CustomEvents that target the
     /// currently-selected conference. The pipeline recompute reads
     /// this in place of viewModel.events so user-created rows flow
@@ -292,6 +307,11 @@ struct EventsView: View {
           }
           .tint(.primary)
           .accessibilityLabel(filters.filters.isEmpty ? "Filters" : "Filters active")
+
+          Spacer()
+
+          // Live count of events currently shown (respects Show Past Events).
+          FloatingCountChip(count: visibleScheduleCount, unit: "event", systemImage: "calendar")
 
           Spacer()
 

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -46,7 +46,6 @@ struct EventFilters: View {
         // app's other modal forms.
         NavigationStack {
             ScrollView {
-                FilterMatchCountLabel(count: matchedCount, unit: unitLabel)
                 if showBookmarks {
                     FilterRow(id: PseudoTagID.bookmarks, name: "Bookmarks", color: ThemeColors.blue)
                     FilterRow(id: PseudoTagID.customEvents, name: "Custom Events", color: .purple)
@@ -67,6 +66,10 @@ struct EventFilters: View {
                     } header: {
                         HStack {
                             Text(tagtype.label)
+                                // Explicit font + fixed row height so the
+                                // title's size and position stay constant
+                                // whether or not the Any/All picker is shown.
+                                .font(themeManager.headingFont)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             let selectedInSection = tagtype.tags.filter { filters.filters.contains($0.id) }.count
                             if selectedInSection >= 2 {
@@ -78,11 +81,30 @@ struct EventFilters: View {
                                 .fixedSize()
                             }
                         }
+                        .frame(height: 34)
                     }
                 }
                 .headerProminence(.increased)
+                // Clearance so the last chips can scroll above the floating count chip.
+                Color.clear.frame(height: 56)
             }
             .padding(.horizontal, 10)
+            // Live matched-count as a floating chip pinned to the bottom of
+            // the sheet so it stays visible while the chip list scrolls.
+            .overlay(alignment: .bottom) {
+                let plural = matchedCount == 1 ? unitLabel : unitLabel + "s"
+                HStack(spacing: 6) {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                    Text("\(matchedCount) \(plural)")
+                }
+                .font(themeManager.subheadlineFont)
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(.regularMaterial, in: Capsule())
+                .overlay(Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 0.5))
+                .padding(.bottom, 14)
+            }
             .navigationTitle("Filters")
             .themedNavTitle("Filters", themeManager)
             .navigationBarTitleDisplayMode(.inline)

--- a/hackertracker/Views/FiltersView.swift
+++ b/hackertracker/Views/FiltersView.swift
@@ -92,18 +92,8 @@ struct EventFilters: View {
             // Live matched-count as a floating chip pinned to the bottom of
             // the sheet so it stays visible while the chip list scrolls.
             .overlay(alignment: .bottom) {
-                let plural = matchedCount == 1 ? unitLabel : unitLabel + "s"
-                HStack(spacing: 6) {
-                    Image(systemName: "line.3.horizontal.decrease.circle")
-                    Text("\(matchedCount) \(plural)")
-                }
-                .font(themeManager.subheadlineFont)
-                .foregroundStyle(.primary)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 9)
-                .background(.regularMaterial, in: Capsule())
-                .overlay(Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 0.5))
-                .padding(.bottom, 14)
+                FloatingCountChip(count: matchedCount, unit: unitLabel)
+                    .padding(.bottom, 14)
             }
             .navigationTitle("Filters")
             .themedNavTitle("Filters", themeManager)
@@ -194,6 +184,37 @@ struct FilterRow: View {
                     .stroke(filters.filters.contains(id) ? Color.clear : color, lineWidth: 2)
             )
         }
+    }
+}
+
+/// Floating "N events" capsule pinned to the bottom of a scrolling list.
+/// Shared by the Filters sheet, the Schedule, All Content, and the
+/// Combined Schedule so the count affordance looks identical everywhere.
+/// The caller supplies the already-computed count (each screen counts
+/// with its own pipeline / past-events rules); the chip just presents it.
+struct FloatingCountChip: View {
+    let count: Int
+    let unit: String
+    /// SF Symbol shown to the left of the count. Defaults to the filter
+    /// glyph used by the Filters sheet; list screens pass a screen-
+    /// appropriate icon (calendar, doc, bookmark).
+    var systemImage: String = "line.3.horizontal.decrease.circle"
+    @Environment(ThemeManager.self) private var themeManager
+
+    var body: some View {
+        let plural = count == 1 ? unit : unit + "s"
+        HStack(spacing: 6) {
+            Image(systemName: systemImage)
+            Text("\(count) \(plural)")
+        }
+        .font(themeManager.subheadlineFont)
+        .foregroundStyle(.primary)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 0.5))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(count) \(plural)")
     }
 }
 

--- a/hackertracker/Views/SharedScheduleView.swift
+++ b/hackertracker/Views/SharedScheduleView.swift
@@ -84,6 +84,9 @@ struct SharedScheduleView: View {
             if !sharedSchedule.entries.isEmpty {
                 HStack {
                     Spacer()
+                    // Live count of bookmarked events shown in the combined list.
+                    FloatingCountChip(count: sharedSchedule.entries.count, unit: "bookmark", systemImage: "bookmark.fill")
+                    Spacer()
                     JumpMenuOverlay(target: $jumpTarget)
                 }
                 .padding(.horizontal, 20)


### PR DESCRIPTION
## Summary
A floating, always-visible count chip on the list screens, per user feedback asking to *"know the number of events selected... an integer value... in the Bookmarks and Schedule screens"* that updates as events are unbookmarked or expire by time.

Clarified scope: the chip counts **events currently shown in the list** (respecting the *Show Past Events* toggle where it applies), on the **Schedule, All Content, and Combined Schedule (Bookmarks)** screens — plus the original filter-sheet chip.

## Changes
- **`FloatingCountChip`** — extracted the filter sheet's inline capsule into a shared view (`.regularMaterial` capsule, `subheadlineFont`, configurable SF Symbol). The Filters sheet now uses it.
- **Schedule (`EventsView`)** — centered chip between the Filter and Jump-to-Day floating buttons. New `visibleScheduleCount` honors *Show Past Events* (mirrors `EventScrollView.visibleEvents`) and recomputes on render, so it reflects filter/bookmark changes and events aging past their end time.
- **All Content (`ContentListView`)** — chip showing `contentFilteredCount` (filter + search applied; no past-events concept — it's a letter-grouped talk list).
- **Combined Schedule (`SharedScheduleView`)** — chip showing the number of bookmarked entries shown.
- Original: stabilized the filter section header title so it doesn't resize when the Any/All picker appears.

## Verification
- `xcodebuild ... build` succeeds.
- Ran on the iPhone 17 Pro Max simulator: chip renders centered on the Schedule ("📅 1,271 events") with no collision against the Filter/Jump buttons.
- Live time-based decrement couldn't be demonstrated in-sim (DEF CON 34 is still 8 days out, so no events have expired); the exclusion logic is shared with the list's own past-event filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)