### PR TITLE
Report sheet: show non-editable content name

### DIFF
--- a/hackertracker/Views/ContentDetailView.swift
+++ b/hackertracker/Views/ContentDetailView.swift
@@ -137,7 +137,7 @@ struct ContentDetailView: View {
                 }
             }
             .sheet(isPresented: $showReport) {
-                ReportContentSheet(objectType: .content, objectId: contentId)
+                ReportContentSheet(objectType: .content, objectId: contentId, objectName: viewModel.contentById[contentId]?.title ?? "")
             }
             .onAppear() {
                 Log.ui.debug("ContentDetailView loading \(item.id) - \(item.title, privacy: .public)")

--- a/hackertracker/Views/DocumentView.swift
+++ b/hackertracker/Views/DocumentView.swift
@@ -66,7 +66,7 @@ struct DocumentView: View {
         }
         .sheet(isPresented: $showReport) {
             if let ctx = reportContext {
-                ReportContentSheet(objectType: ctx.type, objectId: ctx.id)
+                ReportContentSheet(objectType: ctx.type, objectId: ctx.id, objectName: title_text)
             }
         }
     }

--- a/hackertracker/Views/OrgView.swift
+++ b/hackertracker/Views/OrgView.swift
@@ -82,7 +82,7 @@ struct OrgView: View {
             }
         }
         .sheet(isPresented: $showReport) {
-            ReportContentSheet(objectType: .org, objectId: 0)
+            ReportContentSheet(objectType: .org, objectId: 0, objectName: org.name)
         }
     }
 }

--- a/hackertracker/Views/ReportContentSheet.swift
+++ b/hackertracker/Views/ReportContentSheet.swift
@@ -12,6 +12,10 @@ import SwiftUI
 struct ReportContentSheet: View {
     let objectType: ReportObjectType
     let objectId: Int
+    /// Human-readable name of the content being reported (talk title,
+    /// speaker name, org name, document title). Shown non-editably so the
+    /// submitter can confirm what the report is about. Empty = hide the row.
+    var objectName: String = ""
 
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
@@ -25,6 +29,14 @@ struct ReportContentSheet: View {
     var body: some View {
         NavigationStack {
             Form {
+                if !objectName.isEmpty {
+                    Section {
+                        Text(objectName)
+                            .font(themeManager.headingFont)
+                    } header: {
+                        Text("Reporting")
+                    }
+                }
                 Section {
                     TextEditor(text: $message)
                         .frame(minHeight: 140)

--- a/hackertracker/Views/SpeakerDetailView.swift
+++ b/hackertracker/Views/SpeakerDetailView.swift
@@ -107,7 +107,7 @@ struct SpeakerDetailView: View {
                 }
             }
             .sheet(isPresented: $showReport) {
-                ReportContentSheet(objectType: .person, objectId: id)
+                ReportContentSheet(objectType: .person, objectId: id, objectName: viewModel.speakersById[id]?.name ?? "")
             }
             .themedBackground(themeManager)
             .analyticsScreen(name: "SpeakerDetailView")


### PR DESCRIPTION
## Summary
Adds a read-only display of the content being reported to the "Report an Issue" sheet, so the submitter can confirm what the report is about before sending.

- New `objectName` parameter on `ReportContentSheet`, rendered non-editably in a "Reporting" section at the top of the form (hidden when empty).
- Each call site now passes the relevant name:
  - `ContentDetailView` → content title
  - `SpeakerDetailView` → speaker name
  - `OrgView` → org name
  - `DocumentView` → document title

## Verification
- `xcodebuild ... build` succeeds.
- The name is a `Text` label (non-editable by construction); the message field, submit flow, and footer copy are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)