### PR TITLE
Content detail: show end day for cross-midnight sessions

### DIFF
--- a/hackertracker/Utils/DateFormatterUtility.swift
+++ b/hackertracker/Utils/DateFormatterUtility.swift
@@ -232,6 +232,27 @@ class DateFormatterUtility {
         return formatter
     }()
 
+    /// Formats a session's time range for the detail screens. The start
+    /// always shows day + time. The end shows time only when it falls on
+    /// the same calendar day (in the active timezone) — e.g.
+    /// "Mon, Aug 5 13:00-15:00" — but repeats the day when the event
+    /// crosses midnight — e.g. "Mon, Aug 5 13:00 - Tue, Aug 6 09:00".
+    /// A zero-length session (begin == end) shows just the start.
+    func sessionRange(begin: Date, end: Date, use24hour: Bool) -> String {
+        let dayTime = use24hour ? shortDayMonthDayTimeOfWeekFormatter : shortDayMonthDay12HourOfWeekFormatter
+        let start = dayTime.string(from: begin)
+        guard begin != end else { return start }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone ?? .current
+        if calendar.isDate(begin, inSameDayAs: end) {
+            let timeOnly = use24hour ? hourMinuteTimeFormatter : hourMinute12TimeFormatter
+            return "\(start)-\(timeOnly.string(from: end))"
+        } else {
+            return "\(start) - \(dayTime.string(from: end))"
+        }
+    }
+
     func getConferenceDates(start: Date, end: Date) -> [String] {
         let calendar = NSCalendar.current
         var ret: [String] = []

--- a/hackertracker/Views/ContentDetailView.swift
+++ b/hackertracker/Views/ContentDetailView.swift
@@ -292,23 +292,8 @@ struct showSessionRow: View {
                     } label: {
                         Image(systemName: "clock")
                     }
-                    if show24hourtime {
-                        if s.beginTimestamp != s.endTimestamp {
-                            Text("\(dfu.shortDayMonthDayTimeOfWeekFormatter.string(from: s.beginTimestamp))-\(dfu.hourMinuteTimeFormatter.string(from: s.endTimestamp))")
-                                .font(themeManager.subheadlineFont)
-                        } else {
-                            Text("\(dfu.shortDayMonthDayTimeOfWeekFormatter.string(from: s.beginTimestamp))")
-                                .font(themeManager.subheadlineFont)
-                        }
-                    } else {
-                        if s.beginTimestamp != s.endTimestamp {
-                            Text("\(dfu.shortDayMonthDay12HourOfWeekFormatter.string(from: s.beginTimestamp))-\(dfu.hourMinute12TimeFormatter.string(from: s.endTimestamp))")
-                                .font(themeManager.subheadlineFont)
-                        } else {
-                            Text("\(dfu.shortDayMonthDay12HourOfWeekFormatter.string(from: s.beginTimestamp))")
-                                .font(themeManager.subheadlineFont)
-                        }
-                    }
+                    Text(dfu.sessionRange(begin: s.beginTimestamp, end: s.endTimestamp, use24hour: show24hourtime))
+                        .font(themeManager.subheadlineFont)
                 }
                 .fullScreenCover(isPresented: $showAddContentModal) {
                     AddContent(content: item, session: s)


### PR DESCRIPTION
## Summary
On the content detail screen, a session's time range now shows the end's **day** when the event crosses into another calendar day, and otherwise keeps the current time-only end.

- Same day (unchanged): `Mon, Aug 5 13:00-15:00`
- Crosses a day (new): `Mon, Aug 5 13:00 - Tue, Aug 6 09:00`
- Zero-length (begin == end): just the start, as before.

## Implementation
New `DateFormatterUtility.sessionRange(begin:end:use24hour:)`:
- Start always uses the day+time formatter (`EE, MMM d HH:mm` / 12h variant).
- The cross-day check uses `Calendar.isDate(_:inSameDayAs:)` in the **active display timezone** (`dfu.timeZone`), so it matches whatever zone the times are rendered in (conference-local vs device-local per `showLocaltime`).
- Same-day output is byte-identical to the old string (`start-endTime`, no spaces); cross-day uses `start - endDayTime` (spaced), honoring the 24h/12h preference.

This collapses the previous four inline branches in `ContentDetailView`'s session row into one call.

## Verification
- `xcodebuild ... build` succeeds.
- Couldn't drive to a content detail in-sim (tap limitation), but the logic is a deterministic string format. Worth a device glance on a known overnight event (e.g. a party/CTF that runs past midnight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)