### PR TITLE
Report sheet: update guidance copy

### DIFF
--- a/hackertracker/Views/ReportContentSheet.swift
+++ b/hackertracker/Views/ReportContentSheet.swift
@@ -31,7 +31,11 @@ struct ReportContentSheet: View {
                 } header: {
                     Text("What’s wrong with this content?")
                 } footer: {
-                    Text("Please don’t include personal information. Your message and an anonymous app identifier are sent to the organizers.")
+                    Text("""
+                    Submit a report if you believe that the associated content is illegal or unsafe in your jurisdiction.
+
+                    Your message and an anonymous app identifier are sent to the Hacker Tracker team, and may also be shared with the conference organizers. If you would like to receive a response, please reach out to the respective conference organizers instead of submitting a report here. We encourage you to not share personal information here; we do not guarantee a response.
+                    """)
                 }
             }
             .themedNavTitle("Report an Issue", themeManager)


### PR DESCRIPTION
## Summary
Updates the explanatory copy on the "Report an Issue" sheet (`ReportContentSheet`) to the new wording:

> Submit a report if you believe that the associated content is illegal or unsafe in your jurisdiction.
>
> Your message and an anonymous app identifier are sent to the Hacker Tracker team, and may also be shared with the conference organizers. If you would like to receive a response, please reach out to the respective conference organizers instead of submitting a report here. We encourage you to not share personal information here; we do not guarantee a response.

Replaces the previous one-line footer ("Please don't include personal information…"). The section header ("What's wrong with this content?") and the send/cancel/alert flow are unchanged.

## Verification
- `xcodebuild ... build` succeeds.
- Copy-only change; the two-paragraph text renders via a Swift multiline string literal (indentation stripped, blank line preserved as the paragraph break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)