### PR TITLE
Bump build to 26080101

### DIFF
--- a/hackertracker.xcodeproj/project.pbxproj
+++ b/hackertracker.xcodeproj/project.pbxproj
@@ -985,7 +985,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26073101;
+				CURRENT_PROJECT_VERSION = 26080101;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;
@@ -1025,7 +1025,7 @@
 				CODE_SIGN_ENTITLEMENTS = hackertracker/hackertracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 26073101;
+				CURRENT_PROJECT_VERSION = 26080101;
 				DEVELOPMENT_ASSET_PATHS = "\"hackertracker/Preview Content\"";
 				DEVELOPMENT_TEAM = MJ97FDMT75;
 				ENABLE_PREVIEWS = YES;


### PR DESCRIPTION
Bumps `CURRENT_PROJECT_VERSION` from 26073101 to 26080101 for the app target (Debug + Release). Test targets unchanged; `MARKETING_VERSION` (6.3) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)