### PR TITLE
Report sheet: confirmation reads "Report submitted"

### DIFF
--- a/hackertracker/Views/ReportContentSheet.swift
+++ b/hackertracker/Views/ReportContentSheet.swift
@@ -56,9 +56,9 @@ struct ReportContentSheet: View {
                 Button("Retry") { submit() }
                 Button("Cancel", role: .cancel) { errorText = nil }
             } message: { Text(errorText ?? "") }
-            .alert("Report Sent", isPresented: $sent) {
+            .alert("Report submitted", isPresented: $sent) {
                 Button("OK") { dismiss() }
-            } message: { Text("Thanks — the organizers will take a look.") }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Updates the success confirmation on the "Report an Issue" sheet (`ReportContentSheet`):

- Alert title: "Report Sent" → **"Report submitted"**.
- Removed the message body ("Thanks — the organizers will take a look.") so the confirmation no longer references the organizers acting on the report.

The submission flow, error alert, and the footer guidance copy are unchanged.

## Verification
- `xcodebuild ... build` succeeds.
- Copy-only change to the success alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)