### PR TITLE
General feedback: use the survey FeedbackForm instead of Report an Issue

### DIFF
--- a/hackertracker/Utils/FeedbackReporter.swift
+++ b/hackertracker/Utils/FeedbackReporter.swift
@@ -12,7 +12,7 @@ import Foundation
 import Security
 
 enum ReportObjectType: String {
-    case content, org, person, document, conference
+    case content, org, person, document
 }
 
 struct ReportError: Error {

--- a/hackertracker/Views/FeedbackFormView.swift
+++ b/hackertracker/Views/FeedbackFormView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct FeedbackFormView: View {
     @Binding var showFeedback: Bool
-    var item: Content
+    /// The content being rated, or `nil` for conference-level general
+    /// feedback (no associated talk — submits with content_id 0).
+    var item: Content?
     var form: FeedbackForm
     @Environment(InfoViewModel.self) private var viewModel
     @Environment(ThemeManager.self) private var themeManager
@@ -28,9 +30,11 @@ struct FeedbackFormView: View {
         VStack {
             Text(form.name)
                 .font(themeManager.titleFont)
-            Divider()
-            Text(item.title)
-                .font(themeManager.title3Font)
+            if let item {
+                Divider()
+                Text(item.title)
+                    .font(themeManager.title3Font)
+            }
         }
         .padding(15)
         Divider()
@@ -77,11 +81,11 @@ struct FeedbackFormView: View {
 
 extension FeedbackFormView {
     
-    func uploadFeedback(item: Content, form: FeedbackForm, answers: [Int: AnyObject], viewModel: InfoViewModel, dfu: DateFormatterUtility) {
+    func uploadFeedback(item: Content?, form: FeedbackForm, answers: [Int: AnyObject], viewModel: InfoViewModel, dfu: DateFormatterUtility) {
         var feedback: [String: Any] = [:]
         feedback["client"] = "HackerTracker iOS v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "") (\( Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""))"
         feedback["conference_id"] = viewModel.conference?.id ?? 0
-        feedback["content_id"] = item.id
+        feedback["content_id"] = item?.id ?? 0
         feedback["device_id"] = UIDevice.current.identifierForVendor?.uuidString ?? "no-ios-uuid-found"
         feedback["feedback_form_id"] = form.id
         feedback["items"] = []
@@ -115,7 +119,7 @@ extension FeedbackFormView {
                 if let jd = jsonData, let fb = String(data: jd, encoding: .utf8) {
                     NSLog("Feedback form for submission: \(fb)")
                 }
-                let capturedItemId = item.id
+                let capturedItemId = item?.id
                 URLSession.shared.dataTask(with: request) { data, response, error in
                     if let error = error {
                         DispatchQueue.main.async {
@@ -134,7 +138,12 @@ extension FeedbackFormView {
                     }
                     DispatchQueue.main.async {
                         self.alertMessage = "Feedback Sent"
-                        FeedbackUtility.addFeedback(context: viewContext, id: capturedItemId)
+                        // Only content-scoped feedback is recorded locally
+                        // (to hide that content's Submit Feedback button).
+                        // General feedback has no content id to mark.
+                        if let capturedItemId {
+                            FeedbackUtility.addFeedback(context: viewContext, id: capturedItemId)
+                        }
                         self.showAlert.toggle()
                     }
                     NSLog("Feedback sent successfully")

--- a/hackertracker/Views/InfoView.swift
+++ b/hackertracker/Views/InfoView.swift
@@ -684,8 +684,11 @@ struct MenuView: View {
     @AppStorage(AppStorageKeys.colorMode) var colorMode: Bool = false
     let gridItemLayout = [GridItem(.flexible()), GridItem(.flexible())]
     @State var schedule = UUID()
-    /// Drives the conference-level report sheet for a "form" menu item.
-    @State private var showReport = false
+    /// Drives the conference-level "General Feedback" survey sheet for a
+    /// "form" menu item, plus its post-submit confirmation alert.
+    @State private var showGeneralFeedback = false
+    @State private var feedbackAlert = false
+    @State private var feedbackAlertMessage = ""
     @FetchRequest(sortDescriptors: []) var readnews: FetchedResults<News>
     
     @Environment(ThemeManager.self) private var themeManager
@@ -769,14 +772,17 @@ struct MenuView: View {
                          CardView(systemImage: item.symbol ?? "magnifyingglass", text: "Search", color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
                      }
                 case "form":
-                    // Conference-level report: the same "report an issue"
-                    // feedback form as the detail screens, scoped to the
-                    // current conference (its id/name) rather than a single
-                    // piece of content.
-                    Button {
-                        showReport = true
-                    } label: {
-                        CardView(systemImage: item.symbol ?? "exclamationmark.bubble", text: item.title, color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
+                    // Conference-level general feedback: presents the
+                    // survey-style FeedbackForm named "General Feedback"
+                    // (the same mechanism as content "Submit Feedback",
+                    // not the report-an-issue flow). Only shown when that
+                    // form is present in the conference's feedbackForms.
+                    if viewModel.feedbackForms.contains(where: { $0.name == "General Feedback" }) {
+                        Button {
+                            showGeneralFeedback = true
+                        } label: {
+                            CardView(systemImage: item.symbol ?? "exclamationmark.bubble", text: item.title, color: colorMode ? themeManager.carouselColor(index: item.id) : themeManager.cardSurface)
+                        }
                     }
                 default:
                     EmptyView()
@@ -784,10 +790,21 @@ struct MenuView: View {
 
             }
         }
-        .sheet(isPresented: $showReport) {
-            if let con = viewModel.conference {
-                ReportContentSheet(objectType: .conference, objectId: con.id, objectName: con.name)
+        .sheet(isPresented: $showGeneralFeedback) {
+            if let form = viewModel.feedbackForms.first(where: { $0.name == "General Feedback" }) {
+                FeedbackFormView(
+                    showFeedback: $showGeneralFeedback,
+                    item: nil,
+                    form: form,
+                    showAlert: $feedbackAlert,
+                    alertMessage: $feedbackAlertMessage
+                )
             }
+        }
+        .alert("Feedback", isPresented: $feedbackAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(feedbackAlertMessage)
         }
     }
 }

--- a/hackertracker/Views/ReportContentSheet.swift
+++ b/hackertracker/Views/ReportContentSheet.swift
@@ -26,24 +26,6 @@ struct ReportContentSheet: View {
     @State private var errorText: String?
     @State private var sent = false
 
-    /// A conference-level report is general feedback rather than a report
-    /// about a specific piece of content, so it uses softer copy.
-    private var isGeneralFeedback: Bool { objectType == .conference }
-
-    /// Header shown above the message field.
-    private var promptText: String {
-        isGeneralFeedback ? "General Feedback" : "What’s wrong with this content?"
-    }
-
-    /// Footer under the message field. General feedback drops the first
-    /// (illegal/unsafe-content) paragraph and keeps only the second.
-    private var footerText: String {
-        let handling = "Your message and an anonymous app identifier are sent to the Hacker Tracker team, and may also be shared with the conference organizers. If you would like to receive a response, please reach out to the respective conference organizers instead of submitting a report here. We encourage you to not share personal information here; we do not guarantee a response."
-        guard !isGeneralFeedback else { return handling }
-        let scope = "Submit a report if you believe that the associated content is illegal or unsafe in your jurisdiction."
-        return scope + "\n\n" + handling
-    }
-
     var body: some View {
         NavigationStack {
             Form {
@@ -52,21 +34,20 @@ struct ReportContentSheet: View {
                         Text(objectName)
                             .font(themeManager.headingFont)
                     } header: {
-                        // General feedback shows the conference name but
-                        // without the "Reporting" label (it's not a report
-                        // about that named object, just context).
-                        if !isGeneralFeedback {
-                            Text("Reporting")
-                        }
+                        Text("Reporting")
                     }
                 }
                 Section {
                     TextEditor(text: $message)
                         .frame(minHeight: 140)
                 } header: {
-                    Text(promptText)
+                    Text("What’s wrong with this content?")
                 } footer: {
-                    Text(footerText)
+                    Text("""
+                    Submit a report if you believe that the associated content is illegal or unsafe in your jurisdiction.
+
+                    Your message and an anonymous app identifier are sent to the Hacker Tracker team, and may also be shared with the conference organizers. If you would like to receive a response, please reach out to the respective conference organizers instead of submitting a report here. We encourage you to not share personal information here; we do not guarantee a response.
+                    """)
                 }
             }
             .themedNavTitle("Report an Issue", themeManager)


### PR DESCRIPTION
## Summary
Switches the Info-screen **"form"** menu item (conference-level *General Feedback*) from the report-an-issue sheet to the app's **survey-style feedback mechanism** (`FeedbackForm` / `FeedbackFormView` — the same flow behind a talk's "Submit Feedback"), and rolls back the report-an-issue changes that had been made for general feedback.

## Which form
Per your call, it uses the `FeedbackForm` whose **`name` == "General Feedback"** from the conference's `feedbackforms` collection. The menu card only renders when that form is present.

## Changes
- **InfoView (`MenuView`)** — `case "form"` now opens `FeedbackFormView` with the "General Feedback" form (via a sheet), plus a post-submit confirmation alert. Replaces the previous `ReportContentSheet` presentation.
- **FeedbackFormView** — `item` is now `Content?` so the survey can run without a talk. General feedback submits with **`content_id: 0`**, skips the talk-title row, and skips the local "feedback given" mark (that only exists to hide a specific content's button).
- **Rollback of the report-an-issue general-feedback additions:**
  - Removed the `.conference` case from `ReportObjectType`.
  - Reverted `ReportContentSheet` to content-report-only (removed the `isGeneralFeedback` / prompt / footer branching and the conditional "Reporting" header).

## Related PRs
- **Closes the need for #63** (the "Feedback" nav title was only for the report-an-issue general-feedback path) — I'm closing #63.
- #62 (content-detail "•••" menu) is unaffected and still open.

## ⚠️ Confirm submission shape
General feedback POSTs to the form's own `submission_url` with `conference_id`, `feedback_form_id`, `content_id: 0`, and the answers. If the server wants something other than `content_id: 0` (e.g. the field omitted) for conference-level submissions, tell me.

## Verification
- `xcodebuild ... build` succeeds.
- Couldn't exercise end-to-end in-sim (needs the "General Feedback" form in Firestore data + tap navigation, which the sim tap limitation blocks). Logic is build-verified; worth a device check once the form exists in the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)